### PR TITLE
Scaling helper methods

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -1,5 +1,7 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+get-primary:
+  description: Get the unit which is the primary/leader in the replication.
 get-initial-password:
   description: Get the initial postgres user password for the database.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ show_missing = true
 [tool.pytest.ini_options]
 minversion = "6.0"
 log_cli_level = "INFO"
+asyncio_mode = "auto"
 
 # Formatting tools configuration
 [tool.black]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
-ops==1.2.0
+ops==1.5.0
+requests==2.28.1
+tenacity==8.0.1

--- a/src/charm.py
+++ b/src/charm.py
@@ -148,7 +148,14 @@ class PostgresqlOperatorCharm(CharmBase):
         self._update_members_ips(ip_to_remove=ip)
 
     def _update_members_ips(self, ip_to_add: str = None, ip_to_remove: str = None) -> None:
-        """Update cluster members IPs."""
+        """Update cluster member IPs on application data.
+
+        Member IPs on application data are used to determine when a unit of PostgreSQL
+        should be added or removed from the PostgreSQL cluster.
+
+        NOTE: this function does not update the IPs on the PostgreSQL cluster
+        in the Patroni configuration.
+        """
         # Allow leader to reset which members are part of the cluster.
         if not self.unit.is_leader():
             return

--- a/src/charm.py
+++ b/src/charm.py
@@ -11,13 +11,7 @@ import subprocess
 from typing import List
 
 from charms.operator_libs_linux.v0 import apt
-from ops.charm import (
-    ActionEvent,
-    CharmBase,
-    LeaderElectedEvent,
-    RelationChangedEvent,
-    RelationDepartedEvent,
-)
+from ops.charm import ActionEvent, CharmBase
 from ops.main import main
 from ops.model import (
     ActiveStatus,

--- a/src/charm.py
+++ b/src/charm.py
@@ -11,7 +11,13 @@ import subprocess
 from typing import List
 
 from charms.operator_libs_linux.v0 import apt
-from ops.charm import ActionEvent, CharmBase
+from ops.charm import (
+    ActionEvent,
+    CharmBase,
+    LeaderElectedEvent,
+    RelationChangedEvent,
+    RelationDepartedEvent,
+)
 from ops.main import main
 from ops.model import (
     ActiveStatus,

--- a/src/charm.py
+++ b/src/charm.py
@@ -103,17 +103,17 @@ class PostgresqlOperatorCharm(CharmBase):
             self._cluster_name,
             self._member_name,
             self.app.planned_units(),
-            self._peers_ips,
+            self._peer_members_ips,
             self._get_postgres_password(),
             self._replication_password,
         )
 
     @property
-    def _peers_ips(self) -> Set[str]:
-        """Fetch current list of peers IPs.
+    def _peer_members_ips(self) -> Set[str]:
+        """Fetch current list of peer members IPs.
 
         Returns:
-            A list of peers addresses (strings).
+            A list of peer members addresses (strings).
         """
         # Get all members IPs and remove the current unit IP from the list.
         addresses = self.members_ips

--- a/src/charm.py
+++ b/src/charm.py
@@ -75,8 +75,8 @@ class PostgresqlOperatorCharm(CharmBase):
         except SwitchoverFailedError as e:
             logger.error(f"switchover failed with reason: {e}")
 
-    def _get_ip_by_unit(self, unit: Unit) -> str:
-        """Get the IP address of a specific unit."""
+    def _get_peer_unit_ip(self, unit: Unit) -> str:
+        """Get the IP address of a specific peer unit."""
         return self._peers.data[unit].get("private-address")
 
     @property
@@ -130,7 +130,7 @@ class PostgresqlOperatorCharm(CharmBase):
             A list of peers addresses (strings).
         """
         # Get all members IPs and remove the current unit IP from the list.
-        addresses = {self._get_ip_by_unit(unit) for unit in self._peers.units}
+        addresses = {self._get_peer_unit_ip(unit) for unit in self._peers.units}
         addresses.add(self._unit_ip)
         return addresses
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -85,7 +85,8 @@ class PostgresqlOperatorCharm(CharmBase):
 
         Returns:
             a set containing the current Juju hosts
-                with the names in the k8s pod name format
+                with the names using - instead of /
+                to match Patroni members names
         """
         peers = self.model.get_relation(PEER)
         hosts = [self.unit.name.replace("/", "-")] + [

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -256,7 +256,7 @@ class Patroni:
         return service_running(PATRONI_SERVICE)
 
     def switchover(self, candidate: str = None) -> None:
-        """Schedule a switchover to a given candidate member????."""
+        """Schedule a switchover to a given candidate member."""
         current_primary = self.get_primary()
         r = requests.post(
             f"http://{self.unit_ip}:8008/switchover",

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -93,8 +93,8 @@ class Patroni:
     def cluster_members(self) -> set:
         """Get the current cluster members."""
         # Request info from cluster endpoint (which returns all members of the cluster).
-        r = requests.get(f"http://{self.unit_ip}:8008/cluster")
-        return set([member["name"] for member in r.json()["members"]])
+        cluster_status = requests.get(f"http://{self.unit_ip}:8008/cluster")
+        return set([member["name"] for member in cluster_status.json()["members"]])
 
     def _create_directory(self, path: str, mode: int) -> None:
         """Creates a directory.
@@ -133,8 +133,8 @@ class Patroni:
         """
         primary = None
         # Request info from cluster endpoint (which returns all members of the cluster).
-        r = requests.get(f"http://{self.unit_ip}:8008/cluster")
-        for member in r.json()["members"]:
+        cluster_status = requests.get(f"http://{self.unit_ip}:8008/cluster")
+        for member in cluster_status.json()["members"]:
             if member["role"] == "leader":
                 primary = member["name"]
                 if unit_name_pattern:
@@ -155,11 +155,11 @@ class Patroni:
         try:
             for attempt in Retrying(stop=stop_after_delay(10), wait=wait_fixed(3)):
                 with attempt:
-                    r = requests.get(f"http://{self.unit_ip}:8008/cluster")
+                    cluster_status = requests.get(f"http://{self.unit_ip}:8008/cluster")
         except RetryError:
             return False
 
-        return all(member["state"] == "running" for member in r.json()["members"])
+        return all(member["state"] == "running" for member in cluster_status.json()["members"])
 
     @property
     def member_started(self) -> bool:

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -11,6 +11,9 @@ scope: {{ scope }}
 namespace: /db/
 name: {{ member_name }}
 
+log:
+  dir: /var/log/postgresql
+
 restapi:
   listen: '{{ self_ip }}:8008'
   connect_address: '{{ self_ip }}:8008'

--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,7 @@ deps =
 commands =
     # Download patroni resource to use in the charm deployment.
     sh -c 'stat patroni.tar.gz > /dev/null 2>&1 || curl "https://github.com/zalando/patroni/archive/refs/tags/v2.1.3.tar.gz" -L -s > patroni.tar.gz'
-    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} --asyncio-mode=auto
+    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
     # Remove the downloaded resource.
     sh -c 'rm -f patroni.tar.gz'
 whitelist_externals =

--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,7 @@ deps =
 commands =
     # Download patroni resource to use in the charm deployment.
     sh -c 'stat patroni.tar.gz > /dev/null 2>&1 || curl "https://github.com/zalando/patroni/archive/refs/tags/v2.1.3.tar.gz" -L -s > patroni.tar.gz'
-    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} --asyncio-mode=auto
     # Remove the downloaded resource.
     sh -c 'rm -f patroni.tar.gz'
 whitelist_externals =


### PR DESCRIPTION
# Issue
This is a PR that was on hold to copy the feedback that improved the PR from https://github.com/canonical/postgresql-k8s-operator/pull/9.

It is part of the scale up/down logic that is needed to avoid adding or removing more than one member to a PostgreSQL cluster if another member is still syncing data after it has joined.

In long:
* To avoid overload of the network during copy of data between the replicas that are being added to the cluster during a scale up or downtime in the case of a scale down, the charm needs to add and remove on member at a time from the cluster so.
* If the member is the current primary, we need to trigger a switchover before the unit is removed, to make avoid downtime in the cluster.


# Solution
* Add some helper methods to add/remove one member at a time and also trigger a switchover when the primary is the unit that is being removed in a scale down process.

# Context
This PR only adds some helper methods that will be used on https://github.com/canonical/postgresql-operator/pull/11.
In `charm.py`:
* Added an action to get the primary unit.
* Added methods for chaning the primary (on a scaling down process if the primary is the unit that is being removed).
* Added some methods to list the IPs and the units that are part of the cluster.
* Added methods to add and remove members to the cluster (through adding them to peer relation data that is later used to update the patroni configuration file, which is used to update the list of cluster members).
In `cluster.py`:
* Added custom exceptions for cluster not ready for adding/removing new members (because of not all members are ready, probably because of a data sync).
* Added methods for getting the primary and cluster members.
* Added methos for checking if all members are ready and whether the member has started (Patroni and PostgreSQL are running).
* Added methods to change the primary through a switchover and check that it happended.
* Added methods for updating and reloading Patroni configuration (this will be used to update the list of members of the cluster).



# Testing
* The new tests are implemented on https://github.com/canonical/postgresql-operator/pull/14.


# Release Notes
* Add helper methods for scaling up/down.