### PR TITLE
Add network cut test (without unit IP change)

### DIFF
--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -530,8 +530,6 @@ def restore_network_for_unit_without_ip_change(machine_name: str) -> None:
     subprocess.check_call(limit_set_command.split())
     limit_set_command = f"lxc config set {machine_name} limits.network.priority="
     subprocess.check_call(limit_set_command.split())
-    override_command = f"lxc config device remove {machine_name} eth0"
-    subprocess.check_call(override_command.split())
 
 
 async def is_secondary_up_to_date(ops_test: OpsTest, unit_name: str, expected_writes: int) -> bool:

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -530,6 +530,8 @@ def restore_network_for_unit_without_ip_change(machine_name: str) -> None:
     subprocess.check_call(limit_set_command.split())
     limit_set_command = f"lxc config set {machine_name} limits.network.priority="
     subprocess.check_call(limit_set_command.split())
+    override_command = f"lxc config device remove {machine_name} eth0"
+    subprocess.check_call(override_command.split())
 
 
 async def is_secondary_up_to_date(ops_test: OpsTest, unit_name: str, expected_writes: int) -> bool:

--- a/tests/integration/ha_tests/test_self_healing.py
+++ b/tests/integration/ha_tests/test_self_healing.py
@@ -21,6 +21,7 @@ from tests.integration.ha_tests.helpers import (
     check_writes,
     count_writes,
     cut_network_from_unit,
+    cut_network_from_unit_without_ip_change,
     fetch_cluster_members,
     get_controller_machine,
     get_patroni_setting,
@@ -34,6 +35,7 @@ from tests.integration.ha_tests.helpers import (
     is_secondary_up_to_date,
     list_wal_files,
     restore_network_for_unit,
+    restore_network_for_unit_without_ip_change,
     reused_storage,
     send_signal_to_process,
     start_continuous_writes,
@@ -488,6 +490,92 @@ async def test_network_cut(ops_test: OpsTest, continuous_writes, primary_start_t
     # Wait the LXD unit has its IP updated.
     logger.info("waiting for IP address to be updated on Juju unit")
     wait_network_restore(ops_test.model.info.name, primary_hostname, primary_ip)
+
+    # Verify that connection is possible.
+    logger.info("checking whether the connectivity to the database is working")
+    assert await is_connection_possible(
+        ops_test, primary_name
+    ), "Connection is not possible after network restore"
+
+    await is_cluster_updated(ops_test, primary_name)
+
+
+async def test_network_cut_without_ip_change(
+    ops_test: OpsTest, continuous_writes, primary_start_timeout
+):
+    """Completely cut and restore network (situation when the unit IP doesn't change)."""
+    # Locate primary unit.
+    app = await app_name(ops_test)
+    primary_name = await get_primary(ops_test, app)
+
+    # Start an application that continuously writes data to the database.
+    await start_continuous_writes(ops_test, app)
+
+    # Get unit hostname and IP.
+    primary_hostname = await unit_hostname(ops_test, primary_name)
+
+    # Verify that connection is possible.
+    logger.info("checking whether the connectivity to the database is working")
+    assert await is_connection_possible(
+        ops_test, primary_name
+    ), f"Connection {primary_name} is not possible"
+
+    logger.info(f"Cutting network for {primary_name}")
+    cut_network_from_unit_without_ip_change(primary_hostname)
+
+    # Verify machine is not reachable from peer units.
+    all_units_names = [unit.name for unit in ops_test.model.applications[app].units]
+    for unit_name in set(all_units_names) - {primary_name}:
+        logger.info(f"checking for no connectivity between {primary_name} and {unit_name}")
+        hostname = await unit_hostname(ops_test, unit_name)
+        assert not is_machine_reachable_from(
+            hostname, primary_hostname
+        ), "unit is reachable from peer"
+
+    # Verify machine is not reachable from controller.
+    logger.info(f"checking for no connectivity between {primary_name} and the controller")
+    controller = await get_controller_machine(ops_test)
+    assert not is_machine_reachable_from(
+        controller, primary_hostname
+    ), "unit is reachable from controller"
+
+    # Verify that connection is not possible.
+    logger.info("checking whether the connectivity to the database is not working")
+    assert not await is_connection_possible(
+        ops_test, primary_name
+    ), "Connection is possible after network cut"
+
+    # Verify new writes are continuing by counting the number of writes before and after a
+    # 3 minutes wait (this is a little more than the loop wait configuration, that is
+    # considered to trigger a fail-over after primary_start_timeout is changed).
+    logger.info("checking whether writes are increasing")
+    writes = await count_writes(ops_test, primary_name)
+    for attempt in Retrying(stop=stop_after_delay(60 * 3), wait=wait_fixed(3)):
+        with attempt:
+            more_writes = await count_writes(ops_test, primary_name)
+            assert more_writes > writes, "writes not continuing to DB"
+
+    logger.info("checking whether a new primary was elected")
+    async with ops_test.fast_forward():
+        # Verify that a new primary gets elected (ie old primary is secondary).
+        for attempt in Retrying(stop=stop_after_delay(60), wait=wait_fixed(3)):
+            with attempt:
+                new_primary_name = await get_primary(ops_test, app, down_unit=primary_name)
+                assert new_primary_name != primary_name
+
+    logger.info(f"Restoring network for {primary_name}")
+    restore_network_for_unit_without_ip_change(primary_hostname)
+
+    # Wait until the cluster becomes idle.
+    logger.info("waiting for cluster to become idle")
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(
+            apps=[app],
+            status="active",
+            raise_on_blocked=True,
+            timeout=1000,
+            idle_period=30,
+        )
 
     # Verify that connection is possible.
     logger.info("checking whether the connectivity to the database is working")

--- a/tests/integration/ha_tests/test_self_healing.py
+++ b/tests/integration/ha_tests/test_self_healing.py
@@ -569,13 +569,7 @@ async def test_network_cut_without_ip_change(
     # Wait until the cluster becomes idle.
     logger.info("waiting for cluster to become idle")
     async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(
-            apps=[app],
-            status="active",
-            raise_on_blocked=True,
-            timeout=1000,
-            idle_period=30,
-        )
+        await ops_test.model.wait_for_idle(apps=[app], status="active")
 
     # Verify that connection is possible.
     logger.info("checking whether the connectivity to the database is working")


### PR DESCRIPTION
## Issue
Jira ticket: [DPE-541](https://warthogs.atlassian.net/browse/DPE-541)
PostgreSQL should self heal after cutting the network connection and reestablishing it (when the network cut doesn't cause a change in the unit IP address).

## Solution
Limit the network connection of the unit to 0 kbit of egress traffic and 1 kbit of ingress traffic (the minimum allowed), and by reducing the priority of the traffic sent to the unit to the lowest.

In `tests/integration/ha_tests/helpers.py`:
* Added the helper functions needed to perform the network cut/restore operations (they don't cause an unit IP change).

In `tests/integration/ha_tests/test_self_healing.py`:
* Added the network cut test (the one where the unit IP doesn't change).

[DPE-541]: https://warthogs.atlassian.net/browse/DPE-541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ