### PR TITLE
[DPE-2236] Handle invalid extra user roles

### DIFF
--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -19,7 +19,7 @@ The `postgresql` module provides methods for interacting with the PostgreSQL ins
 Any charm using this library should import the `psycopg2` or `psycopg2-binary` dependency.
 """
 import logging
-from typing import List, Set
+from typing import List, Set, Tuple
 
 import psycopg2
 from psycopg2 import sql
@@ -32,7 +32,9 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 11
+LIBPATCH = 12
+
+INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE = "invalid role(s) for extra user roles"
 
 
 logger = logging.getLogger(__name__)
@@ -44,6 +46,10 @@ class PostgreSQLCreateDatabaseError(Exception):
 
 class PostgreSQLCreateUserError(Exception):
     """Exception raised when creating a user fails."""
+
+    def __init__(self, message: str = None):
+        super().__init__(message)
+        self.message = message
 
 
 class PostgreSQLDatabasesSetupError(Exception):
@@ -176,23 +182,29 @@ class PostgreSQL:
             extra_user_roles: additional privileges and/or roles to be assigned to the user.
         """
         try:
-            with self._connect_to_database() as connection, connection.cursor() as cursor:
-                # Separate roles and privileges from the provided extra user roles.
-                admin_role = False
-                roles = privileges = None
-                if extra_user_roles:
-                    extra_user_roles = tuple(extra_user_roles.lower().split(","))
-                    cursor.execute(
-                        "SELECT rolname FROM pg_roles WHERE rolname IN %s;", (extra_user_roles,)
-                    )
-                    admin_role = "admin" in extra_user_roles
-                    roles = [role[0] for role in cursor.fetchall() if role[0] != "admin"]
-                    privileges = {
-                        extra_user_role
-                        for extra_user_role in extra_user_roles
-                        if extra_user_role not in roles and extra_user_role != "admin"
-                    }
+            # Separate roles and privileges from the provided extra user roles.
+            admin_role = False
+            roles = privileges = None
+            if extra_user_roles:
+                extra_user_roles = tuple(extra_user_roles.lower().split(","))
+                admin_role = "admin" in extra_user_roles
+                valid_privileges, valid_roles = self.list_valid_privileges_and_roles()
+                roles = [
+                    role for role in extra_user_roles if role in valid_roles and role != "admin"
+                ]
+                privileges = {
+                    extra_user_role
+                    for extra_user_role in extra_user_roles
+                    if extra_user_role not in roles and extra_user_role != "admin"
+                }
+                invalid_privileges = [
+                    privilege for privilege in privileges if privilege not in valid_privileges
+                ]
+                if len(invalid_privileges) > 0:
+                    logger.error(f'Invalid extra user roles: {", ".join(privileges)}')
+                    raise PostgreSQLCreateUserError(INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE)
 
+            with self._connect_to_database() as connection, connection.cursor() as cursor:
                 # Create or update the user.
                 cursor.execute(f"SELECT TRUE FROM pg_roles WHERE rolname='{user}';")
                 if cursor.fetchone() is not None:
@@ -342,6 +354,21 @@ class PostgreSQL:
         except psycopg2.Error as e:
             logger.error(f"Failed to list PostgreSQL database users: {e}")
             raise PostgreSQLListUsersError()
+
+    def list_valid_privileges_and_roles(self) -> Tuple[Set[str], Set[str]]:
+        """Returns two sets with valid privileges and roles.
+
+        Returns:
+            Tuple containing two sets: the first with valid privileges
+                and the second with valid roles.
+        """
+        with self._connect_to_database() as connection, connection.cursor() as cursor:
+            cursor.execute("SELECT rolname FROM pg_roles;")
+            return {
+                "createdb",
+                "createrole",
+                "superuser",
+            }, {role[0] for role in cursor.fetchall() if role[0]}
 
     def set_up_database(self) -> None:
         """Set up postgres database with the right permissions."""

--- a/src/relations/postgresql_provider.py
+++ b/src/relations/postgresql_provider.py
@@ -202,7 +202,10 @@ class PostgreSQLProvider(Object):
             if relation.id == relation_id:
                 continue
             for data in relation.data.values():
-                extra_user_roles = tuple(data.get("extra-user-roles", "").lower().split(","))
+                extra_user_roles = data.get("extra-user-roles")
+                if extra_user_roles is None:
+                    break
+                extra_user_roles = extra_user_roles.lower().split(",")
                 for extra_user_role in extra_user_roles:
                     if (
                         extra_user_role not in valid_privileges

--- a/tests/integration/new_relations/test_new_relations.py
+++ b/tests/integration/new_relations/test_new_relations.py
@@ -32,6 +32,7 @@ SECOND_DATABASE_RELATION_NAME = "second-database"
 MULTIPLE_DATABASE_CLUSTERS_RELATION_NAME = "multiple-database-clusters"
 ALIASED_MULTIPLE_DATABASE_CLUSTERS_RELATION_NAME = "aliased-multiple-database-clusters"
 NO_DATABASE_RELATION_NAME = "no-database"
+INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE = "invalid role(s) for extra user roles"
 
 
 @pytest.mark.abort_on_fail
@@ -478,3 +479,64 @@ async def test_admin_role(ops_test: OpsTest):
         pass
     finally:
         connection.close()
+
+
+async def test_invalid_extra_user_roles(ops_test: OpsTest):
+    async with ops_test.fast_forward():
+        # Remove the relation between the database and the first data integrator.
+        await ops_test.model.applications[DATABASE_APP_NAME].remove_relation(
+            DATABASE_APP_NAME, DATA_INTEGRATOR_APP_NAME
+        )
+        await ops_test.model.wait_for_idle(apps=APP_NAMES, status="active", raise_on_blocked=True)
+
+        another_data_integrator_app_name = f"another-{DATA_INTEGRATOR_APP_NAME}"
+        data_integrator_apps_names = [DATA_INTEGRATOR_APP_NAME, another_data_integrator_app_name]
+        await ops_test.model.deploy(
+            DATA_INTEGRATOR_APP_NAME, application_name=another_data_integrator_app_name
+        )
+        await ops_test.model.wait_for_idle(
+            apps=[another_data_integrator_app_name], status="blocked"
+        )
+        for app in data_integrator_apps_names:
+            await ops_test.model.applications[app].set_config(
+                {
+                    "database-name": app.replace("-", "_"),
+                    "extra-user-roles": "test",
+                }
+            )
+        await ops_test.model.wait_for_idle(apps=data_integrator_apps_names, status="blocked")
+        for app in data_integrator_apps_names:
+            await ops_test.model.add_relation(f"{app}:postgresql", f"{DATABASE_APP_NAME}:database")
+        await ops_test.model.wait_for_idle(apps=[DATABASE_APP_NAME])
+        ops_test.model.block_until(
+            lambda: any(
+                unit.workload_status_message == INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE
+                for unit in ops_test.model.applications[DATABASE_APP_NAME].units
+            ),
+            timeout=1000,
+        )
+
+        # Verify that the charm remains blocked if there are still other relations with invalid
+        # extra user roles.
+        await ops_test.model.applications[DATABASE_APP_NAME].destroy_relation(
+            f"{DATABASE_APP_NAME}:database", f"{DATA_INTEGRATOR_APP_NAME}:postgresql"
+        )
+        await ops_test.model.wait_for_idle(apps=[DATABASE_APP_NAME])
+        ops_test.model.block_until(
+            lambda: any(
+                unit.workload_status_message == INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE
+                for unit in ops_test.model.applications[DATABASE_APP_NAME].units
+            ),
+            timeout=1000,
+        )
+
+        # Verify that active status is restored after all relations are removed.
+        await ops_test.model.applications[DATABASE_APP_NAME].destroy_relation(
+            f"{DATABASE_APP_NAME}:database", f"{another_data_integrator_app_name}:postgresql"
+        )
+        await ops_test.model.wait_for_idle(
+            apps=[DATABASE_APP_NAME],
+            status="active",
+            raise_on_blocked=False,
+            timeout=1000,
+        )


### PR DESCRIPTION
## Issue
When an application requests invalid extra user roles through the relation with the PostgreSQL charm, PostgreSQL become blocked and that status is not fixed even when removing the relation.

## Solution
Check if there are still active relations with invalid extra user roles being requested and, if not, remove the blocked status (it's similar to what has been done for extensions in the legacy relations).

Added an additional integration test to validate that.