### PR TITLE
Pin OS on release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
     needs:
       - lib-check
       - ci-tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/tox.ini
+++ b/tox.ini
@@ -82,7 +82,7 @@ commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} -m charm_tests
     # Remove the downloaded resource.
     sh -c 'rm -f patroni.tar.gz'
-whitelist_externals =
+allowlist_externals =
     sh
 
 [testenv:database-relation-integration]
@@ -101,7 +101,7 @@ commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} -m database_relation_tests
     # Remove the downloaded resource.
     sh -c 'rm -f patroni.tar.gz'
-whitelist_externals =
+allowlist_externals =
     sh
 
 [testenv:db-relation-integration]
@@ -120,7 +120,7 @@ commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} -m db_relation_tests
     # Remove the downloaded resource.
     sh -c 'rm -f patroni.tar.gz'
-whitelist_externals =
+allowlist_externals =
     sh
 
 [testenv:db-admin-relation-integration]
@@ -139,7 +139,7 @@ commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} -m db_admin_relation_tests
     # Remove the downloaded resource.
     sh -c 'rm -f patroni.tar.gz'
-whitelist_externals =
+allowlist_externals =
     sh
 
 [testenv:ha-self-healing-integration]
@@ -158,7 +158,7 @@ commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} -m ha_self_healing_tests
     # Remove the downloaded resource.
     sh -c 'rm -f patroni.tar.gz'
-whitelist_externals =
+allowlist_externals =
     sh
 
 [testenv:password-rotation-integration]
@@ -177,7 +177,7 @@ commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} -m password_rotation_tests
     # Remove the downloaded resource.
     sh -c 'rm -f patroni.tar.gz'
-whitelist_externals =
+allowlist_externals =
     sh
 
 [testenv:tls-integration]
@@ -196,7 +196,7 @@ commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} -m tls_tests
     # Remove the downloaded resource.
     sh -c 'rm -f patroni.tar.gz'
-whitelist_externals =
+allowlist_externals =
     sh
 
 [testenv:integration]
@@ -215,5 +215,5 @@ commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
     # Remove the downloaded resource.
     sh -c 'rm -f patroni.tar.gz'
-whitelist_externals =
+allowlist_externals =
     sh


### PR DESCRIPTION
# Issue
As the `ubuntu-latest` GH runner image was updated to jammy, the step that publishes the charm will break (due to using `--destructive-mode`).

We can see the issue on the [last attempt to publish the charm](https://github.com/canonical/postgresql-operator/actions/runs/3848767990/jobs/6560271111#step:4:13).


# Solution
Pin focal runner image (`ubuntu-20.04`) on release workflow.


# Context
Jammy was not added to `charmcraft.yaml` because it will require some adjustments on the tests (and maybe also in the charm code).


# Testing
Tested `sudo charmcraft pack --destructive-mode --quiet` manually on a focal VM.


# Release Notes
Pin focal runner image on release workflow.