### PR TITLE
Updating libjuju to latest version for 2

### DIFF
--- a/lib/charms/postgresql_k8s/v0/postgresql_tls.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql_tls.py
@@ -45,7 +45,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version.
-LIBPATCH = 4
+LIBPATCH = 5
 
 logger = logging.getLogger(__name__)
 SCOPE = "unit"
@@ -125,8 +125,8 @@ class PostgreSQLTLS(Object):
 
     def _on_certificate_available(self, event: CertificateAvailableEvent) -> None:
         """Enable TLS when TLS certificate available."""
-        if event.certificate_signing_request != self.charm.get_secret(SCOPE, "csr"):
-            logger.error("An unknown certificate expiring.")
+        if event.certificate_signing_request.strip() != self.charm.get_secret(SCOPE, "csr").strip():
+            logger.error("An unknown certificate available.")
             return
 
         self.charm.set_secret(
@@ -144,7 +144,7 @@ class PostgreSQLTLS(Object):
 
     def _on_certificate_expiring(self, event: CertificateExpiringEvent) -> None:
         """Request the new certificate when old certificate is expiring."""
-        if event.certificate != self.charm.get_secret(SCOPE, "cert"):
+        if event.certificate.strip() != self.charm.get_secret(SCOPE, "cert").strip():
             logger.error("An unknown certificate expiring.")
             return
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cryptography==37.0.4
-ops==1.5.0
+ops==1.5.4
 pgconnstr==1.0.1
 requests==2.28.1
 tenacity==8.0.1

--- a/tests/integration/test_db.py
+++ b/tests/integration/test_db.py
@@ -66,8 +66,8 @@ async def test_mailman3_core_db(ops_test: OpsTest, charm: str) -> None:
 
         # Assert Mailman3 Core is configured to use PostgreSQL instead of SQLite.
         mailman_unit = ops_test.model.applications[MAILMAN3_CORE_APP_NAME].units[0]
-        action = await mailman_unit.run("mailman info")
-        result = action.results.get("Stdout", None)
+        action = await mailman_unit.run("mailman info", block=True)
+        result = action.results.get("stdout", None)
         assert "db url: postgres://" in result
 
         # Do some CRUD operations using Mailman3 Core client.

--- a/tests/integration/test_db.py
+++ b/tests/integration/test_db.py
@@ -66,8 +66,8 @@ async def test_mailman3_core_db(ops_test: OpsTest, charm: str) -> None:
 
         # Assert Mailman3 Core is configured to use PostgreSQL instead of SQLite.
         mailman_unit = ops_test.model.applications[MAILMAN3_CORE_APP_NAME].units[0]
-        action = await mailman_unit.run("mailman info", block=True)
-        result = action.results.get("stdout", None)
+        action = await mailman_unit.run("mailman info")
+        result = action.results.get("Stdout", None)
         assert "db url: postgres://" in result
 
         # Do some CRUD operations using Mailman3 Core client.

--- a/tox.ini
+++ b/tox.ini
@@ -71,7 +71,7 @@ commands =
 description = Run charm integration tests
 deps =
     pytest
-    juju
+    juju==2.9.38.1 # Latest juju 2
     landscape-api-py3
     mailmanclient
     pytest-operator
@@ -90,7 +90,7 @@ allowlist_externals =
 description = Run database relation integration tests
 deps =
     pytest
-    juju
+    juju==2.9.38.1 # Latest juju 2
     landscape-api-py3
     mailmanclient
     pytest-operator
@@ -109,7 +109,7 @@ allowlist_externals =
 description = Run db relation integration tests
 deps =
     pytest
-    juju
+    juju==2.9.38.1 # Latest juju 2
     landscape-api-py3
     mailmanclient
     pytest-operator
@@ -128,7 +128,7 @@ allowlist_externals =
 description = Run db-admin relation integration tests
 deps =
     pytest
-    juju
+    juju==2.9.38.1 # Latest juju 2
     landscape-api-py3
     mailmanclient
     pytest-operator
@@ -147,7 +147,7 @@ allowlist_externals =
 description = Run high availability self healing integration tests
 deps =
     pytest
-    juju
+    juju==2.9.38.1 # Latest juju 2
     landscape-api-py3
     mailmanclient
     pytest-operator
@@ -166,7 +166,7 @@ allowlist_externals =
 description = Run password rotation integration tests
 deps =
     pytest
-    juju
+    juju==2.9.38.1 # Latest juju 2
     landscape-api-py3
     mailmanclient
     pytest-operator
@@ -185,7 +185,7 @@ allowlist_externals =
 description = Run TLS integration tests
 deps =
     pytest
-    juju
+    juju==2.9.38.1 # Latest juju 2
     landscape-api-py3
     mailmanclient
     pytest-operator
@@ -204,7 +204,7 @@ allowlist_externals =
 description = Run all integration tests
 deps =
     pytest
-    juju
+    juju==2.9.38.1 # Latest juju 2
     landscape-api-py3
     mailmanclient
     pytest-operator

--- a/tox.ini
+++ b/tox.ini
@@ -71,7 +71,7 @@ commands =
 description = Run charm integration tests
 deps =
     pytest
-    juju==2.9.11 # juju 3.0.0 has issues with retrieving action results
+    juju
     landscape-api-py3
     mailmanclient
     pytest-operator
@@ -90,7 +90,7 @@ allowlist_externals =
 description = Run database relation integration tests
 deps =
     pytest
-    juju==2.9.11 # juju 3.0.0 has issues with retrieving action results
+    juju
     landscape-api-py3
     mailmanclient
     pytest-operator
@@ -109,7 +109,7 @@ allowlist_externals =
 description = Run db relation integration tests
 deps =
     pytest
-    juju==2.9.11 # juju 3.0.0 has issues with retrieving action results
+    juju
     landscape-api-py3
     mailmanclient
     pytest-operator
@@ -128,7 +128,7 @@ allowlist_externals =
 description = Run db-admin relation integration tests
 deps =
     pytest
-    juju==2.9.11 # juju 3.0.0 has issues with retrieving action results
+    juju
     landscape-api-py3
     mailmanclient
     pytest-operator
@@ -147,7 +147,7 @@ allowlist_externals =
 description = Run high availability self healing integration tests
 deps =
     pytest
-    juju==2.9.11 # juju 3.0.0 has issues with retrieving action results
+    juju
     landscape-api-py3
     mailmanclient
     pytest-operator
@@ -166,7 +166,7 @@ allowlist_externals =
 description = Run password rotation integration tests
 deps =
     pytest
-    juju==2.9.11 # juju 3.0.0 has issues with retrieving action results
+    juju
     landscape-api-py3
     mailmanclient
     pytest-operator
@@ -185,7 +185,7 @@ allowlist_externals =
 description = Run TLS integration tests
 deps =
     pytest
-    juju==2.9.11 # juju 3.0.0 has issues with retrieving action results
+    juju
     landscape-api-py3
     mailmanclient
     pytest-operator
@@ -204,7 +204,7 @@ allowlist_externals =
 description = Run all integration tests
 deps =
     pytest
-    juju==2.9.11 # juju 3.0.0 has issues with retrieving action results
+    juju
     landscape-api-py3
     mailmanclient
     pytest-operator

--- a/tox.ini
+++ b/tox.ini
@@ -71,7 +71,7 @@ commands =
 description = Run charm integration tests
 deps =
     pytest
-    juju==2.9.38.1 # Latest juju 2
+    juju~=2.9.0 # Latest juju 2
     landscape-api-py3
     mailmanclient
     pytest-operator
@@ -90,7 +90,7 @@ allowlist_externals =
 description = Run database relation integration tests
 deps =
     pytest
-    juju==2.9.38.1 # Latest juju 2
+    juju~=2.9.0 # Latest juju 2
     landscape-api-py3
     mailmanclient
     pytest-operator
@@ -109,7 +109,7 @@ allowlist_externals =
 description = Run db relation integration tests
 deps =
     pytest
-    juju==2.9.38.1 # Latest juju 2
+    juju~=2.9.0 # Latest juju 2
     landscape-api-py3
     mailmanclient
     pytest-operator
@@ -128,7 +128,7 @@ allowlist_externals =
 description = Run db-admin relation integration tests
 deps =
     pytest
-    juju==2.9.38.1 # Latest juju 2
+    juju~=2.9.0 # Latest juju 2
     landscape-api-py3
     mailmanclient
     pytest-operator
@@ -147,7 +147,7 @@ allowlist_externals =
 description = Run high availability self healing integration tests
 deps =
     pytest
-    juju==2.9.38.1 # Latest juju 2
+    juju~=2.9.0 # Latest juju 2
     landscape-api-py3
     mailmanclient
     pytest-operator
@@ -166,7 +166,7 @@ allowlist_externals =
 description = Run password rotation integration tests
 deps =
     pytest
-    juju==2.9.38.1 # Latest juju 2
+    juju~=2.9.0 # Latest juju 2
     landscape-api-py3
     mailmanclient
     pytest-operator
@@ -185,7 +185,7 @@ allowlist_externals =
 description = Run TLS integration tests
 deps =
     pytest
-    juju==2.9.38.1 # Latest juju 2
+    juju~=2.9.0 # Latest juju 2
     landscape-api-py3
     mailmanclient
     pytest-operator
@@ -204,7 +204,7 @@ allowlist_externals =
 description = Run all integration tests
 deps =
     pytest
-    juju==2.9.38.1 # Latest juju 2
+    juju~=2.9.0 # Latest juju 2
     landscape-api-py3
     mailmanclient
     pytest-operator

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8==4.0.1 # flake8 version 5.0.0 & 5.0.1 has issues with flake8.options.config
+    flake8==5.0.4 # https://github.com/savoirfairelinux/flake8-copyright/issues/19
     flake8-docstrings
     flake8-copyright
     flake8-builtins


### PR DESCRIPTION
# Issue
* [DPE-1081](https://warthogs.atlassian.net/browse/DPE-1081)
* Old lib juju is causing warnings in integration tests execution

# Solution
* update to latest version of libjuju for 2 (2.9.38.1)

# Context
* Only one test seemed to break
* Also updating flake8 to the latest version expected to work
* Also updating ops requirement to latest stable (1.5.4)

# Testing

# Release Notes

[DPE-1049]: https://warthogs.atlassian.net/browse/DPE-1049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DPE-1081]: https://warthogs.atlassian.net/browse/DPE-1081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ