### PR TITLE
Remove unneeded dependenceis from charmed-postgresql snap

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -32,7 +32,7 @@ SYSTEM_USERS = [BACKUP_USER, REPLICATION_USER, REWIND_USER, USER, MONITORING_USE
 # Snap constants.
 PGBACKREST_EXECUTABLE = "charmed-postgresql.pgbackrest"
 POSTGRESQL_SNAP_NAME = "charmed-postgresql"
-SNAP_PACKAGES = [(POSTGRESQL_SNAP_NAME, {"revision": 42})]
+SNAP_PACKAGES = [(POSTGRESQL_SNAP_NAME, {"revision": 47})]
 
 SNAP_COMMON_PATH = "/var/snap/charmed-postgresql/common"
 SNAP_CURRENT_PATH = "/var/snap/charmed-postgresql/current"

--- a/src/constants.py
+++ b/src/constants.py
@@ -32,7 +32,7 @@ SYSTEM_USERS = [BACKUP_USER, REPLICATION_USER, REWIND_USER, USER, MONITORING_USE
 # Snap constants.
 PGBACKREST_EXECUTABLE = "charmed-postgresql.pgbackrest"
 POSTGRESQL_SNAP_NAME = "charmed-postgresql"
-SNAP_PACKAGES = [(POSTGRESQL_SNAP_NAME, {"revision": 47})]
+SNAP_PACKAGES = [(POSTGRESQL_SNAP_NAME, {"revision": 48})]
 
 SNAP_COMMON_PATH = "/var/snap/charmed-postgresql/common"
 SNAP_CURRENT_PATH = "/var/snap/charmed-postgresql/current"

--- a/src/constants.py
+++ b/src/constants.py
@@ -29,7 +29,7 @@ SYSTEM_USERS = [BACKUP_USER, REPLICATION_USER, REWIND_USER, USER]
 # Snap constants.
 PGBACKREST_EXECUTABLE = "charmed-postgresql.pgbackrest"
 POSTGRESQL_SNAP_NAME = "charmed-postgresql"
-SNAP_PACKAGES = [(POSTGRESQL_SNAP_NAME, {"revision": 34})]
+SNAP_PACKAGES = [(POSTGRESQL_SNAP_NAME, {"revision": 42})]
 
 SNAP_COMMON_PATH = "/var/snap/charmed-postgresql/common"
 SNAP_CURRENT_PATH = "/var/snap/charmed-postgresql/current"


### PR DESCRIPTION
# Issue
* Update the charm to latest published snap, that removes superfluous dependencies

# Solution

# Context

# Testing

# Release Notes
Remove unneeded dependencies in the charmed-postgresql snap