### PR TITLE
[DPE-2173] Fix allowed units relation data field

### DIFF
--- a/src/relations/db.py
+++ b/src/relations/db.py
@@ -360,7 +360,7 @@ class DbProvides(Object):
 
     def _get_allowed_units(self, relation: Relation) -> str:
         """Build the list of allowed units as in the legacy charm."""
-        return ",".join(
+        return " ".join(
             sorted(
                 unit.name
                 for unit in relation.data

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -312,6 +312,7 @@ async def deploy_and_relate_bundle_with_postgresql(
     ops_test: OpsTest,
     bundle_name: str,
     main_application_name: str,
+    main_application_num_units: int = None,
     relation_name: str = "db",
     status: str = "active",
     status_message: str = None,
@@ -324,6 +325,8 @@ async def deploy_and_relate_bundle_with_postgresql(
         bundle_name: The name of the bundle to deploy.
         main_application_name: The name of the application that should be
             related to PostgreSQL.
+        main_application_num_units: Optional number of units for the main
+            application.
         relation_name: The name of the relation to use in PostgreSQL
             (db or db-admin).
         status: Status to wait for in the application after relating
@@ -342,6 +345,11 @@ async def deploy_and_relate_bundle_with_postgresql(
         with zipfile.ZipFile(original.name, "r") as archive:
             bundle_yaml = archive.read("bundle.yaml")
             data = yaml.load(bundle_yaml, Loader=yaml.FullLoader)
+
+            if main_application_num_units is not None:
+                data["applications"][main_application_name][
+                    "num_units"
+                ] = main_application_num_units
 
             # Save the list of relations other than `db` and `db-admin`,
             # so we can add them back later.

--- a/tests/integration/test_db.py
+++ b/tests/integration/test_db.py
@@ -328,10 +328,10 @@ async def test_canonical_livepatch_onprem_bundle_db(ops_test: OpsTest) -> None:
         ops_test,
         "canonical-livepatch-onprem",
         LIVEPATCH_APP_NAME,
-        "db",
-        "blocked",
-        "✘ sync_token not set",
-        overlay,
+        relation_name="db",
+        status="blocked",
+        status_message="✘ sync_token not set",
+        overlay=overlay,
     )
 
     action = await ops_test.model.units.get(f"{LIVEPATCH_APP_NAME}/0").run_action("schema-upgrade")

--- a/tests/integration/test_db_admin.py
+++ b/tests/integration/test_db_admin.py
@@ -43,7 +43,11 @@ async def test_landscape_scalable_bundle_db(ops_test: OpsTest, charm: str) -> No
 
     # Deploy and test the Landscape Scalable bundle (using this PostgreSQL charm).
     relation_id = await deploy_and_relate_bundle_with_postgresql(
-        ops_test, "ch:landscape-scalable", LANDSCAPE_APP_NAME, RELATION_NAME
+        ops_test,
+        "ch:landscape-scalable",
+        LANDSCAPE_APP_NAME,
+        main_application_num_units=2,
+        relation_name=RELATION_NAME,
     )
     await check_databases_creation(
         ops_test,

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -645,3 +645,15 @@ class TestDbProvides(unittest.TestCase):
                     "standbys" in unit_relation_data
                     and standbys + user == unit_relation_data["standbys"]
                 )
+
+    def test_get_allowed_units(self):
+        # No allowed units from the current database application.
+        peer_relation = self.harness.model.get_relation(PEER, self.peer_rel_id)
+        self.assertEqual(self.legacy_db_relation._get_allowed_units(peer_relation), "")
+
+        # List of space separated allowed units from the other application.
+        self.harness.add_relation_unit(self.rel_id, "application/1")
+        db_relation = self.harness.model.get_relation(RELATION_NAME, self.rel_id)
+        self.assertEqual(
+            self.legacy_db_relation._get_allowed_units(db_relation), "application/0 application/1"
+        )


### PR DESCRIPTION
## Issue
When relating more that one unit of the Landscape charm, one of its units became in a waiting state due to wrong data being sent by the PostgreSQL charm in the `allowed-units` relation data field.

## Solution
Use spaces instead of commas as the separator in the `allowed-units` relation data field, as the legacy PostgreSQL charm does. The legacy PostgreSQL K8S charm uses commas (so we will keep the legacy relation from the new PostgreSQL K8S charm as it is right now). We should only change PgBouncer VM. I'm gonna create a PR for that.

Closes https://github.com/canonical/postgresql-operator/issues/171.