### PR TITLE
DPE-781 Run integration tests for passed lint/unit tests only

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,9 @@ jobs:
 
   integration-test-lxd-charm:
     name: Integration tests for charm deployment (lxd)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -43,6 +46,9 @@ jobs:
 
   integration-test-lxd-database-relation:
     name: Integration tests for database relation (lxd)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -56,6 +62,9 @@ jobs:
 
   integration-test-lxd-db-relation:
     name: Integration tests for db relation (lxd)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -69,6 +78,9 @@ jobs:
 
   integration-test-lxd-db-admin-relation:
     name: Integration tests for db-admin relation (lxd)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -82,6 +94,9 @@ jobs:
 
   integration-test-ha-self-healing-rotation:
     name: Integration tests for high availability self healing (lxd)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -95,6 +110,9 @@ jobs:
 
   integration-test-lxd-password-rotation:
     name: Integration tests for password rotation (lxd)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -108,6 +126,9 @@ jobs:
 
   integration-test-lxd-tls:
     name: Integration tests for TLS (lxd)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Avoid a long-running integration test in case of failing gatekeeping tests. It will slightly increase the complete tests scope runtime but will save (a lot?) of electricity/money for Canonical as often new pull requests have some initial typos/issues to be polished.