### PR TITLE
[MISC] Secondary units stuck on configuring exporter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -137,10 +137,10 @@ jobs:
             echo "mark_expression=" >> $GITHUB_OUTPUT
           else
             echo Skipping unstable tests
-            echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
+            echo "mark_expression=and not unstable" >> $GITHUB_OUTPUT
           fi
       - name: Run integration tests
-        run: tox run -e ${{ matrix.tox-environments }}-${{ env.libjuju }} -- -m 'not not${{ env.libjuju }} and ${{ steps.select-tests.outputs.mark_expression }}' --keep-models
+        run: tox run -e ${{ matrix.tox-environments }}-${{ env.libjuju }} -- -m 'not not${{ env.libjuju }} ${{ steps.select-tests.outputs.mark_expression }}' --keep-models
         env:
           AWS_ACCESS_KEY: "${{ secrets.AWS_ACCESS_KEY }}"
           AWS_SECRET_KEY: "${{ secrets.AWS_SECRET_KEY }}"

--- a/src/backups.py
+++ b/src/backups.py
@@ -411,6 +411,9 @@ class PostgreSQLBackups(Object):
 
     @property
     def _is_primary_pgbackrest_service_running(self) -> bool:
+        if not self.charm.primary_endpoint:
+            logger.warning("Failed to contact pgBackRest TLS server: no promary endpoint")
+            return False
         return_code, _, stderr = self._execute_command(
             [PGBACKREST_EXECUTABLE, "server-ping", "--io-timeout=10", self.charm.primary_endpoint]
         )

--- a/src/backups.py
+++ b/src/backups.py
@@ -412,7 +412,7 @@ class PostgreSQLBackups(Object):
     @property
     def _is_primary_pgbackrest_service_running(self) -> bool:
         if not self.charm.primary_endpoint:
-            logger.warning("Failed to contact pgBackRest TLS server: no promary endpoint")
+            logger.warning("Failed to contact pgBackRest TLS server: no primary endpoint")
             return False
         return_code, _, stderr = self._execute_command(
             [PGBACKREST_EXECUTABLE, "server-ping", "--io-timeout=10", self.charm.primary_endpoint]

--- a/src/charm.py
+++ b/src/charm.py
@@ -951,7 +951,7 @@ class PostgresqlOperatorCharm(CharmBase):
             # Set up the postgresql_exporter options.
             self._setup_exporter()
         except snap.SnapError:
-            logger.error("failed to set up postgresql_exporter options")
+            logger.exception("failed to set up postgresql_exporter options")
             self.unit.status = BlockedStatus("failed to set up postgresql_exporter options")
             return
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -949,7 +949,8 @@ class PostgresqlOperatorCharm(CharmBase):
 
         try:
             # Set up the postgresql_exporter options.
-            self._setup_exporter()
+            # self._setup_exporter()
+            pass
         except snap.SnapError:
             logger.exception("failed to set up postgresql_exporter options")
             self.unit.status = BlockedStatus("failed to set up postgresql_exporter options")

--- a/src/charm.py
+++ b/src/charm.py
@@ -539,6 +539,9 @@ class PostgresqlOperatorCharm(CharmBase):
             event.defer()
             return
 
+        if "exporter-started" not in self.unit_peer_data:
+            self._setup_exporter()
+
         self._update_new_unit_status()
 
     def _update_new_unit_status(self) -> None:
@@ -1391,10 +1394,7 @@ class PostgresqlOperatorCharm(CharmBase):
                 "Early exit update_config: Trying to reset metrics service with no configuration set"
             )
             return True
-        if (
-            snap_password != self.get_secret(APP_SCOPE, MONITORING_PASSWORD_KEY)
-            or "exporter-started" not in self.unit_peer_data
-        ):
+        if snap_password != self.get_secret(APP_SCOPE, MONITORING_PASSWORD_KEY):
             self._setup_exporter()
 
         return True

--- a/src/grafana_dashboards/postgresql-metrics.json
+++ b/src/grafana_dashboards/postgresql-metrics.json
@@ -3034,7 +3034,6 @@
   "tags": [
     "postgres",
     "db",
-    "stats"
   ],
   "templating": {
     "list": [
@@ -3263,7 +3262,7 @@
     ]
   },
   "timezone": "",
-  "title": "PostgreSQL Database",
+  "title": "PostgreSQL",
   "uid": "000000039",
   "version": 1
 }

--- a/tests/unit/test_backups.py
+++ b/tests/unit/test_backups.py
@@ -595,9 +595,16 @@ class TestPostgreSQLBackups(unittest.TestCase):
         self.assertFalse(self.charm.backup._is_primary_pgbackrest_service_running)
         _execute_command.assert_called_once()
 
+        # Test when the endpoint is not generated.
+        _execute_command.reset_mock()
+        _primary_endpoint.return_value = None
+        self.assertFalse(self.charm.backup._is_primary_pgbackrest_service_running)
+        _execute_command.assert_not_called()
+
         # Test when the pgBackRest succeeds on contacting the primary server.
         _execute_command.reset_mock()
         _execute_command.return_value = (0, "fake stdout", "")
+        _primary_endpoint.return_value = "fake_endpoint"
         self.assertTrue(self.charm.backup._is_primary_pgbackrest_service_running)
         _execute_command.assert_called_once()
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -331,7 +331,6 @@ class TestCharm(unittest.TestCase):
         _enable_disable_extensions.assert_called_once()
         self.assertTrue(isinstance(self.harness.model.unit.status, ActiveStatus))
 
-    @patch("charm.PostgresqlOperatorCharm.get_secret")
     @patch("charm.snap.SnapCache")
     @patch("charm.Patroni.get_postgresql_version")
     @patch_network_get(private_address="1.1.1.1")
@@ -359,7 +358,6 @@ class TestCharm(unittest.TestCase):
         _configure_patroni_on_unit,
         _get_postgresql_version,
         _snap_cache,
-        _get_secret,
     ):
         _get_postgresql_version.return_value = "14.0"
 
@@ -369,7 +367,6 @@ class TestCharm(unittest.TestCase):
         # Mock the passwords.
         _get_password.return_value = "fake-operator-password"
         _replication_password.return_value = "fake-replication-password"
-        _get_secret.return_value = "fake-monitoring-passwordl"
 
         # Test an uninitialized cluster.
         self.charm._peers.data[self.charm.app].update({"cluster_initialised": ""})

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -331,6 +331,7 @@ class TestCharm(unittest.TestCase):
         _enable_disable_extensions.assert_called_once()
         self.assertTrue(isinstance(self.harness.model.unit.status, ActiveStatus))
 
+    @patch("charm.PostgresqlOperatorCharm.get_secret")
     @patch("charm.snap.SnapCache")
     @patch("charm.Patroni.get_postgresql_version")
     @patch_network_get(private_address="1.1.1.1")
@@ -358,6 +359,7 @@ class TestCharm(unittest.TestCase):
         _configure_patroni_on_unit,
         _get_postgresql_version,
         _snap_cache,
+        _get_secret,
     ):
         _get_postgresql_version.return_value = "14.0"
 
@@ -367,6 +369,7 @@ class TestCharm(unittest.TestCase):
         # Mock the passwords.
         _get_password.return_value = "fake-operator-password"
         _replication_password.return_value = "fake-replication-password"
+        _get_secret.return_value = "fake-monitoring-passwordl"
 
         # Test an uninitialized cluster.
         self.charm._peers.data[self.charm.app].update({"cluster_initialised": ""})

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1126,6 +1126,7 @@ class TestCharm(unittest.TestCase):
         self.assertTrue(isinstance(self.harness.model.unit.status, ActiveStatus))
 
     @patch_network_get(private_address="1.1.1.1")
+    @patch("charm.snap.SnapCache")
     @patch("charm.PostgresqlOperatorCharm._update_relation_endpoints")
     @patch("charm.PostgresqlOperatorCharm.primary_endpoint", new_callable=PropertyMock)
     @patch("charm.Patroni.member_started", new_callable=PropertyMock)
@@ -1142,6 +1143,7 @@ class TestCharm(unittest.TestCase):
         _member_started,
         _primary_endpoint,
         _update_relation_endpoints,
+        _,
     ):
         # Test an uninitialized cluster.
         mock_event = Mock()


### PR DESCRIPTION
## Issue
Starting the Postgresql exporter is frequently failing on replica units, likely due to LXD update.

## Solution
Trigger the exporter start in on peer data change, after Patroni and PG are started.
