### PR TITLE
Set workload version based on installed package

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -673,6 +673,8 @@ class PostgresqlOperatorCharm(CharmBase):
 
         self.unit_peer_data.update({"ip": self.get_hostname_by_unit(None)})
 
+        self.unit.set_workload_version(self._patroni.get_postgresql_version())
+
         # Only the leader can bootstrap the cluster.
         # On replicas, only prepare for starting the instance later.
         if not self.unit.is_leader():

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -168,7 +168,7 @@ class Patroni:
         os.chmod(path, mode)
         self._change_owner(path)
 
-    def _get_postgresql_version(self) -> str:
+    def get_postgresql_version(self) -> str:
         """Return the PostgreSQL version from the system."""
         package = DebianPackage.from_system("postgresql")
         # Remove the Ubuntu revision from the version.
@@ -399,7 +399,7 @@ class Patroni:
             restoring_backup=backup_id is not None,
             backup_id=backup_id,
             stanza=stanza,
-            version=self._get_postgresql_version(),
+            version=self.get_postgresql_version(),
             minority_count=self.planned_units // 2,
         )
         self.render_file(f"{self.storage_path}/patroni.yml", rendered, 0o644)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -174,6 +174,7 @@ class TestCharm(unittest.TestCase):
         _update_relation_endpoints.assert_called_once()  # Assert it was not called again.
         self.assertTrue(isinstance(self.harness.model.unit.status, BlockedStatus))
 
+    @patch("charm.Patroni.get_postgresql_version")
     @patch_network_get(private_address="1.1.1.1")
     @patch("charm.PostgreSQLProvider.oversee_users")
     @patch("charm.PostgresqlOperatorCharm._update_relation_endpoints", new_callable=PropertyMock)
@@ -205,7 +206,10 @@ class TestCharm(unittest.TestCase):
         _postgresql,
         _update_relation_endpoints,
         _oversee_users,
+        _get_postgresql_version,
     ):
+        _get_postgresql_version.return_value = "14"
+
         # Test without storage.
         self.charm.on.start.emit()
         _reboot_on_detached_storage.assert_called_once()
@@ -255,6 +259,7 @@ class TestCharm(unittest.TestCase):
         _oversee_users.assert_called_once()
         self.assertTrue(isinstance(self.harness.model.unit.status, ActiveStatus))
 
+    @patch("charm.Patroni.get_postgresql_version")
     @patch_network_get(private_address="1.1.1.1")
     @patch("charm.Patroni.configure_patroni_on_unit")
     @patch(
@@ -278,7 +283,10 @@ class TestCharm(unittest.TestCase):
         _update_relation_endpoints,
         _member_started,
         _configure_patroni_on_unit,
+        _get_postgresql_version,
     ):
+        _get_postgresql_version.return_value = "14"
+
         # Set the current unit to be a replica (non leader unit).
         self.harness.set_leader(False)
 
@@ -328,6 +336,8 @@ class TestCharm(unittest.TestCase):
         _get_password.return_value = "fake-operator-password"
         bootstrap_cluster = patroni.return_value.bootstrap_cluster
         bootstrap_cluster.return_value = True
+
+        patroni.return_value.get_postgresql_version.return_value = "14"
 
         self.harness.set_leader()
         self.charm.on.start.emit()

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -107,7 +107,7 @@ class TestCluster(unittest.TestCase):
         _from_system.return_value = DebianPackage(
             "postgresql", "12+214ubuntu0.1", "", "all", PackageState.Present
         )
-        version = self.patroni._get_postgresql_version()
+        version = self.patroni.get_postgresql_version()
         _from_system.assert_called_once_with("postgresql")
         self.assertEqual(version, "12")
 
@@ -191,7 +191,7 @@ class TestCluster(unittest.TestCase):
             0o644,
         )
 
-    @patch("charm.Patroni._get_postgresql_version")
+    @patch("charm.Patroni.get_postgresql_version")
     @patch("charm.Patroni.render_file")
     @patch("charm.Patroni._create_directory")
     def test_render_patroni_yml_file(self, _, _render_file, __):
@@ -217,7 +217,7 @@ class TestCluster(unittest.TestCase):
             replication_password=replication_password,
             rewind_user=REWIND_USER,
             rewind_password=rewind_password,
-            version=self.patroni._get_postgresql_version(),
+            version=self.patroni.get_postgresql_version(),
             minority_count=self.patroni.planned_units // 2,
         )
 


### PR DESCRIPTION
# Issue
* [DPE-1514](https://warthogs.atlassian.net/browse/DPE-1514)
* Setting the workload version based on installed package

# Solution
<!-- A summary of the solution addressing the above issue -->


# Context
* This was merged in [PR#81](https://github.com/canonical/postgresql-operator/pull/81) and reworked there since the snap changes the way version is handled

# Testing
<!-- What steps need to be taken to test this PR? -->


# Release Notes


[DPE-1514]: https://warthogs.atlassian.net/browse/DPE-1514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ