### PR TITLE
Pin Juju agent version on CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,6 +57,8 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
+          # This is needed until https://bugs.launchpad.net/juju/+bug/1992833 is fixed.
+          bootstrap-options: "--agent-version 2.9.34"
       - name: Run integration tests
         run: tox -e database-relation-integration
 
@@ -105,6 +107,8 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
+          # This is needed until https://bugs.launchpad.net/juju/+bug/1992833 is fixed.
+          bootstrap-options: "--agent-version 2.9.34"
       - name: Run integration tests
         run: tox -e ha-self-healing-integration
 


### PR DESCRIPTION
Jira issue: [DPE-788](https://warthogs.atlassian.net/browse/DPE-788)

As described on https://bugs.launchpad.net/juju/+bug/1992833, the new Juju version released on 2022-10-12 is breaking some CI jobs.

The problem is that it's enforcing the `series` field on `metadata.yaml` (the problem is solved after adding the field, but that field is not present on the [metadata reference](https://juju.is/docs/sdk/metadata-yaml)).

Only the affected integration tests had the agents version pinned.