### PR TITLE
[DPE-2129] Mark failing Nextcloud test as unstable temporarily

### DIFF
--- a/tests/integration/test_db.py
+++ b/tests/integration/test_db.py
@@ -168,6 +168,47 @@ async def test_relation_data_is_updated_correctly_when_scaling(ops_test: OpsTest
                 psycopg2.connect(primary_connection_string)
 
 
+@pytest.mark.unstable
+async def test_nextcloud_db_blocked(ops_test: OpsTest, charm: str) -> None:
+    async with ops_test.fast_forward():
+        # Deploy Nextcloud.
+        await ops_test.model.deploy(
+            "nextcloud",
+            channel="edge",
+            application_name="nextcloud",
+            num_units=APPLICATION_UNITS,
+        )
+        await ops_test.model.wait_for_idle(
+            apps=["nextcloud"],
+            status="blocked",
+            raise_on_blocked=False,
+            timeout=1000,
+        )
+
+        await ops_test.model.relate("nextcloud:db", f"{DATABASE_APP_NAME}:db")
+
+        # Only the leader will block
+        leader_unit = await find_unit(ops_test, DATABASE_APP_NAME, True)
+
+        try:
+            await ops_test.model.wait_for_idle(
+                apps=[DATABASE_APP_NAME],
+                status="blocked",
+                raise_on_blocked=True,
+                timeout=1000,
+            )
+            assert False, "Leader didn't block"
+        except JujuUnitError:
+            pass
+
+        assert (
+            leader_unit.workload_status_message
+            == "extensions requested through relation, enable them through config options"
+        )
+
+        await ops_test.model.remove_application("nextcloud", block_until_done=True)
+
+
 async def test_sentry_db_blocked(ops_test: OpsTest, charm: str) -> None:
     async with ops_test.fast_forward():
         # Deploy Sentry and its dependencies.


### PR DESCRIPTION
## Issue
The new Nextcloud charm revision (released on June 15th) is failing as on https://pastebin.canonical.com/p/PCVKx49j7R/, even when it's the only charm that is deployed in the model (no PostgreSQL to relate to it). This is blocking releases on the main branch of this repository.

Reference: https://github.com/erik78se/nextcloud-charms/issues/61#issuecomment-1593605323

## Solution
Mark the test as unstable temporarily.

The test should be enabled back again (with improvements to check that the charm works when extensions are enabled) on [DPE-2130](https://warthogs.atlassian.net/browse/DPE-2130).

[DPE-2130]: https://warthogs.atlassian.net/browse/DPE-2130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ