### PR TITLE
Restart the service when the member is isolated from the rest of the cluster

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -827,6 +827,12 @@ class PostgresqlOperatorCharm(CharmBase):
             self._patroni.reinitialize_postgresql()
             return
 
+        # Restart the service if the current cluster member is isolated from the cluster
+        # (stuck with the "awaiting for member to start" message).
+        if not self._patroni.member_started and self._patroni.is_member_isolated:
+            self._patroni.restart_patroni()
+            return
+
         if "restoring-backup" in self.app_peer_data:
             if "failed" in self._patroni.get_member_status(self._member_name):
                 self.unit.status = BlockedStatus("Failed to restore backup")

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -340,7 +340,7 @@ class Patroni:
     def is_member_isolated(self) -> bool:
         """Returns whether the unit is isolated from the cluster."""
         try:
-            for attempt in Retrying(stop=stop_after_delay(60), wait=wait_fixed(3)):
+            for attempt in Retrying(stop=stop_after_delay(10), wait=wait_fixed(3)):
                 with attempt:
                     cluster_status = requests.get(
                         f"{self._patroni_url}/{PATRONI_CLUSTER_STATUS_ENDPOINT}",

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -336,6 +336,23 @@ class Patroni:
 
         return "unknown"
 
+    @property
+    def is_member_isolated(self) -> bool:
+        """Returns whether the unit is isolated from the cluster."""
+        try:
+            for attempt in Retrying(stop=stop_after_delay(60), wait=wait_fixed(3)):
+                with attempt:
+                    cluster_status = requests.get(
+                        f"{self._patroni_url}/{PATRONI_CLUSTER_STATUS_ENDPOINT}",
+                        verify=self.verify,
+                        timeout=API_REQUEST_TIMEOUT,
+                    )
+        except RetryError:
+            # Return False if it was not possible to get the cluster info. Try again later.
+            return False
+
+        return len(cluster_status.json()["members"]) == 0
+
     def render_file(self, path: str, content: str, mode: int) -> None:
         """Write a content rendered from a template to a file.
 


### PR DESCRIPTION
# Issue
Jira ticket: [DPE-1415](https://warthogs.atlassian.net/browse/DPE-1415)
When deploying a 3+ unit cluster, often one of the units gets stuck in a `awaiting for member to start` Waiting status.

This happened because TCP connections between the 3rd+ replica to the primary were being aborted after being created (couldn't figure out the reason yet).


# Solution
When the 3rd+ member is added to the cluster, first of all add it to the raft cluster, so it can communicate with the primary and participate in the primary election later (and also be in sync with the cluster).


# Context
* In `src/charm.py`:
  * Added a call to restart Patroni and enable the node to correctly connect to the cluster.
* In `src/cluster.py`
  * Added a property that returns whether the member is isolated from the cluster (what happens in the situation where the TCP connections are aborted).
* Closes https://github.com/canonical/postgresql-operator/issues/92.

I tried the improve the logic used to add members to the raft cluster on https://github.com/canonical/postgresql-operator/pull/100, but sometimes it caused worse situations (like demoting the primary and making it required to remove the data directory from it to make it follow the new primary).

# Testing
Added unit tests.

Tested locally and on CI multiple times to ensure the issue was resolved.


# Release Notes
Restart the service when the member is isolated from the rest of the cluster.

[DPE-1415]: https://warthogs.atlassian.net/browse/DPE-1415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ