### PR TITLE
Legacy interface fails to relate if event attributes are None

### DIFF
--- a/src/relations/db.py
+++ b/src/relations/db.py
@@ -211,17 +211,6 @@ class DbProvides(Object):
             {unit for unit in current_allowed_units.split() if unit != departing_unit}
         )
 
-        # Clean up Blocked status if caused by the departed relation
-        if (
-            self.charm._has_blocked_status
-            and self.charm.unit.status.message == EXTENSIONS_BLOCKING_MESSAGE
-        ):
-            if "extensions" in event.relation.data.get(
-                event.app, {}
-            ) or "extensions" in event.relation.data.get(event.unit, {}):
-                if not self._check_for_blocking_relations(event.relation.id):
-                    self.charm.unit.status = ActiveStatus()
-
     def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
         """Remove the user created for this relation."""
         # Check for some conditions before trying to access the PostgreSQL instance.
@@ -255,6 +244,17 @@ class DbProvides(Object):
             self.charm.unit.status = BlockedStatus(
                 f"Failed to delete user during {self.relation_name} relation broken event"
             )
+
+        # Clean up Blocked status if caused by the departed relation
+        if (
+            self.charm._has_blocked_status
+            and self.charm.unit.status.message == EXTENSIONS_BLOCKING_MESSAGE
+        ):
+            if "extensions" in event.relation.data.get(
+                event.app, {}
+            ) or "extensions" in event.relation.data.get(event.unit, {}):
+                if not self._check_for_blocking_relations(event.relation.id):
+                    self.charm.unit.status = ActiveStatus()
 
     def update_endpoints(self, event: RelationChangedEvent = None) -> None:
         """Set the read/write and read-only endpoints."""

--- a/src/relations/db.py
+++ b/src/relations/db.py
@@ -20,13 +20,15 @@ from ops.charm import (
     RelationDepartedEvent,
 )
 from ops.framework import Object
-from ops.model import BlockedStatus, Relation, Unit
+from ops.model import ActiveStatus, BlockedStatus, Relation, Unit
 from pgconnstr import ConnectionString
 
 from constants import DATABASE_PORT
 from utils import new_password
 
 logger = logging.getLogger(__name__)
+
+EXTENSIONS_BLOCKING_MESSAGE = "extensions requested through relation"
 
 
 class DbProvides(Object):
@@ -66,6 +68,21 @@ class DbProvides(Object):
         self.admin = admin
         self.charm = charm
 
+    def _check_for_blocking_relations(self, relation_id: int) -> bool:
+        """Checks if there are relations with extensions.
+
+        Args:
+            relation_id: current relation to be skipped
+        """
+        for relname in ["db", "db-admin"]:
+            for relation in self.charm.model.relations.get(relname, []):
+                if relation.id == relation_id:
+                    continue
+                for data in relation.data.values():
+                    if "extensions" in data:
+                        return True
+        return False
+
     def _on_relation_changed(self, event: RelationChangedEvent) -> None:
         """Handle the legacy db/db-admin relation changed event.
 
@@ -92,20 +109,20 @@ class DbProvides(Object):
         application_relation_databag = event.relation.data[self.charm.app]
 
         # Do not allow apps requesting extensions to be installed.
-        if "extensions" in event.relation.data[
-            event.app
-        ] or "extensions" in event.relation.data.get(event.unit, {}):
+        if "extensions" in event.relation.data.get(
+            event.app, {}
+        ) or "extensions" in event.relation.data.get(event.unit, {}):
             logger.error(
                 "ERROR - `extensions` cannot be requested through relations"
                 " - they should be installed through a database charm config in the future"
             )
-            self.charm.unit.status = BlockedStatus("extensions requested through relation")
+            self.charm.unit.status = BlockedStatus(EXTENSIONS_BLOCKING_MESSAGE)
             return
 
         # Sometimes a relation changed event is triggered,
         # and it doesn't have a database name in it.
-        database = event.relation.data[event.app].get(
-            "database", event.relation.data[event.unit].get("database")
+        database = event.relation.data.get(event.app, {}).get(
+            "database", event.relation.data.get(event.unit, {}).get("database")
         )
         if not database:
             logger.warning("No database name provided")
@@ -193,6 +210,17 @@ class DbProvides(Object):
         local_app_data["allowed_units"] = local_unit_data["allowed_units"] = " ".join(
             {unit for unit in current_allowed_units.split() if unit != departing_unit}
         )
+
+        # Clean up Blocked status if caused by the departed relation
+        if (
+            self.charm._has_blocked_status
+            and self.charm.unit.status.message == EXTENSIONS_BLOCKING_MESSAGE
+        ):
+            if "extensions" in event.relation.data.get(
+                event.app, {}
+            ) or "extensions" in event.relation.data.get(event.unit, {}):
+                if not self._check_for_blocking_relations(event.relation.id):
+                    self.charm.unit.status = ActiveStatus()
 
     def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
         """Remove the user created for this relation."""

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -212,6 +212,70 @@ class TestDbProvides(unittest.TestCase):
             self.assertTrue(isinstance(self.harness.model.unit.status, BlockedStatus))
 
     @patch(
+        "charm.PostgresqlOperatorCharm.primary_endpoint",
+        new_callable=PropertyMock,
+    )
+    @patch("charm.PostgresqlOperatorCharm._has_blocked_status", new_callable=PropertyMock)
+    @patch("charm.Patroni.member_started", new_callable=PropertyMock)
+    @patch("charm.DbProvides._on_relation_departed")
+    def test_on_relation_broken_extensions_unblock(
+        self, _on_relation_departed, _member_started, _primary_endpoint, _has_blocked_status
+    ):
+        with patch.object(PostgresqlOperatorCharm, "postgresql", Mock()) as postgresql_mock:
+            # Set some side effects to test multiple situations.
+            _has_blocked_status.return_value = True
+            _member_started.return_value = True
+            _primary_endpoint.return_value = {"1.1.1.1"}
+            postgresql_mock.delete_user = PropertyMock(return_value=None)
+            self.harness.model.unit.status = BlockedStatus("extensions requested through relation")
+            with self.harness.hooks_disabled():
+                self.rel_id = self.harness.add_relation(RELATION_NAME, "application")
+                self.harness.update_relation_data(
+                    self.rel_id,
+                    "application",
+                    {"database": DATABASE, "extensions": ["test"]},
+                )
+
+            # Break the relation before the database is ready.
+            self.harness.remove_relation(self.rel_id)
+            self.assertTrue(isinstance(self.harness.model.unit.status, ActiveStatus))
+
+    @patch(
+        "charm.PostgresqlOperatorCharm.primary_endpoint",
+        new_callable=PropertyMock,
+    )
+    @patch("charm.PostgresqlOperatorCharm._has_blocked_status", new_callable=PropertyMock)
+    @patch("charm.Patroni.member_started", new_callable=PropertyMock)
+    @patch("charm.DbProvides._on_relation_departed")
+    def test_on_relation_broken_extensions_keep_block(
+        self, _on_relation_departed, _member_started, _primary_endpoint, _has_blocked_status
+    ):
+        with patch.object(PostgresqlOperatorCharm, "postgresql", Mock()) as postgresql_mock:
+            # Set some side effects to test multiple situations.
+            _has_blocked_status.return_value = True
+            _member_started.return_value = True
+            _primary_endpoint.return_value = {"1.1.1.1"}
+            postgresql_mock.delete_user = PropertyMock(return_value=None)
+            self.harness.model.unit.status = BlockedStatus("extensions requested through relation")
+            with self.harness.hooks_disabled():
+                self.rel_id = self.harness.add_relation(RELATION_NAME, "application")
+                self.harness.update_relation_data(
+                    self.rel_id,
+                    "application",
+                    {"database": DATABASE, "extensions": ["test"]},
+                )
+                second_rel_id = self.harness.add_relation(RELATION_NAME, "application2")
+                self.harness.update_relation_data(
+                    second_rel_id,
+                    "application2",
+                    {"database": DATABASE, "extensions": ["test"]},
+                )
+
+            # Break the relation before the database is ready.
+            self.harness.remove_relation(self.rel_id)
+            self.assertTrue(isinstance(self.harness.model.unit.status, BlockedStatus))
+
+    @patch(
         "charm.DbProvides._get_state",
         side_effect="postgresql/0",
     )

--- a/tox.ini
+++ b/tox.ini
@@ -71,7 +71,7 @@ commands =
 description = Run charm integration tests
 deps =
     pytest
-    juju
+    juju==2.9.11 # juju 3.0.0 has issues with retrieving action results
     landscape-api-py3
     mailmanclient
     pytest-operator
@@ -90,7 +90,7 @@ allowlist_externals =
 description = Run database relation integration tests
 deps =
     pytest
-    juju
+    juju==2.9.11 # juju 3.0.0 has issues with retrieving action results
     landscape-api-py3
     mailmanclient
     pytest-operator
@@ -109,7 +109,7 @@ allowlist_externals =
 description = Run db relation integration tests
 deps =
     pytest
-    juju
+    juju==2.9.11 # juju 3.0.0 has issues with retrieving action results
     landscape-api-py3
     mailmanclient
     pytest-operator
@@ -128,7 +128,7 @@ allowlist_externals =
 description = Run db-admin relation integration tests
 deps =
     pytest
-    juju
+    juju==2.9.11 # juju 3.0.0 has issues with retrieving action results
     landscape-api-py3
     mailmanclient
     pytest-operator
@@ -147,7 +147,7 @@ allowlist_externals =
 description = Run high availability self healing integration tests
 deps =
     pytest
-    juju
+    juju==2.9.11 # juju 3.0.0 has issues with retrieving action results
     landscape-api-py3
     mailmanclient
     pytest-operator
@@ -166,7 +166,7 @@ allowlist_externals =
 description = Run password rotation integration tests
 deps =
     pytest
-    juju
+    juju==2.9.11 # juju 3.0.0 has issues with retrieving action results
     landscape-api-py3
     mailmanclient
     pytest-operator
@@ -185,7 +185,7 @@ allowlist_externals =
 description = Run TLS integration tests
 deps =
     pytest
-    juju
+    juju==2.9.11 # juju 3.0.0 has issues with retrieving action results
     landscape-api-py3
     mailmanclient
     pytest-operator
@@ -204,7 +204,7 @@ allowlist_externals =
 description = Run all integration tests
 deps =
     pytest
-    juju
+    juju==2.9.11 # juju 3.0.0 has issues with retrieving action results
     landscape-api-py3
     mailmanclient
     pytest-operator

--- a/tox.ini
+++ b/tox.ini
@@ -71,7 +71,7 @@ commands =
 description = Run charm integration tests
 deps =
     pytest
-    juju==2.9.11 # juju 3.0.0 has issues with retrieving action results
+    juju
     landscape-api-py3
     mailmanclient
     pytest-operator
@@ -90,7 +90,7 @@ allowlist_externals =
 description = Run database relation integration tests
 deps =
     pytest
-    juju==2.9.11 # juju 3.0.0 has issues with retrieving action results
+    juju
     landscape-api-py3
     mailmanclient
     pytest-operator
@@ -109,7 +109,7 @@ allowlist_externals =
 description = Run db relation integration tests
 deps =
     pytest
-    juju==2.9.11 # juju 3.0.0 has issues with retrieving action results
+    juju
     landscape-api-py3
     mailmanclient
     pytest-operator
@@ -128,7 +128,7 @@ allowlist_externals =
 description = Run db-admin relation integration tests
 deps =
     pytest
-    juju==2.9.11 # juju 3.0.0 has issues with retrieving action results
+    juju
     landscape-api-py3
     mailmanclient
     pytest-operator
@@ -147,7 +147,7 @@ allowlist_externals =
 description = Run high availability self healing integration tests
 deps =
     pytest
-    juju==2.9.11 # juju 3.0.0 has issues with retrieving action results
+    juju
     landscape-api-py3
     mailmanclient
     pytest-operator
@@ -166,7 +166,7 @@ allowlist_externals =
 description = Run password rotation integration tests
 deps =
     pytest
-    juju==2.9.11 # juju 3.0.0 has issues with retrieving action results
+    juju
     landscape-api-py3
     mailmanclient
     pytest-operator
@@ -185,7 +185,7 @@ allowlist_externals =
 description = Run TLS integration tests
 deps =
     pytest
-    juju==2.9.11 # juju 3.0.0 has issues with retrieving action results
+    juju
     landscape-api-py3
     mailmanclient
     pytest-operator
@@ -204,7 +204,7 @@ allowlist_externals =
 description = Run all integration tests
 deps =
     pytest
-    juju==2.9.11 # juju 3.0.0 has issues with retrieving action results
+    juju
     landscape-api-py3
     mailmanclient
     pytest-operator


### PR DESCRIPTION
# Issue
* [DPE-1049](https://warthogs.atlassian.net/browse/DPE-1049)
* Relating fails if  `event.app` is None

# Solution
* More resilient check for database name and extensions 

# Context
* The VM charm is also affected by perpetual blocked status if extensions are requested, so the check to unblock is also copied

# Testing
* Adds integration test for relating with weebl
* Adds unit tests for extension unblocking logic

# Release Notes
* More resilient check for database name and extensions
* Unblock charm when relations requesting extensions are broken


[DPE-1049]: https://warthogs.atlassian.net/browse/DPE-1049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ