### PR TITLE
[MISC]  More resilient topology observer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,9 +86,9 @@ jobs:
         agent-versions:
           - "2.9.44"  # renovate: latest juju 2
           - "3.1.5"  # renovate: latest juju 3
-        include:
-          - tox-environments: db-admin-relation-integration
-            agent-versions: "2.9.43"  # renovate: latest juju 2
+        # include:
+        #   - tox-environments: db-admin-relation-integration
+        #     agent-versions: "2.9.43"  # renovate: latest juju 2
     name: ${{ matrix.tox-environments }} | ${{ matrix.agent-versions }}
     needs:
       - lib-check

--- a/src/charm.py
+++ b/src/charm.py
@@ -1154,6 +1154,9 @@ class PostgresqlOperatorCharm(CharmBase):
 
         self._set_primary_status_message()
 
+        # Restart topology observer if it is gone
+        self._observer.start_observer()
+
     def _handle_processes_failures(self) -> bool:
         """Handle Patroni and PostgreSQL OS processes failures.
 

--- a/src/cluster_topology_observer.py
+++ b/src/cluster_topology_observer.py
@@ -54,12 +54,16 @@ class ClusterTopologyObserver(Object):
 
     def start_observer(self):
         """Start the cluster topology observer running in a new process."""
-        if (
-            not isinstance(self._charm.unit.status, ActiveStatus)
-            or self._charm._peers is None
-            or "observer-pid" in self._charm._peers.data[self._charm.unit]
-        ):
+        if not isinstance(self._charm.unit.status, ActiveStatus) or self._charm._peers is None:
             return
+        if "observer-pid" in self._charm._peers.data[self._charm.unit]:
+            # Double check that the PID exists
+            pid = int(self._charm._peers.data[self._charm.unit]["observer-pid"])
+            try:
+                os.kill(pid, 0)
+                return
+            except OSError:
+                pass
 
         logging.info("Starting cluster topology observer process")
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -560,6 +560,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch_network_get(private_address="1.1.1.1")
+    @patch("charm.ClusterTopologyObserver.start_observer")
     @patch("charm.PostgresqlOperatorCharm._set_primary_status_message")
     @patch("charm.Patroni.restart_patroni")
     @patch("charm.Patroni.is_member_isolated")
@@ -583,6 +584,7 @@ class TestCharm(unittest.TestCase):
         _is_member_isolated,
         _restart_patroni,
         _set_primary_status_message,
+        _start_observer,
     ):
         # Test before the cluster is initialised.
         self.charm.on.update_status.emit()
@@ -625,8 +627,10 @@ class TestCharm(unittest.TestCase):
             )
         self.charm.on.update_status.emit()
         _restart_patroni.assert_called_once()
+        _start_observer.assert_called_once()
 
     @patch_network_get(private_address="1.1.1.1")
+    @patch("charm.ClusterTopologyObserver.start_observer")
     @patch("charm.PostgresqlOperatorCharm._set_primary_status_message")
     @patch("charm.PostgresqlOperatorCharm._handle_workload_failures")
     @patch("charm.PostgresqlOperatorCharm._update_relation_endpoints")
@@ -652,6 +656,7 @@ class TestCharm(unittest.TestCase):
         _update_relation_endpoints,
         _handle_workload_failures,
         _set_primary_status_message,
+        _,
     ):
         # Test when the restore operation fails.
         with self.harness.hooks_disabled():


### PR DESCRIPTION
## Issue
A bug was reported in the public MM that the legacy relation for VM doesn't fire the hook to update the primary. It seems to me that the topology observer has crashed at some point and changes in the topology are no longer passed on to relations.

## Solution
Check that the observer is still alive in  _on_update_status and restart it if it os not. This is more of a POC fix to see if it will resolve the bug. If it is indeed the issue at hand, we can revisit with a better solution.