### PR TITLE
Fix change WAL settings fixture

### DIFF
--- a/tests/integration/ha_tests/conftest.py
+++ b/tests/integration/ha_tests/conftest.py
@@ -13,7 +13,7 @@ from tests.integration.ha_tests.helpers import (
     get_postgresql_parameter,
     update_restart_delay,
 )
-from tests.integration.helpers import get_primary, run_command_on_unit
+from tests.integration.helpers import run_command_on_unit
 
 APPLICATION_NAME = "application"
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -325,7 +325,6 @@ class TestCharm(unittest.TestCase):
         patroni,
         _postgresql,
     ):
-
         # Mock the passwords.
         patroni.return_value.member_started = False
         _get_password.return_value = "fake-operator-password"


### PR DESCRIPTION
# Issue
Jira ticket: [DPE-1190](https://warthogs.atlassian.net/browse/DPE-1190)
The fixture called `wal_settings` was failing if another error happened stopping the SST test.


# Solution
Start the stopped units (they were stopped inside the SST test). This makes the Patroni REST API available again to enable the fixture to rollback the changes in the WAL settings (that were made in the beginning of the test by this fixture) on all the units.


# Context
Still need to address transient errors (that triggered the error fixed by this PR in the past) in another PR.


# Testing
Manually tested locally.


# Release Notes
Fix change WAL settings fixture to start the stopped units.


[DPE-1190]: https://warthogs.atlassian.net/browse/DPE-1190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ