### PR TITLE
Hold the postgresql snap to a specific revision

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -860,12 +860,19 @@ class PostgresqlOperatorCharm(CharmBase):
         Args:
             packages: list of packages to install.
         """
-        for snap_name, snap_channel in packages:
+        for snap_name, snap_version in packages:
             try:
                 snap_cache = snap.SnapCache()
                 snap_package = snap_cache[snap_name]
 
-                snap_package.ensure(snap.SnapState.Latest, channel=snap_channel)
+                if not snap_package.present:
+                    if snap_version.get("revision"):
+                        snap_package.ensure(
+                            snap.SnapState.Latest, revision=snap_version["revision"]
+                        )
+                        snap_package.hold()
+                    else:
+                        snap_package.ensure(snap.SnapState.Latest, channel=snap_version["channel"])
 
             except (snap.SnapError, snap.SnapNotFoundError) as e:
                 logger.error(

--- a/src/constants.py
+++ b/src/constants.py
@@ -29,7 +29,7 @@ SYSTEM_USERS = [BACKUP_USER, REPLICATION_USER, REWIND_USER, USER]
 # Snap constants.
 PGBACKREST_EXECUTABLE = "charmed-postgresql.pgbackrest"
 POSTGRESQL_SNAP_NAME = "charmed-postgresql"
-SNAP_PACKAGES = [(POSTGRESQL_SNAP_NAME, "14/edge")]
+SNAP_PACKAGES = [(POSTGRESQL_SNAP_NAME, {"revision": 31})]
 
 SNAP_COMMON_PATH = "/var/snap/charmed-postgresql/common"
 SNAP_CURRENT_PATH = "/var/snap/charmed-postgresql/current"
@@ -47,4 +47,4 @@ PGBACKREST_LOGS_PATH = f"{SNAP_LOGS_PATH}/pgbackrest"
 POSTGRESQL_CONF_PATH = f"{SNAP_CONF_PATH}/postgresql"
 POSTGRESQL_DATA_PATH = f"{SNAP_DATA_PATH}/postgresql"
 
-PGBACKREST_CONFIGURATION_FILE = f"--config={SNAP_CONF_PATH}/pgbackrest/pgbackrest.conf"
+PGBACKREST_CONFIGURATION_FILE = f"--config={PGBACKREST_CONF_PATH}/pgbackrest.conf"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -12,7 +12,7 @@ from charms.postgresql_k8s.v0.postgresql import (
 from ops.framework import EventBase
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.testing import Harness
-from tenacity import RetryError
+from tenacity import RetryError, stop_after_delay, wait_fixed
 
 from charm import NO_PRIMARY_MESSAGE, PostgresqlOperatorCharm
 from constants import PEER
@@ -425,6 +425,8 @@ class TestCharm(unittest.TestCase):
             "app", "replication-password", "replication-test-password"
         )
 
+    @patch("charm.wait_fixed", return_vaule=wait_fixed(0))
+    @patch("charm.stop_after_delay", return_value=stop_after_delay(0))
     @patch_network_get(private_address="1.1.1.1")
     @patch("charm.PostgresqlOperatorCharm._set_primary_status_message")
     @patch("charm.Patroni.restart_patroni")
@@ -444,6 +446,8 @@ class TestCharm(unittest.TestCase):
         _is_member_isolated,
         _restart_patroni,
         _set_primary_status_message,
+        _,
+        __,
     ):
         # Test before the cluster is initialised.
         self.charm.on.update_status.emit()

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -2,7 +2,6 @@
 # See LICENSE file for licensing details.
 
 import unittest
-from unittest import mock
 from unittest.mock import Mock, PropertyMock, mock_open, patch, sentinel
 
 import requests as requests
@@ -79,7 +78,7 @@ class TestCluster(unittest.TestCase):
             url = self.patroni._get_alternative_patroni_url(attempt)
             self.assertIn(url.split("http://")[1].split(":8008")[0], self.peers_ips)
 
-    @mock.patch("requests.get", side_effect=mocked_requests_get)
+    @patch("requests.get", side_effect=mocked_requests_get)
     @patch("charm.Patroni._get_alternative_patroni_url")
     def test_get_member_ip(self, _get_alternative_patroni_url, _get):
         # Test error on trying to get the member IP.
@@ -120,7 +119,7 @@ class TestCluster(unittest.TestCase):
         _snap_client.assert_called_once_with()
         _get_installed_snaps.assert_called_once_with()
 
-    @mock.patch("requests.get", side_effect=mocked_requests_get)
+    @patch("requests.get", side_effect=mocked_requests_get)
     @patch("charm.Patroni._get_alternative_patroni_url")
     def test_get_primary(self, _get_alternative_patroni_url, _get):
         # Test error on trying to get the member IP.
@@ -147,7 +146,7 @@ class TestCluster(unittest.TestCase):
         primary = self.patroni.get_primary(unit_name_pattern=True)
         self.assertEqual(primary, "postgresql/0")
 
-    @mock.patch("requests.get", side_effect=mocked_requests_get)
+    @patch("requests.get", side_effect=mocked_requests_get)
     @patch("charm.Patroni._patroni_url", new_callable=PropertyMock)
     def test_is_member_isolated(self, _patroni_url, _get):
         # Test when it wasn't possible to connect to the Patroni API.
@@ -276,7 +275,7 @@ class TestCluster(unittest.TestCase):
         # Test a fail scenario.
         assert not self.patroni.stop_patroni()
 
-    @mock.patch("requests.get", side_effect=mocked_requests_get)
+    @patch("requests.get", side_effect=mocked_requests_get)
     @patch("charm.Patroni._patroni_url", new_callable=PropertyMock)
     def test_member_replication_lag(self, _patroni_url, _get):
         # Test when the cluster member has a value for the lag field.
@@ -302,7 +301,7 @@ class TestCluster(unittest.TestCase):
             f"http://{self.patroni.unit_ip}:8008/reinitialize", verify=True
         )
 
-    @mock.patch("requests.post")
+    @patch("requests.post")
     @patch("cluster.Patroni.get_primary", return_value="primary")
     def test_switchover(self, _, _post):
         response = _post.return_value
@@ -314,7 +313,7 @@ class TestCluster(unittest.TestCase):
             "http://1.1.1.1:8008/switchover", json={"leader": "primary"}, verify=True
         )
 
-    @mock.patch("requests.patch")
+    @patch("requests.patch")
     def test_update_synchronous_node_count(self, _patch):
         response = _patch.return_value
         response.status_code = 200

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -146,9 +146,11 @@ class TestCluster(unittest.TestCase):
         primary = self.patroni.get_primary(unit_name_pattern=True)
         self.assertEqual(primary, "postgresql/0")
 
+    @patch("cluster.stop_after_delay", return_value=tenacity.stop_after_delay(0))
+    @patch("cluster.wait_fixed", return_value=tenacity.wait_fixed(0))
     @patch("requests.get", side_effect=mocked_requests_get)
     @patch("charm.Patroni._patroni_url", new_callable=PropertyMock)
-    def test_is_member_isolated(self, _patroni_url, _get):
+    def test_is_member_isolated(self, _patroni_url, _get, _, __):
         # Test when it wasn't possible to connect to the Patroni API.
         _patroni_url.return_value = "http://server3"
         self.assertFalse(self.patroni.is_member_isolated)


### PR DESCRIPTION
# Issue
* [DPE-1647](https://warthogs.atlassian.net/browse/DPE-1647)
* Pin the charmed postgresql snap

# Solution
<!-- A summary of the solution addressing the above issue -->


# Context


# Testing
<!-- What steps need to be taken to test this PR? -->


# Release Notes
Hold charmed-postgresql snap to revision 31

[DPE-1647]: https://warthogs.atlassian.net/browse/DPE-1647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ