### PR TITLE
fix departing unit subtleties

### DIFF
--- a/tests/unit/test_postgresql_provider.py
+++ b/tests/unit/test_postgresql_provider.py
@@ -41,7 +41,6 @@ class TestPostgreSQLProvider(unittest.TestCase):
         # Define some relations.
         self.rel_id = self.harness.add_relation(RELATION_NAME, "application")
         self.harness.add_relation_unit(self.rel_id, "application/0")
-        self.harness.add_relation_unit(self.rel_id, self.unit)
         self.peer_rel_id = self.harness.add_relation(PEER, self.app)
         self.harness.add_relation_unit(self.peer_rel_id, self.unit)
         self.harness.update_relation_data(
@@ -191,6 +190,7 @@ class TestPostgreSQLProvider(unittest.TestCase):
             # Test that a flag for preventing user deletion is set in peer relation data
             # when the unit that is being removed is the current unit.
             mock_departing_unit.return_value = self.harness.model.get_unit(self.unit)
+            self.harness.add_relation_unit(self.rel_id, self.unit)
             self.harness.remove_relation_unit(self.rel_id, self.unit)
             peer_relation_data = self.harness.get_relation_data(self.peer_rel_id, self.unit)
             self.assertDictEqual(peer_relation_data, {"departing": "True"})


### PR DESCRIPTION
ops 1.5.2 introduced a fix to the harness' handling for departing unit tracking for events.  This uncovered a subtle error in the tests here. remove_relation was triggering the "departing" relation data key to be inserted into the local charm's data because the local charm had been added to the relation units list (which is not really how that is intended to be used).  This was causing the delete_user method to be called earlier than intended and caused assertion failures in the on_relation_broken test.  The fix is to not add the local unit to the relation units.  But then the relation departed test that checks for the "departing" data key wasn't working.  So for now, we can add the local unit to the relation in that test only.