### PR TITLE
DPE-135 Update CI trigger

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,9 @@
 name: Tests
-on: [pull_request, push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   lint:


### PR DESCRIPTION
# Issue
In short this PR address JIRA ticket [DPE-135](https://warthogs.atlassian.net/browse/DPE-135).

In long:
* The current CI configuration of this repository is triggering the actions execution whenever someone pushes some code to it.


# Solution
* Fix the CI trigger to execute only when pushing to main (which is expected to happen only when merging a pull request) and when creating a pull request.


# Context
* There was the same issue in the [k8s operator repository](https://github.com/canonical/postgresql-k8s-operator/pull/5).


# Release Notes
* Update CI to trigger only when creating a pull request and when pushing to main.