### PR TITLE
pgBackRest restore action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,6 +71,7 @@ jobs:
       fail-fast: false
       matrix:
         tox-environments:
+          - backup-integration
           - charm-integration
           - database-relation-integration
           - db-relation-integration

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,4 +114,8 @@ jobs:
       - name: Run integration tests
         run: tox run -e ${{ matrix.tox-environments }} -- -m '${{ steps.select-tests.outputs.mark_expression }}'
         env:
+          AWS_ACCESS_KEY: "${{ secrets.AWS_ACCESS_KEY }}"
+          AWS_SECRET_KEY: "${{ secrets.AWS_SECRET_KEY }}"
+          GCP_ACCESS_KEY: "${{ secrets.GCP_ACCESS_KEY }}"
+          GCP_SECRET_KEY: "${{ secrets.GCP_SECRET_KEY }}"
           CI_PACKED_CHARMS: ${{ needs.build.outputs.charms }}

--- a/actions.yaml
+++ b/actions.yaml
@@ -15,6 +15,13 @@ get-password:
         Possible values - operator, replication, rewind.
 list-backups:
   description: Lists backups in s3 storage.
+restore:
+  description: Restore a database backup using pgBackRest.
+    S3 credentials are retrieved from a relation with the S3 integrator charm.
+  params:
+    backup-id:
+      type: string
+      description: A backup-id to identify the backup to restore (format = %Y-%m-%dT%H:%M:%SZ)
 set-password:
   description: Change the system user's password, which is used by charm.
     It is for internal charm users and SHOULD NOT be used by applications.

--- a/src/backups.py
+++ b/src/backups.py
@@ -7,8 +7,10 @@ import logging
 import os
 import pwd
 import re
+import shutil
 import tempfile
 from datetime import datetime
+from pathlib import Path
 from subprocess import PIPE, run
 from typing import Dict, List, Optional, Tuple
 
@@ -106,11 +108,12 @@ class PostgreSQLBackups(Object):
 
     def _empty_data_files(self) -> bool:
         """Empty the PostgreSQL data directory in preparation of backup restore."""
-        return_code, _, stderr = self._execute_command(
-            "rm -r /var/lib/postgresql/data/pgdata".split()
-        )
-        if return_code != 0:
-            logger.warning(f"Failed to remove contents of the data directory with error: {stderr}")
+        try:
+            path = Path("/var/lib/postgresql/data/pgdata")
+            if path.exists() and path.is_dir():
+                shutil.rmtree(path)
+        except OSError as e:
+            logger.warning(f"Failed to remove contents of the data directory with error: {str(e)}")
             return False
 
         return True

--- a/src/backups.py
+++ b/src/backups.py
@@ -432,7 +432,6 @@ Stderr:
         if return_code != 0:
             logger.warning(f"Failed to remove previous cluster information with error: {stderr}")
             event.fail(error_message)
-            self._restart_database()
             return
 
         event.set_results({"restore-status": "restore started"})

--- a/src/charm.py
+++ b/src/charm.py
@@ -430,6 +430,7 @@ class PostgresqlOperatorCharm(CharmBase):
     def _patroni(self) -> Patroni:
         """Returns an instance of the Patroni object."""
         return Patroni(
+            self.app_peer_data.get("archive-mode", "on"),
             self._unit_ip,
             self._storage_path,
             self.cluster_name,

--- a/src/charm.py
+++ b/src/charm.py
@@ -806,7 +806,7 @@ class PostgresqlOperatorCharm(CharmBase):
         event.set_results({f"{username}-password": password})
 
     def _on_update_status(self, _) -> None:
-        """Update users list in the database."""
+        """Update the unit status message and users list in the database."""
         if "cluster_initialised" not in self._peers.data[self.app]:
             return
 
@@ -820,6 +820,32 @@ class PostgresqlOperatorCharm(CharmBase):
             and self._patroni.member_replication_lag == "unknown"
         ):
             self._patroni.reinitialize_postgresql()
+            return
+
+        if "restoring-backup" in self.app_peer_data:
+            # if services[0].current != ServiceStatus.ACTIVE:
+            #     self.unit.status = BlockedStatus("Failed to restore backup")
+            #     return
+
+            if not self._patroni.member_started:
+                logger.debug("on_update_status early exit: Patroni has not started yet")
+                return
+
+            # Remove the restoring backup flag.
+            self.app_peer_data.update({"restoring-backup": ""})
+            self.update_config()
+
+        self._set_primary_status_message()
+
+    def _set_primary_status_message(self) -> None:
+        """Display 'Primary' in the unit status message if the current unit is the primary."""
+        try:
+            if self._patroni.get_primary(unit_name_pattern=True) == self.unit.name:
+                self.unit.status = ActiveStatus("Primary")
+            elif self._patroni.member_started:
+                self.unit.status = ActiveStatus()
+        except (RetryError, ConnectionError) as e:
+            logger.error(f"failed to get primary with error {e}")
 
     def _update_certificate(self) -> None:
         """Updates the TLS certificate if the unit IP changes."""
@@ -967,8 +993,10 @@ class PostgresqlOperatorCharm(CharmBase):
 
         # Update and reload configuration based on TLS files availability.
         self._patroni.render_patroni_yml_file(
+            archive_mode=self.app_peer_data.get("archive-mode", "on"),
             enable_tls=enable_tls,
-            stanza=self._peers.data[self.unit].get("stanza"),
+            backup_id=self.app_peer_data.get("restoring-backup"),
+            stanza=self.unit_peer_data.get("stanza"),
         )
         if not self._patroni.member_started:
             # If Patroni/PostgreSQL has not started yet and TLS relations was initialised,

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -421,7 +421,6 @@ class Patroni:
         Returns:
             Whether the service stopped successfully.
         """
-        # Start the service and enable it to start at boot.
         service_stop(PATRONI_SERVICE)
         return not service_running(PATRONI_SERVICE)
 

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -68,6 +68,7 @@ class Patroni:
 
     def __init__(
         self,
+        archive_mode,
         unit_ip: str,
         storage_path: str,
         cluster_name: str,
@@ -82,6 +83,7 @@ class Patroni:
         """Initialize the Patroni class.
 
         Args:
+            archive_mode: PostgreSQL archive mode
             unit_ip: IP address of the current unit
             storage_path: path to the storage mounted on this unit
             cluster_name: name of the cluster
@@ -93,6 +95,7 @@ class Patroni:
             rewind_password: password for the user used on rewinds
             tls_enabled: whether TLS is enabled
         """
+        self.archive_mode = archive_mode
         self.unit_ip = unit_ip
         self.storage_path = storage_path
         self.cluster_name = cluster_name
@@ -124,7 +127,7 @@ class Patroni:
         self._change_owner(self.storage_path)
         # Avoid rendering the Patroni config file if it was already rendered.
         if not os.path.exists(f"{self.storage_path}/patroni.yml"):
-            self.render_patroni_yml_file()
+            self.render_patroni_yml_file(self.archive_mode)
         self._render_patroni_service_file()
         # Reload systemd services before trying to start Patroni.
         daemon_reload()

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -203,7 +203,8 @@ class Patroni:
             member_name: cluster member name.
 
         Returns:
-            status of the cluster member or an empty string if the status couldn't be retrieved yet.
+            status of the cluster member or an empty string if the status
+                couldn't be retrieved yet.
         """
         # Request info from cluster endpoint (which returns all members of the cluster).
         for attempt in Retrying(stop=stop_after_attempt(2 * len(self.peers_ips) + 1)):

--- a/src/constants.py
+++ b/src/constants.py
@@ -3,6 +3,8 @@
 
 """File containing constants to be used in the charm."""
 
+BACKUP_ID_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+PGBACKREST_BACKUP_ID_FORMAT = "%Y%m%d-%H%M%S"
 DATABASE = "database"
 DATABASE_PORT = "5432"
 LEGACY_DB = "db"

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -62,12 +62,22 @@ bootstrap:
         {% else %}
         archive_command: /bin/true
         {%- endif %}
-        archive_mode: on
+        archive_mode: {{ archive_mode }}
+        log_filename: 'postgresql.log'
+        log_directory: '/var/log/postgresql'
+        logging_collector: 'on'
         wal_level: logical
-
+  {%- if restoring_backup %}
+  method: pgbackrest
+  pgbackrest:
+    command: pgbackrest --stanza={{ stanza }} --set={{ backup_id }} --type=immediate --target-action=promote restore
+    no_params: True
+    keep_existing_recovery_conf: True
+  {% else %}
   initdb:
   - encoding: UTF8
   - data-checksums
+  {%- endif %}
 
 postgresql:
   listen: '{{ self_ip }}:5432'

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -63,9 +63,6 @@ bootstrap:
         archive_command: /bin/true
         {%- endif %}
         archive_mode: {{ archive_mode }}
-        log_filename: 'postgresql.log'
-        log_directory: '/var/log/postgresql'
-        logging_collector: 'on'
         wal_level: logical
   {%- if restoring_backup %}
   method: pgbackrest

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,13 +1,63 @@
 #!/usr/bin/env python3
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
-
 import json
 import os
+import uuid
 from pathlib import Path
 
+import boto3
 import pytest
 from pytest_operator.plugin import OpsTest
+
+from tests.integration.helpers import construct_endpoint
+
+AWS = "AWS"
+GCP = "GCP"
+
+
+@pytest.fixture()
+async def cloud_configs(ops_test: OpsTest) -> None:
+    # Define some configurations and credentials.
+    configs = {
+        AWS: {
+            "endpoint": "https://s3.amazonaws.com",
+            "bucket": "canonical-postgres",
+            "path": f"/{uuid.uuid1()}",
+            "region": "us-east-2",
+        },
+        GCP: {
+            "endpoint": "https://storage.googleapis.com",
+            "bucket": "data-charms-testing",
+            "path": f"/postgresql-k8s/{uuid.uuid1()}",
+            "region": "",
+        },
+    }
+    credentials = {
+        AWS: {
+            "access-key": os.environ.get("AWS_ACCESS_KEY"),
+            "secret-key": os.environ.get("AWS_SECRET_KEY"),
+        },
+        GCP: {
+            "access-key": os.environ.get("GCP_ACCESS_KEY"),
+            "secret-key": os.environ.get("GCP_SECRET_KEY"),
+        },
+    }
+    yield configs, credentials
+    # Delete the previously created objects.
+    for cloud, config in configs.items():
+        session = boto3.session.Session(
+            aws_access_key_id=credentials[cloud]["access-key"],
+            aws_secret_access_key=credentials[cloud]["secret-key"],
+            region_name=config["region"],
+        )
+        s3 = session.resource(
+            "s3", endpoint_url=construct_endpoint(config["endpoint"], config["region"])
+        )
+        bucket = s3.Bucket(config["bucket"])
+        # GCS doesn't support batch delete operation, so delete the objects one by one.
+        for bucket_object in bucket.objects.filter(Prefix=config["path"].lstrip("/")):
+            bucket_object.delete()
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -24,7 +24,7 @@ async def cloud_configs(ops_test: OpsTest) -> None:
             "endpoint": "https://s3.amazonaws.com",
             "bucket": "data-charms-testing",
             "path": f"/{uuid.uuid1()}",
-            "region": "us-east-2",
+            "region": "us-east-1",
         },
         GCP: {
             "endpoint": "https://storage.googleapis.com",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -22,7 +22,7 @@ async def cloud_configs(ops_test: OpsTest) -> None:
     configs = {
         AWS: {
             "endpoint": "https://s3.amazonaws.com",
-            "bucket": "canonical-postgres",
+            "bucket": "data-charms-testing",
             "path": f"/{uuid.uuid1()}",
             "region": "us-east-2",
         },

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -23,13 +23,13 @@ async def cloud_configs(ops_test: OpsTest) -> None:
         AWS: {
             "endpoint": "https://s3.amazonaws.com",
             "bucket": "data-charms-testing",
-            "path": f"/{uuid.uuid1()}",
+            "path": f"/postgresql-vm/{uuid.uuid1()}",
             "region": "us-east-1",
         },
         GCP: {
             "endpoint": "https://storage.googleapis.com",
             "bucket": "data-charms-testing",
-            "path": f"/postgresql-k8s/{uuid.uuid1()}",
+            "path": f"/postgresql-vm/{uuid.uuid1()}",
             "region": "",
         },
     }

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -216,6 +216,7 @@ def construct_endpoint(endpoint: str, region: str) -> str:
     # Load endpoints data.
     loader = botocore.loaders.create_loader()
     data = loader.load_data("endpoints")
+
     # Construct the endpoint using the region.
     resolver = botocore.regions.EndpointResolver(data)
     endpoint_data = resolver.construct_endpoint("s3", region)
@@ -223,6 +224,8 @@ def construct_endpoint(endpoint: str, region: str) -> str:
     # Use the built endpoint if it is an AWS endpoint.
     if endpoint_data and endpoint.endswith(endpoint_data["dnsSuffix"]):
         endpoint = f'{endpoint.split("://")[0]}://{endpoint_data["hostname"]}'
+
+    return endpoint
 
 
 def convert_records_to_dict(records: List[tuple]) -> dict:

--- a/tests/integration/test_backups.py
+++ b/tests/integration/test_backups.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+import logging
+from typing import Dict, Tuple
+
+import pytest as pytest
+from pytest_operator.plugin import OpsTest
+
+from tests.integration.helpers import (
+    CHARM_SERIES,
+    DATABASE_APP_NAME,
+    db_connect,
+    get_password,
+    get_unit_address,
+)
+
+S3_INTEGRATOR_APP_NAME = "s3-integrator"
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.abort_on_fail
+async def test_backup(ops_test: OpsTest, cloud_configs: Tuple[Dict, Dict]) -> None:
+    """Build and deploy one unit of PostgreSQL and then test the backup and restore actions."""
+    # Build the PostgreSQL charm.
+    charm = await ops_test.build_charm(".")
+
+    # Deploy S3 Integrator.
+    await ops_test.model.deploy(S3_INTEGRATOR_APP_NAME, channel="edge")
+
+    for cloud, config in cloud_configs[0].items():
+        # Deploy and relate PostgreSQL to S3 integrator (one database app for each cloud for now
+        # as archivo_mode is disabled after restoring the backup).
+        database_app_name = f"{DATABASE_APP_NAME}-{cloud.lower()}"
+        await ops_test.model.deploy(
+            charm,
+            resources={"patroni": "patroni.tar.gz"},
+            application_name=database_app_name,
+            series=CHARM_SERIES,
+        )
+        await ops_test.juju("attach-resource", database_app_name, "patroni=patroni.tar.gz")
+        await ops_test.model.relate(database_app_name, S3_INTEGRATOR_APP_NAME)
+
+        # Configure and set access and secret keys.
+        logger.info(f"configuring S3 integrator for {cloud}")
+        await ops_test.model.applications[S3_INTEGRATOR_APP_NAME].set_config(config)
+        action = await ops_test.model.units.get(f"{S3_INTEGRATOR_APP_NAME}/0").run_action(
+            "sync-s3-credentials",
+            **cloud_configs[1][cloud],
+        )
+        await action.wait()
+        await ops_test.model.wait_for_idle(
+            apps=[database_app_name, S3_INTEGRATOR_APP_NAME], status="active", timeout=1000
+        )
+
+        # Write some data.
+        unit_name = f"{database_app_name}/0"
+        password = await get_password(ops_test, unit_name)
+        address = get_unit_address(ops_test, unit_name)
+        logger.info("creating a table in the database")
+        with db_connect(host=address, password=password) as connection:
+            connection.autocommit = True
+            connection.cursor().execute(
+                "CREATE TABLE IF NOT EXISTS backup_table_1 (test_collumn INT );"
+            )
+        connection.close()
+
+        # Run the "create backup" action.
+        logger.info("creating a backup")
+        action = await ops_test.model.units.get(unit_name).run_action("create-backup")
+        await action.wait()
+        logger.info(f"backup results: {action.results}")
+        await ops_test.model.wait_for_idle(
+            apps=[database_app_name, S3_INTEGRATOR_APP_NAME], status="active", timeout=1000
+        )
+
+        # Run the "list backups" action.
+        logger.info("listing the available backups")
+        action = await ops_test.model.units.get(unit_name).run_action("list-backups")
+        await action.wait()
+        backups = action.results["backups"]
+        assert backups, "backups not outputted"
+        await ops_test.model.wait_for_idle(status="active", timeout=1000)
+
+        # Write some data.
+        logger.info("creating a second table in the database")
+        with db_connect(host=address, password=password) as connection:
+            connection.autocommit = True
+            connection.cursor().execute("CREATE TABLE backup_table_2 (test_collumn INT );")
+        connection.close()
+
+        # Run the "restore backup" action.
+        logger.info("restoring the backup")
+        most_recent_backup = backups.split("\n")[-1]
+        backup_id = most_recent_backup.split()[0]
+        action = await ops_test.model.units.get(unit_name).run_action(
+            "restore", **{"backup-id": backup_id}
+        )
+        await action.wait()
+        logger.info(f"restore results: {action.results}")
+
+        # Wait for the backup to complete.
+        async with ops_test.fast_forward():
+            await ops_test.model.wait_for_idle(status="active", timeout=1000)
+
+        # Check that the backup was correctly restored by having only the first created table.
+        logger.info("checking that the backup was correctly restored")
+        with db_connect(
+            host=address, password=password
+        ) as connection, connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT EXISTS (SELECT FROM information_schema.tables"
+                " WHERE table_schema = 'public' AND table_name = 'backup_table_1');"
+            )
+            assert cursor.fetchone()[
+                0
+            ], "backup wasn't correctly restored: table 'backup_table_1' doesn't exist"
+            cursor.execute(
+                "SELECT EXISTS (SELECT FROM information_schema.tables"
+                " WHERE table_schema = 'public' AND table_name = 'backup_table_2');"
+            )
+            assert not cursor.fetchone()[
+                0
+            ], "backup wasn't correctly restored: table 'backup_table_2' exists"
+        connection.close()
+
+        # Remove the database app.
+        await ops_test.model.applications[database_app_name].remove()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -609,7 +609,9 @@ class TestCharm(unittest.TestCase):
             )  # Mock some data in the relation to test that it change.
             _get_tls_files.return_value = [None]
             self.charm.update_config()
-            _render_patroni_yml_file.assert_called_once_with(enable_tls=False, stanza=None)
+            _render_patroni_yml_file.assert_called_once_with(
+                archive_mode="on", enable_tls=False, backup_id=None, stanza=None
+            )
             _reload_patroni_configuration.assert_called_once()
             _restart.assert_not_called()
             self.assertNotIn(
@@ -624,7 +626,9 @@ class TestCharm(unittest.TestCase):
             _render_patroni_yml_file.reset_mock()
             _reload_patroni_configuration.reset_mock()
             self.charm.update_config()
-            _render_patroni_yml_file.assert_called_once_with(enable_tls=True, stanza=None)
+            _render_patroni_yml_file.assert_called_once_with(
+                archive_mode="on", enable_tls=True, backup_id=None, stanza=None
+            )
             _reload_patroni_configuration.assert_called_once()
             _restart.assert_called_once()
             self.assertEqual(

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -205,6 +205,7 @@ class TestCluster(unittest.TestCase):
         with open("templates/patroni.yml.j2") as file:
             template = Template(file.read())
         expected_content = template.render(
+            archive_mode="on",
             conf_path=STORAGE_PATH,
             member_name=member_name,
             peers_ips=self.peers_ips,
@@ -226,7 +227,7 @@ class TestCluster(unittest.TestCase):
         # Patch the `open` method with our mock.
         with patch("builtins.open", mock, create=True):
             # Call the method.
-            self.patroni.render_patroni_yml_file()
+            self.patroni.render_patroni_yml_file(archive_mode="on")
 
         # Check the template is opened read-only in the call to open.
         self.assertEqual(mock.call_args_list[0][0], ("templates/patroni.yml.j2", "r"))

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -43,6 +43,7 @@ class TestCluster(unittest.TestCase):
         self.peers_ips = {"2.2.2.2", "3.3.3.3"}
 
         self.patroni = Patroni(
+            "on",
             "1.1.1.1",
             STORAGE_PATH,
             "postgresql",

--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,27 @@ commands =
     poetry run coverage report
     poetry run coverage xml
 
+[testenv:backup-integration]
+description = Run backup integration tests
+pass_env =
+    {[testenv]pass_env}
+    AWS_ACCESS_KEY
+    AWS_SECRET_KEY
+    GCP_ACCESS_KEY
+    GCP_SECRET_KEY
+    CI
+    CI_PACKED_CHARMS
+commands =
+    # Download patroni resource to use in the charm deployment.
+    sh -c 'stat patroni.tar.gz > /dev/null 2>&1 || curl "https://github.com/zalando/patroni/archive/refs/tags/v2.1.4.tar.gz" -L -s > patroni.tar.gz'
+    poetry install --with integration
+    poetry export -f requirements.txt -o requirements.txt
+    poetry run pytest -v --tb native --log-cli-level=INFO -s {posargs} {[vars]tests_path}/integration/test_backups.py
+    # Remove the downloaded resource.
+    sh -c 'rm -f patroni.tar.gz'
+allowlist_externals =
+    sh
+
 [testenv:charm-integration]
 description = Run charm integration tests
 pass_env =


### PR DESCRIPTION
# Issue
Jira ticket: [DPE-1192](https://warthogs.atlassian.net/browse/DPE-1192)
Backup cannot be restored in the charm.


# Solution
Add an action to perform the restore of a backup in the unit.

# Context
This PR is mostly a copy and paste of https://github.com/canonical/postgresql-k8s-operator/pull/104 (here the calls to pgBackRest to use subprocess instead of pebble).

Also, the other difference is that the removal of previous cluster information is done after the database is started again, because `patronictl remove` (the command used for that) cannot be executed while Patroni is down and it cannot be executed before stopping the database (because Patroni will keep the cluster info).

Summary of the changes:
* `actions.yaml`: added the restore action.
* `src/backups.py`: added the event handler for the action with the following steps:
  * do some initial validations (including whether the backup id is valid)
  * stop the database
  * empty the data directory
  * configure Patroni to bootstrap a new cluster by restoring the backup
  * start the database service (Patroni, which starts PostgreSQL later) to run the restore
  * remove previous cluster information (needed to start a new cluster after the restore; it uses an interative approach, by providing the cluster name and later some words as input to the command)
* `src/charm.py`: updated the unit status after the backup is restored (or if it failed).
* `src/cluster.py` and `templates/patroni.yml.j2`: the template updates the config file with the restore command when it's ready to perform the restore through Patroni bootstrap process (using pgBackRest instead of the default initdb bootstrap mechanism).

The `archive_mode` setting is turned off after the backup is restored.

The list of backups come from pgbackrest info command.



# Testing
Added a basic integration test (copied from https://github.com/canonical/postgresql-k8s-operator/pull/104).

More tests will be added on [DPE-557](https://warthogs.atlassian.net/browse/DPE-557).


# Release Notes
Add restore backup action.

[DPE-1192]: https://warthogs.atlassian.net/browse/DPE-1192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DPE-557]: https://warthogs.atlassian.net/browse/DPE-557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ