### PR TITLE
Bump juju from 2.9.34 to 2.9.38 (latest)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,6 +73,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
+          bootstrap-options: "--agent-version 2.9.38"
       - name: Download packed charm(s)
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,8 +73,6 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
-          # This is needed until https://bugs.launchpad.net/juju/+bug/1992833 is fixed.
-          bootstrap-options: "--agent-version 2.9.34"
       - name: Download packed charm(s)
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
# Issue
Jira tickets: [DPE-1419](https://warthogs.atlassian.net/browse/DPE-1419)
The integration tests are not running in the latest Juju agent version due to a bootstrap constraint (`--agent-version=2.9.34`)


# Solution
Update the Juju agent version in the bootstrap constraint from `.github/workflows/ci.yaml`.

# Context
Juju Python library was updated to fix https://bugs.launchpad.net/juju/+bug/1992833 (and it's already updated in this repo).



# Testing
Executed the existing tests and all of them worked fine.


# Release Notes
Bump juju from 2.9.34 to 2.9.38 (latest)

[DPE-1419]: https://warthogs.atlassian.net/browse/DPE-1419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ