### PR TITLE
Internal changes to the charm shouldn't be released

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,12 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'tests/**'
+      - 'docs/**'
+      - renovate.json
+      - poetry.lock
+      - pyproject.toml
 
 jobs:
   ci-tests:

--- a/tests/integration/test_db.py
+++ b/tests/integration/test_db.py
@@ -288,6 +288,7 @@ async def test_sentry_db_blocked(ops_test: OpsTest, charm: str) -> None:
         )
 
 
+@pytest.mark.unstable
 async def test_weebl_db(ops_test: OpsTest, charm: str) -> None:
     async with ops_test.fast_forward():
         await ops_test.model.deploy(


### PR DESCRIPTION
## Issue
Charm is published to charmhub on each push to main even if there are no changes to the charm itself

## Solution
Try to limit the amount of releases based on the content of the push