### PR TITLE
DPE-71 - Add Patroni functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 __pycache__/
 *.py[cod]
 coverage.xml
+patroni.tar.gz

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -25,4 +25,4 @@ resources:
 storage:
   pgdata:
     type: filesystem
-    location: /var/lib/postgresql/data/pgdata
+    location: /var/lib/postgresql/data

--- a/src/charm.py
+++ b/src/charm.py
@@ -88,14 +88,9 @@ class PostgresqlOperatorCharm(CharmBase):
     def _on_leader_elected(self, _) -> None:
         """Handle the leader-elected event."""
         data = self._peers.data[self.app]
-        postgres_password = data.get("postgres-password")
-        replication_password = data.get("replication-password")
-
-        if postgres_password is None:
-            self._peers.data[self.app]["postgres-password"] = self._new_password()
-
-        if replication_password is None:
-            self._peers.data[self.app]["replication-password"] = self._new_password()
+        # The leader sets the needed password on peer relation databag if they weren't set before.
+        data.setdefault("postgres-password", self._new_password())
+        data.setdefault("replication-password", self._new_password())
 
     def _on_start(self, event) -> None:
         password = self._get_postgres_password()

--- a/src/charm.py
+++ b/src/charm.py
@@ -88,8 +88,8 @@ class PostgresqlOperatorCharm(CharmBase):
     def _on_leader_elected(self, _) -> None:
         """Handle the leader-elected event."""
         data = self._peers.data[self.app]
-        postgres_password = data.get("postgres-password", None)
-        replication_password = data.get("replication-password", None)
+        postgres_password = data.get("postgres-password")
+        replication_password = data.get("replication-password")
 
         if postgres_password is None:
             self._peers.data[self.app]["postgres-password"] = self._new_password()
@@ -136,7 +136,7 @@ class PostgresqlOperatorCharm(CharmBase):
             password has not yet been set by the leader.
         """
         data = self._peers.data[self.app]
-        return data.get("postgres-password", None)
+        return data.get("postgres-password")
 
     @property
     def _replication_password(self) -> str:
@@ -147,7 +147,7 @@ class PostgresqlOperatorCharm(CharmBase):
             password has not yet been set by the leader.
         """
         data = self._peers.data[self.app]
-        return data.get("replication-password", None)
+        return data.get("replication-password")
 
     def _install_apt_packages(self, _, packages: List[str]) -> None:
         """Simple wrapper around 'apt-get install -y.

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -84,9 +84,9 @@ class PostgresqlCluster:
             path: path to a file or directory.
         """
         # Get the uid/gid for the postgres user.
-        u = pwd.getpwnam("postgres")
+        user_database = pwd.getpwnam("postgres")
         # Set the correct ownership for the file or directory.
-        os.chown(path, uid=u.pw_uid, gid=u.pw_gid)
+        os.chown(path, uid=user_database.pw_uid, gid=user_database.pw_gid)
 
     def _create_directory(self, path: str, mode: int) -> None:
         """Creates a directory.

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,30 @@
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+
+from pathlib import Path
+from typing import Callable
+from unittest.mock import patch
+
+import yaml
+
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+STORAGE_PATH = METADATA["storage"]["pgdata"]["location"]
+
+
+def patch_network_get(private_address="1.1.1.1") -> Callable:
+    def network_get(*args, **kwargs) -> dict:
+        """Patch for the not-yet-implemented testing backend needed for `bind_address`.
+
+        This patch decorator can be used for cases such as:
+        self.model.get_binding(event.relation).network.bind_address
+        """
+        return {
+            "bind-addresses": [
+                {
+                    "addresses": [{"value": private_address}],
+                }
+            ]
+        }
+
+    return patch("ops.testing._TestingModelBackend.network_get", network_get)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -17,9 +17,11 @@ from cluster import (
     ClusterNotRunningError,
     ClusterStartError,
 )
+from tests.helpers import patch_network_get
 
 
 class TestCharm(unittest.TestCase):
+    @patch_network_get(private_address="1.1.1.1")
     def setUp(self):
         self._peer_relation = "postgresql-replicas"
         self._postgresql_container = "postgresql"

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -67,18 +67,6 @@ class TestCharm(unittest.TestCase):
         _render_postgresql_conf_file.assert_called_once()
         _start_cluster.assert_called_once()
 
-    @patch("charm.PostgresqlCluster._change_owner")
-    @patch("os.chmod")
-    @patch("os.makedirs")
-    def test_create_directory(self, _makedirs, _chmod, _change_owner):
-        path = "/tmp/fakedir"
-        mode = 0o755
-
-        self.cluster._create_directory(path, mode)
-        _makedirs.assert_called_once_with(path, mode=mode, exist_ok=True)
-        _chmod.assert_called_once_with(path, mode)
-        _change_owner.assert_called_once_with(path)
-
     @patch("os.makedirs")
     def test_inhibit_default_cluster_creation(self, _makedirs):
         # Setup a mock for the `open` method.

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -5,20 +5,24 @@ import os
 import unittest
 from unittest.mock import call, mock_open, patch
 
+from jinja2 import Template
+
 from cluster import (
     ClusterAlreadyRunningError,
     ClusterNotRunningError,
     PostgresqlCluster,
 )
 from lib.charms.operator_libs_linux.v0.apt import DebianPackage, PackageState
+from tests.helpers import STORAGE_PATH
 
 CREATE_CLUSTER_CONF_PATH = "/etc/postgresql-common/createcluster.d/pgcharm.conf"
+PATRONI_SERVICE = "patroni"
 
 
 class TestCharm(unittest.TestCase):
     def setUp(self):
         # Setup a cluster.
-        self.cluster = PostgresqlCluster()
+        self.cluster = PostgresqlCluster("1.1.1.1")
 
     @patch("charm.PostgresqlCluster._start_cluster")
     @patch("charm.PostgresqlCluster._render_postgresql_conf_file")
@@ -62,6 +66,18 @@ class TestCharm(unittest.TestCase):
         _copy_pg_hba_conf_file.assert_called_once()
         _render_postgresql_conf_file.assert_called_once()
         _start_cluster.assert_called_once()
+
+    @patch("charm.PostgresqlCluster._change_owner")
+    @patch("os.chmod")
+    @patch("os.makedirs")
+    def test_create_directory(self, _makedirs, _chmod, _change_owner):
+        path = "/tmp/fakedir"
+        mode = 0o755
+
+        self.cluster._create_directory(path, mode)
+        _makedirs.assert_called_once_with(path, mode=mode, exist_ok=True)
+        _chmod.assert_called_once_with(path, mode)
+        _change_owner.assert_called_once_with(path)
 
     @patch("os.makedirs")
     def test_inhibit_default_cluster_creation(self, _makedirs):
@@ -184,7 +200,79 @@ class TestCharm(unittest.TestCase):
         _chown.assert_called_with(filename, uid=35, gid=35)
 
     @patch("charm.PostgresqlCluster._render_file")
-    def test_render_postgresql_conf_file(self, _render_file):
+    @patch("charm.PostgresqlCluster._create_directory")
+    def test_render_patroni_service_file(self, _, _render_file):
+        # Get the expected content from a file.
+        with open("templates/patroni.service.j2") as file:
+            template = Template(file.read())
+        expected_content = template.render(conf_path=STORAGE_PATH)
+
+        # Setup a mock for the `open` method, set returned data to patroni.service template.
+        with open("templates/patroni.service.j2", "r") as f:
+            mock = mock_open(read_data=f.read())
+
+        # Patch the `open` method with our mock.
+        with patch("builtins.open", mock, create=True):
+            # Call the method
+            self.cluster._render_patroni_service_file()
+
+        # Check the template is opened read-only in the call to open.
+        self.assertEqual(mock.call_args_list[0][0], ("templates/patroni.service.j2", "r"))
+        # Ensure the correct rendered template is sent to _render_file method.
+        _render_file.assert_called_once_with(
+            "/etc/systemd/system/patroni.service",
+            expected_content,
+            0o644,
+        )
+
+    @patch("charm.PostgresqlCluster._render_file")
+    @patch("charm.PostgresqlCluster._create_directory")
+    def test_render_patroni_yml_file(self, _, _render_file):
+        # Define variables to render in the template.
+        member_name = "postgresql-0"
+        scope = "postgresql"
+        superuser_password = "fake-superuser-password"
+        replication_password = "fake-replication-password"
+
+        # Get the expected content from a file.
+        with open("templates/patroni.yml.j2") as file:
+            template = Template(file.read())
+        expected_content = template.render(
+            conf_path=STORAGE_PATH,
+            member_name=member_name,
+            scope=scope,
+            self_ip=self.cluster.unit_ip,
+            superuser_password=superuser_password,
+            replication_password=replication_password,
+            version=self.cluster._get_postgresql_version(),
+        )
+
+        # Setup a mock for the `open` method, set returned data to patroni.yml template.
+        with open("templates/patroni.yml.j2", "r") as f:
+            mock = mock_open(read_data=f.read())
+
+        # Patch the `open` method with our mock.
+        with patch("builtins.open", mock, create=True):
+            # Call the method.
+            self.cluster._render_patroni_yml_file(
+                scope,
+                member_name,
+                superuser_password,
+                replication_password,
+            )
+
+        # Check the template is opened read-only in the call to open.
+        self.assertEqual(mock.call_args_list[0][0], ("templates/patroni.yml.j2", "r"))
+        # Ensure the correct rendered template is sent to _render_file method.
+        _render_file.assert_called_once_with(
+            f"{STORAGE_PATH}/patroni.yml",
+            expected_content,
+            0o644,
+        )
+
+    @patch("charm.PostgresqlCluster._render_file")
+    @patch("charm.PostgresqlCluster._create_directory")
+    def test_render_postgresql_conf_file(self, _, _render_file):
         # Get the expected content from a file.
         with open("tests/data/postgresql.conf") as file:
             expected_content = file.read()
@@ -215,3 +303,19 @@ class TestCharm(unittest.TestCase):
         self.cluster._start_cluster()
         # Check that check_call was invoked with the correct arguments.
         _call.assert_called_once_with(["pg_ctlcluster", self.cluster.version, "main", "start"])
+
+    @patch("cluster.service_start")
+    @patch("cluster.service_running")
+    @patch("charm.PostgresqlCluster._create_directory")
+    def test_start_patroni(self, _create_directory, _service_running, _service_start):
+        _service_running.side_effect = [True, False]
+
+        # Test a success scenario.
+        success = self.cluster._start_patroni()
+        _service_start.assert_called_with(PATRONI_SERVICE)
+        _service_running.assert_called_with(PATRONI_SERVICE)
+        assert success
+
+        # Test a fail scenario.
+        success = self.cluster._start_patroni()
+        assert not success


### PR DESCRIPTION
# Issue
In short this PR partially address JIRA ticket [DPE-71](https://warthogs.atlassian.net/browse/DPE-71). The remaining implementation is split in three separate PRs to make the review easier.

In long:
* In order to enable automatic failover and replication through Patroni in a PostgreSQL deployment we need to change the way PostgreSQL is bootstraped/started (Patroni should be started; it'll start PostgreSQL later).
* For this specific PR we need to provide some additional functions to create configuration files for Patroni and also to start it later.


# Solution
* Generate configuration file (patroni.yml) and systemd unit file (patroni.service).
* Add helper functions to get unit IP, change owner of file and create directory.
* Add replication password.
* Add function to start Patroni.


# Context
A call to `systemd daemon-reload` is not present as it'll be part of the next PR.
Also, raft data directory (needed for tracking the primary in the Patroni cluster) creation will be made in the next PR.
Integrations tests seems to be failing due https://bugs.launchpad.net/juju/+bug/1968849.



# Testing
* Only unit tests where updated as the new functions were not used yet.
* Manual testing was done.


# Release Notes
* Add  functions for creating Patroni configuration file and systemd unit file
* Add helper functions for Patroni startup
* Add replication password generation