### PR TITLE
[MISC] Don't fail if the unit is already missing

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -566,7 +566,7 @@ class PostgresqlOperatorCharm(CharmBase):
         """
         if (
             hasattr(event, "unit")
-            and event.unit is not None
+            and event.relation.data.get(event.unit) is not None
             and event.relation.data[event.unit].get("ip-to-remove") is not None
         ):
             ip_to_remove = event.relation.data[event.unit].get("ip-to-remove")


### PR DESCRIPTION
# Issue
Charm can fail on reconfiguring if the departing unit is already gone from the relation databag:
```
unit-postgresql-24: 13:06:29 DEBUG unit.postgresql/24.juju-log database-peers:42: Re-emitting deferred event <RelationChangedEvent via Postgres
qlOperatorCharm/on/database_peers_relation_changed[112]>.
unit-postgresql-24: 13:06:29 ERROR unit.postgresql/24.juju-log database-peers:42: Uncaught exception while in charm code:
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-postgresql-24/charm/./src/charm.py", line 1436, in <module>
    main(PostgresqlOperatorCharm)
  File "/var/lib/juju/agents/unit-postgresql-24/charm/venv/ops/main.py", line 439, in main
    framework.reemit()
  File "/var/lib/juju/agents/unit-postgresql-24/charm/venv/ops/framework.py", line 851, in reemit
    self._reemit()
  File "/var/lib/juju/agents/unit-postgresql-24/charm/venv/ops/framework.py", line 930, in _reemit
    custom_handler(event)
  File "/var/lib/juju/agents/unit-postgresql-24/charm/./src/charm.py", line 502, in _on_peer_relation_changed
    if self.unit.is_leader() and not self._reconfigure_cluster(event):
  File "/var/lib/juju/agents/unit-postgresql-24/charm/./src/charm.py", line 570, in _reconfigure_cluster
    and event.relation.data[event.unit].get("ip-to-remove") is not None
  File "/var/lib/juju/agents/unit-postgresql-24/charm/venv/ops/model.py", line 1438, in __getitem__
    return self._data[key]
KeyError: <ops.model.Unit postgresql/26>
```

# Solution
Ignore if the unit is already missing from the databag.