### PR TITLE
Fix delete user call when user was not created before

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
     needs:
       - lib-check
       - ci-tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -32,7 +32,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 7
 
 
 logger = logging.getLogger(__name__)
@@ -119,6 +119,31 @@ class PostgreSQL:
                     sql.Identifier(database), sql.Identifier(user)
                 )
             )
+            with self._connect_to_database(database=database) as conn:
+                with conn.cursor() as curs:
+                    statements = []
+                    curs.execute(
+                        "SELECT schema_name FROM information_schema.schemata WHERE schema_name NOT LIKE 'pg_%' and schema_name <> 'information_schema';"
+                    )
+                    for row in curs:
+                        schema = sql.Identifier(row[0])
+                        statements.append(
+                            sql.SQL(
+                                "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA {} TO {};"
+                            ).format(schema, sql.Identifier(user))
+                        )
+                        statements.append(
+                            sql.SQL(
+                                "GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA {} TO {};"
+                            ).format(schema, sql.Identifier(user))
+                        )
+                        statements.append(
+                            sql.SQL(
+                                "GRANT ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA {} TO {};"
+                            ).format(schema, sql.Identifier(user))
+                        )
+                    for statement in statements:
+                        curs.execute(statement)
         except psycopg2.Error as e:
             logger.error(f"Failed to create database: {e}")
             raise PostgreSQLCreateDatabaseError()
@@ -159,6 +184,11 @@ class PostgreSQL:
         Args:
             user: user to be deleted.
         """
+        # First of all, check whether the user exists. Otherwise, do nothing.
+        users = self.list_users()
+        if user not in users:
+            return
+
         # List all databases.
         try:
             with self._connect_to_database() as connection, connection.cursor() as cursor:

--- a/tests/integration/new_relations/application-charm/metadata.yaml
+++ b/tests/integration/new_relations/application-charm/metadata.yaml
@@ -16,3 +16,5 @@ requires:
   aliased-multiple-database-clusters:
     interface: postgresql_client
     limit: 2
+  no-database:
+    interface: postgresql_client

--- a/tests/integration/new_relations/application-charm/src/charm.py
+++ b/tests/integration/new_relations/application-charm/src/charm.py
@@ -103,6 +103,9 @@ class ApplicationCharm(CharmBase):
             self._on_cluster2_endpoints_changed,
         )
 
+        # Relation used to test the situation where no database name is provided.
+        self.no_database = DatabaseRequires(self, "no-database", database_name="")
+
     def _on_start(self, _) -> None:
         """Only sets an Active status."""
         self.unit.status = ActiveStatus()

--- a/tox.ini
+++ b/tox.ini
@@ -82,7 +82,7 @@ commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} -m charm_tests
     # Remove the downloaded resource.
     sh -c 'rm -f patroni.tar.gz'
-whitelist_externals =
+allowlist_externals =
     sh
 
 [testenv:database-relation-integration]
@@ -101,7 +101,7 @@ commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} -m database_relation_tests
     # Remove the downloaded resource.
     sh -c 'rm -f patroni.tar.gz'
-whitelist_externals =
+allowlist_externals =
     sh
 
 [testenv:db-relation-integration]
@@ -120,7 +120,7 @@ commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} -m db_relation_tests
     # Remove the downloaded resource.
     sh -c 'rm -f patroni.tar.gz'
-whitelist_externals =
+allowlist_externals =
     sh
 
 [testenv:db-admin-relation-integration]
@@ -139,7 +139,7 @@ commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} -m db_admin_relation_tests
     # Remove the downloaded resource.
     sh -c 'rm -f patroni.tar.gz'
-whitelist_externals =
+allowlist_externals =
     sh
 
 [testenv:ha-self-healing-integration]
@@ -158,7 +158,7 @@ commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} -m ha_self_healing_tests
     # Remove the downloaded resource.
     sh -c 'rm -f patroni.tar.gz'
-whitelist_externals =
+allowlist_externals =
     sh
 
 [testenv:password-rotation-integration]
@@ -177,7 +177,7 @@ commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} -m password_rotation_tests
     # Remove the downloaded resource.
     sh -c 'rm -f patroni.tar.gz'
-whitelist_externals =
+allowlist_externals =
     sh
 
 [testenv:tls-integration]
@@ -196,7 +196,7 @@ commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} -m tls_tests
     # Remove the downloaded resource.
     sh -c 'rm -f patroni.tar.gz'
-whitelist_externals =
+allowlist_externals =
     sh
 
 [testenv:integration]
@@ -215,5 +215,5 @@ commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
     # Remove the downloaded resource.
     sh -c 'rm -f patroni.tar.gz'
-whitelist_externals =
+allowlist_externals =
     sh


### PR DESCRIPTION
# Issue
Jira issue: [DPE-991](https://warthogs.atlassian.net/browse/DPE-991)
Also fixes: [DPE-1066](https://warthogs.atlassian.net/browse/DPE-1066)

When a charm relates to the database interface without providing a database name and later the relation is removed the PostgreSQL charm tries to delete the database user that was not created (because the database user is only created if the relation is complete: the other application needs to provide a database name for that).


# Solution
Check whether the database user exists before the charm tries to delete it by importing the updated `lib/charms/postgresql_k8s/v0/postgresql.py` library from https://github.com/canonical/postgresql-k8s-operator/pull/75.

In summary, this is a copy and paste of the PR from the k8s charm.


# Context
`lib/charms/postgresql_k8s/v0/postgresql.py` (reviewed on https://github.com/canonical/postgresql-k8s-operator/pull/75) was imported from the K8S charm.


# Testing
A test was simulating a relation without providing a database name was copied from https://github.com/canonical/postgresql-k8s-operator/pull/75.

For that, the tester application got a new relation (because it was easy to implemented on that and the data integrator - the charm used in the test that lead to the bug report - is not available yet on Charmhub).


# Release Notes
Check if a database user exists before trying to delete it.


[DPE-991]: https://warthogs.atlassian.net/browse/DPE-991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DPE-1066]: https://warthogs.atlassian.net/browse/DPE-1066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ