### PR TITLE
Fix unit tests

### DIFF
--- a/lib/charms/postgresql_k8s/v0/postgresql_tls.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql_tls.py
@@ -125,7 +125,10 @@ class PostgreSQLTLS(Object):
 
     def _on_certificate_available(self, event: CertificateAvailableEvent) -> None:
         """Enable TLS when TLS certificate available."""
-        if event.certificate_signing_request.strip() != self.charm.get_secret(SCOPE, "csr").strip():
+        if (
+            event.certificate_signing_request.strip()
+            != str(self.charm.get_secret(SCOPE, "csr")).strip()
+        ):
             logger.error("An unknown certificate available.")
             return
 
@@ -144,7 +147,7 @@ class PostgreSQLTLS(Object):
 
     def _on_certificate_expiring(self, event: CertificateExpiringEvent) -> None:
         """Request the new certificate when old certificate is expiring."""
-        if event.certificate.strip() != self.charm.get_secret(SCOPE, "cert").strip():
+        if event.certificate.strip() != str(self.charm.get_secret(SCOPE, "cert")).strip():
             logger.error("An unknown certificate expiring.")
             return
 

--- a/src/relations/db.py
+++ b/src/relations/db.py
@@ -250,11 +250,8 @@ class DbProvides(Object):
             self.charm._has_blocked_status
             and self.charm.unit.status.message == EXTENSIONS_BLOCKING_MESSAGE
         ):
-            if "extensions" in event.relation.data.get(
-                event.app, {}
-            ) or "extensions" in event.relation.data.get(event.unit, {}):
-                if not self._check_for_blocking_relations(event.relation.id):
-                    self.charm.unit.status = ActiveStatus()
+            if not self._check_for_blocking_relations(event.relation.id):
+                self.charm.unit.status = ActiveStatus()
 
     def update_endpoints(self, event: RelationChangedEvent = None) -> None:
         """Set the read/write and read-only endpoints."""

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -42,7 +42,6 @@ class TestDbProvides(unittest.TestCase):
         # Define some relations.
         self.rel_id = self.harness.add_relation(RELATION_NAME, "application")
         self.harness.add_relation_unit(self.rel_id, "application/0")
-        self.harness.add_relation_unit(self.rel_id, self.unit)
         self.peer_rel_id = self.harness.add_relation(PEER, self.app)
         self.harness.add_relation_unit(self.peer_rel_id, self.unit)
         self.harness.update_relation_data(
@@ -229,51 +228,15 @@ class TestDbProvides(unittest.TestCase):
             postgresql_mock.delete_user = PropertyMock(return_value=None)
             self.harness.model.unit.status = BlockedStatus("extensions requested through relation")
             with self.harness.hooks_disabled():
-                self.rel_id = self.harness.add_relation(RELATION_NAME, "application")
                 self.harness.update_relation_data(
                     self.rel_id,
                     "application",
-                    {"database": DATABASE, "extensions": ["test"]},
+                    {"database": DATABASE, "extensions": "test"},
                 )
 
             # Break the relation before the database is ready.
             self.harness.remove_relation(self.rel_id)
             self.assertTrue(isinstance(self.harness.model.unit.status, ActiveStatus))
-
-    @patch(
-        "charm.PostgresqlOperatorCharm.primary_endpoint",
-        new_callable=PropertyMock,
-    )
-    @patch("charm.PostgresqlOperatorCharm._has_blocked_status", new_callable=PropertyMock)
-    @patch("charm.Patroni.member_started", new_callable=PropertyMock)
-    @patch("charm.DbProvides._on_relation_departed")
-    def test_on_relation_broken_extensions_keep_block(
-        self, _on_relation_departed, _member_started, _primary_endpoint, _has_blocked_status
-    ):
-        with patch.object(PostgresqlOperatorCharm, "postgresql", Mock()) as postgresql_mock:
-            # Set some side effects to test multiple situations.
-            _has_blocked_status.return_value = True
-            _member_started.return_value = True
-            _primary_endpoint.return_value = {"1.1.1.1"}
-            postgresql_mock.delete_user = PropertyMock(return_value=None)
-            self.harness.model.unit.status = BlockedStatus("extensions requested through relation")
-            with self.harness.hooks_disabled():
-                self.rel_id = self.harness.add_relation(RELATION_NAME, "application")
-                self.harness.update_relation_data(
-                    self.rel_id,
-                    "application",
-                    {"database": DATABASE, "extensions": ["test"]},
-                )
-                second_rel_id = self.harness.add_relation(RELATION_NAME, "application2")
-                self.harness.update_relation_data(
-                    second_rel_id,
-                    "application2",
-                    {"database": DATABASE, "extensions": ["test"]},
-                )
-
-            # Break the relation before the database is ready.
-            self.harness.remove_relation(self.rel_id)
-            self.assertTrue(isinstance(self.harness.model.unit.status, BlockedStatus))
 
     @patch(
         "charm.DbProvides._get_state",

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -256,6 +256,12 @@ class TestDbProvides(unittest.TestCase):
             postgresql_mock.delete_user = PropertyMock(return_value=None)
             self.harness.model.unit.status = BlockedStatus("extensions requested through relation")
             with self.harness.hooks_disabled():
+                first_rel_id = self.harness.add_relation(RELATION_NAME, "application1")
+                self.harness.update_relation_data(
+                    first_rel_id,
+                    "application1",
+                    {"database": DATABASE, "extensions": "test"},
+                )
                 second_rel_id = self.harness.add_relation(RELATION_NAME, "application2")
                 self.harness.update_relation_data(
                     second_rel_id,
@@ -264,7 +270,7 @@ class TestDbProvides(unittest.TestCase):
                 )
 
             event = Mock()
-            event.relation.id = 1
+            event.relation.id = first_rel_id
             # Break one of the relations that block the charm.
             self.harness.charm.legacy_db_relation._on_relation_broken(event)
             self.assertTrue(isinstance(self.harness.model.unit.status, BlockedStatus))


### PR DESCRIPTION
# Issue
* [PR#53](https://github.com/canonical/postgresql-operator/pull/53) silently broke the unit tests due to running CI on older ops version (1.5.4)

# Solution
* Fix issues resulting from the ops update

# Context
* One of the unit tests added in [PR#53](https://github.com/canonical/postgresql-operator/pull/53) doesn't seem to be possible anymore with the test harnesss relation broken functionality. It may be possible to reproduce it using mock events and calling the `_on_relation_broken()` directly
* Also updating postgres_tls

# Testing

# Release Notes
