### PR TITLE
Update revision due to outdated packages

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -32,7 +32,7 @@ SYSTEM_USERS = [BACKUP_USER, REPLICATION_USER, REWIND_USER, USER, MONITORING_USE
 # Snap constants.
 PGBACKREST_EXECUTABLE = "charmed-postgresql.pgbackrest"
 POSTGRESQL_SNAP_NAME = "charmed-postgresql"
-SNAP_PACKAGES = [(POSTGRESQL_SNAP_NAME, {"revision": 61})]
+SNAP_PACKAGES = [(POSTGRESQL_SNAP_NAME, {"revision": 62})]
 
 SNAP_COMMON_PATH = "/var/snap/charmed-postgresql/common"
 SNAP_CURRENT_PATH = "/var/snap/charmed-postgresql/current"


### PR DESCRIPTION
## Issue
Security scan report:
```
Revision r61 (amd64; channels: 14/edge)
 * libc-ares2: 6164-1
```

## Solution
Rebuild and update snap