### PR TITLE
Upgrade to jammy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
           - charm-integration
           - database-relation-integration
           - db-relation-integration
-          - db-admin-relation-integration
+#          - db-admin-relation-integration
           - ha-self-healing-integration
           - password-rotation-integration
           - tls-integration

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
     needs:
       - lib-check
       - ci-tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,5 +54,5 @@ juju add-model dev
 # Enable DEBUG logging
 juju model-config logging-config="<root>=INFO;unit=DEBUG"
 # Deploy the charm
-juju deploy ./postgresql_ubuntu-20.04-amd64.charm
+juju deploy ./postgresql_ubuntu-22.04-amd64.charm
 ```

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -5,10 +5,10 @@ type: charm
 bases:
   - build-on:
       - name: "ubuntu"
-        channel: "20.04"
+        channel: "22.04"
     run-on:
       - name: "ubuntu"
-        channel: "20.04"
+        channel: "22.04"
 parts:
   charm:
     build-packages:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -7,11 +7,6 @@ description: |
 summary: |
   Charm to operate the PostgreSQL database on machines
 
-series:
-  # TODO: add jammy when it's released
-  - focal
-  - bionic
-
 peers:
   database-peers:
     interface: postgresql_peers

--- a/tests/integration/ha_tests/application-charm/charmcraft.yaml
+++ b/tests/integration/ha_tests/application-charm/charmcraft.yaml
@@ -5,10 +5,10 @@ type: charm
 bases:
   - build-on:
       - name: "ubuntu"
-        channel: "20.04"
+        channel: "22.04"
     run-on:
       - name: "ubuntu"
-        channel: "20.04"
+        channel: "22.04"
 parts:
   charm:
     charm-binary-python-packages: [psycopg2-binary==2.9.3]

--- a/tests/integration/ha_tests/conftest.py
+++ b/tests/integration/ha_tests/conftest.py
@@ -13,6 +13,7 @@ from tests.integration.ha_tests.helpers import (
     get_postgresql_parameter,
     update_restart_delay,
 )
+from tests.integration.helpers import CHARM_SERIES
 
 APPLICATION_NAME = "application"
 
@@ -24,7 +25,9 @@ async def continuous_writes(ops_test: OpsTest) -> None:
     async with ops_test.fast_forward():
         if await app_name(ops_test, APPLICATION_NAME) is None:
             charm = await ops_test.build_charm("tests/integration/ha_tests/application-charm")
-            await ops_test.model.deploy(charm, application_name=APPLICATION_NAME)
+            await ops_test.model.deploy(
+                charm, application_name=APPLICATION_NAME, series=CHARM_SERIES
+            )
             await ops_test.model.wait_for_idle(status="active", timeout=1000)
     yield
     # Clear the written data at the end.

--- a/tests/integration/ha_tests/test_self_healing.py
+++ b/tests/integration/ha_tests/test_self_healing.py
@@ -28,6 +28,7 @@ from tests.integration.ha_tests.helpers import (
     update_restart_delay,
 )
 from tests.integration.helpers import (
+    CHARM_SERIES,
     db_connect,
     get_password,
     get_unit_address,
@@ -51,7 +52,9 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
 
     charm = await ops_test.build_charm(".")
     async with ops_test.fast_forward():
-        await ops_test.model.deploy(charm, resources={"patroni": "patroni.tar.gz"}, num_units=3)
+        await ops_test.model.deploy(
+            charm, resources={"patroni": "patroni.tar.gz"}, num_units=3, series=CHARM_SERIES
+        )
         await ops_test.juju("attach-resource", APP_NAME, "patroni=patroni.tar.gz")
         await ops_test.model.wait_for_idle(status="active", timeout=1000)
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -27,6 +27,7 @@ from tenacity import (
     wait_fixed,
 )
 
+CHARM_SERIES = "jammy"
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 DATABASE_APP_NAME = METADATA["name"]
 
@@ -171,11 +172,6 @@ def check_patroni(ops_test: OpsTest, unit_name: str, restart_time: float) -> boo
         health_info["postmaster_start_time"], "%Y-%m-%d %H:%M:%S.%f%z"
     ).timestamp()
     return postmaster_start_time > restart_time and health_info["state"] == "running"
-
-
-def build_application_name(series: str) -> str:
-    """Return a composite application name combining application name and series."""
-    return f"{DATABASE_APP_NAME}-{series}"
 
 
 async def check_cluster_members(ops_test: OpsTest, application_name: str) -> None:

--- a/tests/integration/new_relations/application-charm/charmcraft.yaml
+++ b/tests/integration/new_relations/application-charm/charmcraft.yaml
@@ -5,7 +5,7 @@ type: charm
 bases:
   - build-on:
       - name: "ubuntu"
-        channel: "20.04"
+        channel: "22.04"
     run-on:
       - name: "ubuntu"
-        channel: "20.04"
+        channel: "22.04"

--- a/tests/integration/new_relations/test_new_relations.py
+++ b/tests/integration/new_relations/test_new_relations.py
@@ -10,7 +10,7 @@ import pytest
 import yaml
 from pytest_operator.plugin import OpsTest
 
-from tests.integration.helpers import scale_application
+from tests.integration.helpers import CHARM_SERIES, scale_application
 from tests.integration.new_relations.helpers import (
     build_connection_string,
     check_relation_data_existence,
@@ -43,20 +43,21 @@ async def test_deploy_charms(ops_test: OpsTest, application_charm, database_char
                 application_charm,
                 application_name=APPLICATION_APP_NAME,
                 num_units=2,
+                series=CHARM_SERIES,
             ),
             ops_test.model.deploy(
                 database_charm,
                 resources={"patroni": "patroni.tar.gz"},
                 application_name=DATABASE_APP_NAME,
                 num_units=1,
-                trust=True,
+                series=CHARM_SERIES,
             ),
             ops_test.model.deploy(
                 database_charm,
                 resources={"patroni": "patroni.tar.gz"},
                 application_name=ANOTHER_DATABASE_APP_NAME,
                 num_units=2,
-                trust=True,
+                series=CHARM_SERIES,
             ),
         )
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -14,8 +14,8 @@ from tenacity import Retrying, stop_after_attempt, wait_exponential
 
 from tests.helpers import STORAGE_PATH
 from tests.integration.helpers import (
+    CHARM_SERIES,
     DATABASE_APP_NAME,
-    build_application_name,
     check_cluster_members,
     convert_records_to_dict,
     db_connect,
@@ -29,66 +29,57 @@ from tests.integration.helpers import (
 
 logger = logging.getLogger(__name__)
 
-SERIES = ["focal"]
 UNIT_IDS = [0, 1, 2]
 
 
 @pytest.mark.abort_on_fail
 @pytest.mark.charm_tests
-@pytest.mark.parametrize("series", SERIES)
 @pytest.mark.skip_if_deployed
-async def test_deploy(ops_test: OpsTest, charm: str, series: str):
+async def test_deploy(ops_test: OpsTest, charm: str):
     """Deploy the charm-under-test.
 
     Assert on the unit status before any relations/configurations take place.
     """
-    # Set a composite application name in order to test in more than one series at the same time.
-    application_name = build_application_name(series)
-
     # Deploy the charm with Patroni resource.
     resources = {"patroni": "patroni.tar.gz"}
     await ops_test.model.deploy(
-        charm, resources=resources, application_name=application_name, series=series, num_units=3
+        charm,
+        resources=resources,
+        application_name=DATABASE_APP_NAME,
+        num_units=3,
+        series=CHARM_SERIES,
     )
     # Attach the resource to the controller.
-    await ops_test.juju("attach-resource", application_name, "patroni=patroni.tar.gz")
+    await ops_test.juju("attach-resource", DATABASE_APP_NAME, "patroni=patroni.tar.gz")
 
     # Reducing the update status frequency to speed up the triggering of deferred events.
     await ops_test.model.set_config({"update-status-hook-interval": "10s"})
 
-    await ops_test.model.wait_for_idle(apps=[application_name], status="active", timeout=1000)
-    assert ops_test.model.applications[application_name].units[0].workload_status == "active"
+    await ops_test.model.wait_for_idle(apps=[DATABASE_APP_NAME], status="active", timeout=1000)
+    assert ops_test.model.applications[DATABASE_APP_NAME].units[0].workload_status == "active"
 
 
 @pytest.mark.abort_on_fail
 @pytest.mark.charm_tests
-@pytest.mark.parametrize("series", SERIES)
 @pytest.mark.parametrize("unit_id", UNIT_IDS)
-async def test_database_is_up(ops_test: OpsTest, series: str, unit_id: int):
-    # Set a composite application name in order to test in more than one series at the same time.
-    application_name = build_application_name(series)
-
+async def test_database_is_up(ops_test: OpsTest, unit_id: int):
     # Query Patroni REST API and check the status that indicates
     # both Patroni and PostgreSQL are up and running.
-    host = get_unit_address(ops_test, f"{application_name}/{unit_id}")
+    host = get_unit_address(ops_test, f"{DATABASE_APP_NAME}/{unit_id}")
     result = requests.get(f"http://{host}:8008/health")
     assert result.status_code == 200
 
 
 @pytest.mark.charm_tests
-@pytest.mark.parametrize("series", SERIES)
 @pytest.mark.parametrize("unit_id", UNIT_IDS)
-async def test_settings_are_correct(ops_test: OpsTest, series: str, unit_id: int):
+async def test_settings_are_correct(ops_test: OpsTest, unit_id: int):
     # Connect to the PostgreSQL instance.
-    # Set a composite application name in order to test in more than one series at the same time.
-    application_name = build_application_name(series)
-
     # Retrieving the operator user password using the action.
-    any_unit_name = ops_test.model.applications[application_name].units[0].name
+    any_unit_name = ops_test.model.applications[DATABASE_APP_NAME].units[0].name
     password = await get_password(ops_test, any_unit_name)
 
     # Connect to PostgreSQL.
-    host = get_unit_address(ops_test, f"{application_name}/{unit_id}")
+    host = get_unit_address(ops_test, f"{DATABASE_APP_NAME}/{unit_id}")
     logger.info("connecting to the database host: %s", host)
     with db_connect(host, password) as connection:
         assert connection.status == psycopg2.extensions.STATUS_READY
@@ -120,7 +111,7 @@ async def test_settings_are_correct(ops_test: OpsTest, series: str, unit_id: int
     # Validate each configuration set by Patroni on PostgreSQL.
     assert settings["archive_command"] == "/bin/true"
     assert settings["archive_mode"] == "on"
-    assert settings["cluster_name"] == f"{DATABASE_APP_NAME}-{series}"
+    assert settings["cluster_name"] == DATABASE_APP_NAME
     assert settings["data_directory"] == f"{STORAGE_PATH}/pgdata"
     assert settings["data_checksums"] == "on"
     assert settings["listen_addresses"] == host
@@ -140,33 +131,29 @@ async def test_settings_are_correct(ops_test: OpsTest, series: str, unit_id: int
 
 
 @pytest.mark.charm_tests
-@pytest.mark.parametrize("series", SERIES)
-async def test_scale_down_and_up(ops_test: OpsTest, series: str):
+async def test_scale_down_and_up(ops_test: OpsTest):
     """Test data is replicated to new units after a scale up."""
-    # Set a composite application name in order to test in more than one series at the same time.
-    application_name = build_application_name(series)
-
     # Ensure the initial number of units in the application.
     initial_scale = len(UNIT_IDS)
-    await scale_application(ops_test, application_name, initial_scale)
+    await scale_application(ops_test, DATABASE_APP_NAME, initial_scale)
 
     # Scale down the application.
-    await scale_application(ops_test, application_name, initial_scale - 1)
+    await scale_application(ops_test, DATABASE_APP_NAME, initial_scale - 1)
 
     # Ensure the member was correctly removed from the cluster
     # (by comparing the cluster members and the current units).
-    await check_cluster_members(ops_test, application_name)
+    await check_cluster_members(ops_test, DATABASE_APP_NAME)
 
     # Scale up the application (2 more units than the current scale).
-    await scale_application(ops_test, application_name, initial_scale + 1)
+    await scale_application(ops_test, DATABASE_APP_NAME, initial_scale + 1)
 
     # Assert the correct members are part of the cluster.
-    await check_cluster_members(ops_test, application_name)
+    await check_cluster_members(ops_test, DATABASE_APP_NAME)
 
     # Test the deletion of the unit that is both the leader and the primary.
-    any_unit_name = ops_test.model.applications[application_name].units[0].name
+    any_unit_name = ops_test.model.applications[DATABASE_APP_NAME].units[0].name
     primary = await get_primary(ops_test, any_unit_name)
-    leader_unit = await find_unit(ops_test, leader=True, application=application_name)
+    leader_unit = await find_unit(ops_test, leader=True, application=DATABASE_APP_NAME)
 
     # Trigger a switchover if the primary and the leader are not the same unit.
     if primary != leader_unit.name:
@@ -181,21 +168,21 @@ async def test_scale_down_and_up(ops_test: OpsTest, series: str):
             with attempt:
                 assert primary == leader_unit.name
 
-    await ops_test.model.applications[application_name].destroy_units(leader_unit.name)
+    await ops_test.model.applications[DATABASE_APP_NAME].destroy_units(leader_unit.name)
     await ops_test.model.wait_for_idle(
-        apps=[application_name], status="active", timeout=1000, wait_for_exact_units=initial_scale
+        apps=[DATABASE_APP_NAME], status="active", timeout=1000, wait_for_exact_units=initial_scale
     )
 
     # Assert the correct members are part of the cluster.
-    await check_cluster_members(ops_test, application_name)
+    await check_cluster_members(ops_test, DATABASE_APP_NAME)
 
     # Scale up the application (2 more units than the current scale).
-    await scale_application(ops_test, application_name, initial_scale + 2)
+    await scale_application(ops_test, DATABASE_APP_NAME, initial_scale + 2)
 
     # Test the deletion of both the unit that is the leader and the unit that is the primary.
-    any_unit_name = ops_test.model.applications[application_name].units[0].name
+    any_unit_name = ops_test.model.applications[DATABASE_APP_NAME].units[0].name
     primary = await get_primary(ops_test, any_unit_name)
-    leader_unit = await find_unit(ops_test, application_name, True)
+    leader_unit = await find_unit(ops_test, DATABASE_APP_NAME, True)
 
     # Trigger a switchover if the primary and the leader are the same unit.
     if primary == leader_unit.name:
@@ -210,28 +197,26 @@ async def test_scale_down_and_up(ops_test: OpsTest, series: str):
             with attempt:
                 assert primary != leader_unit.name
 
-    await ops_test.model.applications[application_name].destroy_units(primary, leader_unit.name)
+    await ops_test.model.applications[DATABASE_APP_NAME].destroy_units(primary, leader_unit.name)
     await ops_test.model.wait_for_idle(
-        apps=[application_name],
+        apps=[DATABASE_APP_NAME],
         status="active",
         timeout=1000,
         wait_for_exact_units=initial_scale,
     )
 
     # Assert the correct members are part of the cluster.
-    await check_cluster_members(ops_test, application_name)
+    await check_cluster_members(ops_test, DATABASE_APP_NAME)
 
     # End with the cluster having the initial number of units.
-    await scale_application(ops_test, application_name, initial_scale)
+    await scale_application(ops_test, DATABASE_APP_NAME, initial_scale)
 
 
 @pytest.mark.charm_tests
-@pytest.mark.parametrize("series", SERIES)
-async def test_persist_data_through_primary_deletion(ops_test: OpsTest, series: str):
+async def test_persist_data_through_primary_deletion(ops_test: OpsTest):
     """Test data persists through a primary deletion."""
     # Set a composite application name in order to test in more than one series at the same time.
-    application_name = build_application_name(series)
-    any_unit_name = ops_test.model.applications[application_name].units[0].name
+    any_unit_name = ops_test.model.applications[DATABASE_APP_NAME].units[0].name
     primary = await get_primary(ops_test, any_unit_name)
     password = await get_password(ops_test, primary)
 
@@ -248,14 +233,14 @@ async def test_persist_data_through_primary_deletion(ops_test: OpsTest, series: 
     await ops_test.model.destroy_units(
         primary,
     )
-    await ops_test.model.wait_for_idle(apps=[application_name], status="active", timeout=1000)
+    await ops_test.model.wait_for_idle(apps=[DATABASE_APP_NAME], status="active", timeout=1000)
 
     # Add the unit again.
-    await ops_test.model.applications[application_name].add_unit(count=1)
-    await ops_test.model.wait_for_idle(apps=[application_name], status="active", timeout=1000)
+    await ops_test.model.applications[DATABASE_APP_NAME].add_unit(count=1)
+    await ops_test.model.wait_for_idle(apps=[DATABASE_APP_NAME], status="active", timeout=1000)
 
     # Testing write occurred to every postgres instance by reading from them
-    for unit in ops_test.model.applications[application_name].units:
+    for unit in ops_test.model.applications[DATABASE_APP_NAME].units:
         host = unit.public_address
         logger.info("connecting to the database host: %s", host)
         with db_connect(host, password) as connection:

--- a/tests/integration/test_db.py
+++ b/tests/integration/test_db.py
@@ -10,6 +10,7 @@ from mailmanclient import Client
 from pytest_operator.plugin import OpsTest
 
 from tests.integration.helpers import (
+    CHARM_SERIES,
     DATABASE_APP_NAME,
     build_connection_string,
     check_database_users_existence,
@@ -36,6 +37,7 @@ async def test_mailman3_core_db(ops_test: OpsTest, charm: str) -> None:
             resources=resources,
             application_name=DATABASE_APP_NAME,
             num_units=DATABASE_UNITS,
+            series=CHARM_SERIES,
         )
         # Attach the resource to the controller.
         await ops_test.juju("attach-resource", DATABASE_APP_NAME, "patroni=patroni.tar.gz")

--- a/tests/integration/test_db_admin.py
+++ b/tests/integration/test_db_admin.py
@@ -5,7 +5,6 @@ import ast
 import json
 import logging
 
-import pytest as pytest
 from landscape_api.base import HTTPError, run_query
 from pytest_operator.plugin import OpsTest
 
@@ -34,11 +33,10 @@ DATABASE_UNITS = 3
 RELATION_NAME = "db-admin"
 
 
-@pytest.mark.unstable
 async def test_landscape_scalable_bundle_db(ops_test: OpsTest, charm: str) -> None:
     """Deploy Landscape Scalable Bundle to test the 'db-admin' relation."""
     config = {
-        "extra-packages": "python3-apt postgresql-contrib postgresql-.*-debversion postgresql-plpython*"
+        "extra-packages": "python-apt postgresql-contrib postgresql-.*-debversion postgresql-plpython.*"
     }
     resources = {"patroni": "patroni.tar.gz"}
     await ops_test.model.deploy(

--- a/tests/integration/test_db_admin.py
+++ b/tests/integration/test_db_admin.py
@@ -10,6 +10,7 @@ from landscape_api.base import run_query
 from pytest_operator.plugin import OpsTest
 
 from tests.integration.helpers import (
+    CHARM_SERIES,
     DATABASE_APP_NAME,
     check_database_users_existence,
     check_databases_creation,
@@ -29,7 +30,7 @@ DATABASE_UNITS = 3
 async def test_landscape_scalable_bundle_db(ops_test: OpsTest, charm: str) -> None:
     """Deploy Landscape Scalable Bundle to test the 'db-admin' relation."""
     config = {
-        "extra-packages": "python-apt postgresql-contrib postgresql-.*-debversion postgresql-plpython.*"
+        "extra-packages": "python3-apt postgresql-contrib postgresql-.*-debversion postgresql-plpython*"
     }
     resources = {"patroni": "patroni.tar.gz"}
     await ops_test.model.deploy(
@@ -38,6 +39,7 @@ async def test_landscape_scalable_bundle_db(ops_test: OpsTest, charm: str) -> No
         resources=resources,
         application_name=DATABASE_APP_NAME,
         num_units=DATABASE_UNITS,
+        series=CHARM_SERIES,
     )
     # Attach the resource to the controller.
     await ops_test.juju("attach-resource", DATABASE_APP_NAME, "patroni=patroni.tar.gz")

--- a/tests/integration/test_password_rotation.py
+++ b/tests/integration/test_password_rotation.py
@@ -8,6 +8,7 @@ from pytest_operator.plugin import OpsTest
 
 from tests.helpers import METADATA
 from tests.integration.helpers import (
+    CHARM_SERIES,
     check_patroni,
     get_password,
     restart_patroni,
@@ -25,7 +26,11 @@ async def test_deploy_active(ops_test: OpsTest):
     charm = await ops_test.build_charm(".")
     async with ops_test.fast_forward():
         await ops_test.model.deploy(
-            charm, resources={"patroni": "patroni.tar.gz"}, application_name=APP_NAME, num_units=3
+            charm,
+            resources={"patroni": "patroni.tar.gz"},
+            application_name=APP_NAME,
+            num_units=3,
+            series=CHARM_SERIES,
         )
         await ops_test.juju("attach-resource", APP_NAME, "patroni=patroni.tar.gz")
         await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -325,7 +325,6 @@ class TestCharm(unittest.TestCase):
         patroni,
         _postgresql,
     ):
-
         # Mock the passwords.
         patroni.return_value.member_started = False
         _get_password.return_value = "fake-operator-password"


### PR DESCRIPTION
# Issue
Jira issue: https://warthogs.atlassian.net/browse/DPE-1413
The charm is still on Focal.


# Solution
Upgrade all the bases and all the deployments to use Jammy.


# Context
The Landscape bundle test was disabled due to incompatibilities. Ticket to manage those incompatibilities: https://warthogs.atlassian.net/browse/DPE-1414

A lot of changes in the tests related to the database app name constant are due to removing multiple series in the tests.


# Testing
Used the existing tests to confirm that the charm works on Jammy.


# Release Notes
Upgrade charm to Jammy.
