### PR TITLE
[DPE-2127] Fixed databases access

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -176,6 +176,7 @@ class PostgresqlOperatorCharm(CharmBase):
             user=USER,
             password=self.get_secret("app", f"{USER}-password"),
             database="postgres",
+            system_users=SYSTEM_USERS,
         )
 
     @property
@@ -844,6 +845,8 @@ class PostgresqlOperatorCharm(CharmBase):
             logger.exception(e)
             self.unit.status = BlockedStatus("Failed to create postgres user")
             return
+
+        self.postgresql.set_up_database()
 
         self.postgresql_client_relation.oversee_users()
 

--- a/tests/integration/new_relations/helpers.py
+++ b/tests/integration/new_relations/helpers.py
@@ -16,6 +16,7 @@ async def build_connection_string(
     relation_id: str = None,
     relation_alias: str = None,
     read_only_endpoint: bool = False,
+    database: str = None,
 ) -> str:
     """Build a PostgreSQL connection string.
 
@@ -28,12 +29,14 @@ async def build_connection_string(
             to get connection data from
         read_only_endpoint: whether to choose the read-only endpoint
             instead of the read/write endpoint
+        database: optional database to be used in the connection string
 
     Returns:
         a PostgreSQL connection string
     """
     # Get the connection data exposed to the application through the relation.
-    database = f'{application_name.replace("-", "_")}_{relation_name.replace("-", "_")}'
+    if database is None:
+        database = f'{application_name.replace("-", "_")}_{relation_name.replace("-", "_")}'
     username = await get_application_relation_data(
         ops_test, application_name, relation_name, "username", relation_id, relation_alias
     )

--- a/tests/integration/new_relations/test_new_relations.py
+++ b/tests/integration/new_relations/test_new_relations.py
@@ -204,6 +204,25 @@ async def test_two_applications_doesnt_share_the_same_relation_data(
 
     assert application_connection_string != another_application_connection_string
 
+    # Check that the user cannot access other databases.
+    for application, other_application_database in [
+        (APPLICATION_APP_NAME, "another_application_first_database"),
+        (another_application_app_name, "application_first_database"),
+    ]:
+        connection_string = await build_connection_string(
+            ops_test, application, FIRST_DATABASE_RELATION_NAME, database="postgres"
+        )
+        with pytest.raises(psycopg2.Error):
+            psycopg2.connect(connection_string)
+        connection_string = await build_connection_string(
+            ops_test,
+            application,
+            FIRST_DATABASE_RELATION_NAME,
+            database=other_application_database,
+        )
+        with pytest.raises(psycopg2.Error):
+            psycopg2.connect(connection_string)
+
 
 async def test_an_application_can_connect_to_multiple_database_clusters(
     ops_test: OpsTest, database_charm


### PR DESCRIPTION
## Issue
Users created for the relations established have access to all the databases because when a new database is created, PostgreSQL enable all the users to connect to it by default.

## Solution
Restrict access to the system database to the system users and to the newly created database only to the user that requested it.