### PR TITLE
[DPE-2467] Socket connection

### DIFF
--- a/src/cluster.py
+++ b/src/cluster.py
@@ -498,7 +498,7 @@ class Patroni:
             version=self.get_postgresql_version().split(".")[0],
             minority_count=self.planned_units // 2,
         )
-        self.render_file(f"{PATRONI_CONF_PATH}/patroni.yaml", rendered, 0o644)
+        self.render_file(f"{PATRONI_CONF_PATH}/patroni.yaml", rendered, 0o600)
 
     def start_patroni(self) -> bool:
         """Start Patroni service using snap.

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -99,6 +99,7 @@ postgresql:
   pgpass: /tmp/pgpass
   pg_hba:
     - local all backup peer map=operator
+    - local all operator password
     - local all monitoring password
     {%- if not connectivity %}
     - {{ 'hostssl' if enable_tls else 'host' }} all all 0.0.0.0/0 reject

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -99,7 +99,7 @@ postgresql:
   pgpass: /tmp/pgpass
   pg_hba:
     - local all backup peer map=operator
-    - local all operator password
+    - local all operator scram-sha-256
     - local all monitoring password
     {%- if not connectivity %}
     - {{ 'hostssl' if enable_tls else 'host' }} all all 0.0.0.0/0 reject

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -273,7 +273,7 @@ class TestCluster(unittest.TestCase):
         _render_file.assert_called_once_with(
             "/var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml",
             expected_content,
-            0o644,
+            0o600,
         )
 
     @patch("charm.snap.SnapCache")


### PR DESCRIPTION
## Issue
Default configuration prevents socket connections for the operator user from within the charm machine

## Solution
* Allow socket connections
* Restrict the access to Patroni configuration
