### PR TITLE
[DPE-2740] Handle tables ownership

### DIFF
--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -22,7 +22,9 @@ import logging
 from typing import Dict, List, Optional, Set, Tuple
 
 import psycopg2
+from ops.model import Relation
 from psycopg2 import sql
+from psycopg2.sql import Composed
 
 # The unique Charmhub library identifier, never change it
 LIBID = "24ee217a54e840a598ff21a079c3e678"
@@ -32,7 +34,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 20
+LIBPATCH = 21
 
 INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE = "invalid role(s) for extra user roles"
 
@@ -117,13 +119,20 @@ class PostgreSQL:
         connection.autocommit = True
         return connection
 
-    def create_database(self, database: str, user: str, plugins: List[str] = []) -> None:
+    def create_database(
+        self,
+        database: str,
+        user: str,
+        plugins: List[str] = [],
+        client_relations: List[Relation] = [],
+    ) -> None:
         """Creates a new database and grant privileges to a user on it.
 
         Args:
             database: database to be created.
             user: user that will have access to the database.
             plugins: extensions to enable in the new database.
+            client_relations: current established client relations.
         """
         try:
             connection = self._connect_to_database()
@@ -142,29 +151,20 @@ class PostgreSQL:
                         sql.Identifier(database), sql.Identifier(user_to_grant_access)
                     )
                 )
+            relations_accessing_this_database = 0
+            for relation in client_relations:
+                for data in relation.data.values():
+                    if data.get("database") == database:
+                        relations_accessing_this_database += 1
             with self._connect_to_database(database=database) as conn:
                 with conn.cursor() as curs:
-                    statements = []
                     curs.execute(
                         "SELECT schema_name FROM information_schema.schemata WHERE schema_name NOT LIKE 'pg_%' and schema_name <> 'information_schema';"
                     )
-                    for row in curs:
-                        schema = sql.Identifier(row[0])
-                        statements.append(
-                            sql.SQL(
-                                "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA {} TO {};"
-                            ).format(schema, sql.Identifier(user))
-                        )
-                        statements.append(
-                            sql.SQL(
-                                "GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA {} TO {};"
-                            ).format(schema, sql.Identifier(user))
-                        )
-                        statements.append(
-                            sql.SQL(
-                                "GRANT ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA {} TO {};"
-                            ).format(schema, sql.Identifier(user))
-                        )
+                    schemas = [row[0] for row in curs.fetchall()]
+                    statements = self._generate_database_privileges_statements(
+                        relations_accessing_this_database, schemas, user
+                    )
                     for statement in statements:
                         curs.execute(statement)
         except psycopg2.Error as e:
@@ -307,6 +307,55 @@ class PostgreSQL:
         finally:
             if connection is not None:
                 connection.close()
+
+    def _generate_database_privileges_statements(
+        self, relations_accessing_this_database: int, schemas: List[str], user: str
+    ) -> List[Composed]:
+        """Generates a list of databases privileges statements."""
+        statements = []
+        if relations_accessing_this_database == 1:
+            statements.append(
+                sql.SQL(
+                    """DO $$
+DECLARE r RECORD;
+BEGIN
+  FOR r IN (SELECT statement FROM (SELECT 1 AS index,'ALTER TABLE '|| schemaname || '."' || tablename ||'" OWNER TO {};' AS statement
+FROM pg_tables WHERE NOT schemaname IN ('pg_catalog', 'information_schema')
+UNION SELECT 2 AS index,'ALTER SEQUENCE '|| sequence_schema || '."' || sequence_name ||'" OWNER TO {};' AS statement
+FROM information_schema.sequences WHERE NOT sequence_schema IN ('pg_catalog', 'information_schema')
+UNION SELECT 3 AS index,'ALTER FUNCTION '|| nsp.nspname || '."' || p.proname ||'"('||pg_get_function_identity_arguments(p.oid)||') OWNER TO {};' AS statement
+FROM pg_proc p JOIN pg_namespace nsp ON p.pronamespace = nsp.oid WHERE NOT nsp.nspname IN ('pg_catalog', 'information_schema')
+UNION SELECT 4 AS index,'ALTER VIEW '|| schemaname || '."' || viewname ||'" OWNER TO {};' AS statement
+FROM pg_catalog.pg_views WHERE NOT schemaname IN ('pg_catalog', 'information_schema')) AS statements ORDER BY index) LOOP
+      EXECUTE format(r.statement);
+  END LOOP;
+END; $$;"""
+                ).format(
+                    sql.Identifier(user),
+                    sql.Identifier(user),
+                    sql.Identifier(user),
+                    sql.Identifier(user),
+                )
+            )
+        else:
+            for schema in schemas:
+                schema = sql.Identifier(schema)
+                statements.append(
+                    sql.SQL("GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA {} TO {};").format(
+                        schema, sql.Identifier(user)
+                    )
+                )
+                statements.append(
+                    sql.SQL("GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA {} TO {};").format(
+                        schema, sql.Identifier(user)
+                    )
+                )
+                statements.append(
+                    sql.SQL("GRANT ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA {} TO {};").format(
+                        schema, sql.Identifier(user)
+                    )
+                )
+        return statements
 
     def get_postgresql_text_search_configs(self) -> Set[str]:
         """Returns the PostgreSQL available text search configs.

--- a/src/charm.py
+++ b/src/charm.py
@@ -1479,6 +1479,15 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
 
         return 0
 
+    @property
+    def client_relations(self) -> List[Relation]:
+        """Return the list of established client relations."""
+        relations = []
+        for relation_name in ["database", "db", "db-admin"]:
+            for relation in self.model.relations.get(relation_name, []):
+                relations.append(relation)
+        return relations
+
 
 if __name__ == "__main__":
     main(PostgresqlOperatorCharm)

--- a/src/relations/db.py
+++ b/src/relations/db.py
@@ -174,7 +174,9 @@ class DbProvides(Object):
                 if self.charm.config[plugin]
             ]
 
-            self.charm.postgresql.create_database(database, user, plugins=plugins)
+            self.charm.postgresql.create_database(
+                database, user, plugins=plugins, client_relations=self.charm.client_relations
+            )
 
         except (PostgreSQLCreateDatabaseError, PostgreSQLCreateUserError) as e:
             logger.exception(e)

--- a/src/relations/postgresql_provider.py
+++ b/src/relations/postgresql_provider.py
@@ -90,7 +90,9 @@ class PostgreSQLProvider(Object):
                 if self.charm.config[plugin]
             ]
 
-            self.charm.postgresql.create_database(database, user, plugins=plugins)
+            self.charm.postgresql.create_database(
+                database, user, plugins=plugins, client_relations=self.charm.client_relations
+            )
 
             # Share the credentials with the application.
             self.database_provides.set_credentials(event.relation.id, user, password)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1538,3 +1538,18 @@ class TestCharm(unittest.TestCase):
         harness = Harness(PostgresqlOperatorCharm)
         harness.begin()
         _topology_observer.assert_called_once_with(harness.charm, "/usr/bin/juju-exec")
+
+    def test_client_relations(self):
+        # Test when the charm has no relations.
+        self.assertEqual(self.charm.client_relations, [])
+
+        # Test when the charm has some relations.
+        self.harness.add_relation("database", "application")
+        self.harness.add_relation("db", "legacy-application")
+        self.harness.add_relation("db-admin", "legacy-admin-application")
+        database_relation = self.harness.model.get_relation("database")
+        db_relation = self.harness.model.get_relation("db")
+        db_admin_relation = self.harness.model.get_relation("db-admin")
+        self.assertEqual(
+            self.charm.client_relations, [database_relation, db_relation, db_admin_relation]
+        )

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -235,7 +235,9 @@ class TestDbProvides(unittest.TestCase):
             self.assertTrue(self.harness.charm.legacy_db_relation.set_up_relation(relation))
             user = f"relation-{self.rel_id}"
             postgresql_mock.create_user.assert_called_once_with(user, "test-password", False)
-            postgresql_mock.create_database.assert_called_once_with(DATABASE, user, plugins=[])
+            postgresql_mock.create_database.assert_called_once_with(
+                DATABASE, user, plugins=[], client_relations=[relation]
+            )
             _update_endpoints.assert_called_once()
             _update_unit_status.assert_called_once()
             self.assertNotIsInstance(self.harness.model.unit.status, BlockedStatus)
@@ -260,7 +262,9 @@ class TestDbProvides(unittest.TestCase):
                 )
             self.assertTrue(self.harness.charm.legacy_db_relation.set_up_relation(relation))
             postgresql_mock.create_user.assert_called_once_with(user, "test-password", False)
-            postgresql_mock.create_database.assert_called_once_with(DATABASE, user, plugins=[])
+            postgresql_mock.create_database.assert_called_once_with(
+                DATABASE, user, plugins=[], client_relations=[relation]
+            )
             _update_endpoints.assert_called_once()
             _update_unit_status.assert_called_once()
             self.assertNotIsInstance(self.harness.model.unit.status, BlockedStatus)
@@ -280,7 +284,7 @@ class TestDbProvides(unittest.TestCase):
             self.assertTrue(self.harness.charm.legacy_db_relation.set_up_relation(relation))
             postgresql_mock.create_user.assert_called_once_with(user, "test-password", False)
             postgresql_mock.create_database.assert_called_once_with(
-                "application", user, plugins=[]
+                "application", user, plugins=[], client_relations=[relation]
             )
             _update_endpoints.assert_called_once()
             _update_unit_status.assert_called_once()

--- a/tests/unit/test_postgresql_provider.py
+++ b/tests/unit/test_postgresql_provider.py
@@ -124,7 +124,11 @@ class TestPostgreSQLProvider(unittest.TestCase):
             postgresql_mock.create_user.assert_called_once_with(
                 user, "test-password", extra_user_roles=EXTRA_USER_ROLES
             )
-            postgresql_mock.create_database.assert_called_once_with(DATABASE, user, plugins=[])
+            database_relation = self.harness.model.get_relation(RELATION_NAME)
+            client_relations = [database_relation]
+            postgresql_mock.create_database.assert_called_once_with(
+                DATABASE, user, plugins=[], client_relations=client_relations
+            )
             postgresql_mock.get_postgresql_version.assert_called_once()
             _update_endpoints.assert_called_once()
 


### PR DESCRIPTION
## Issue
Some charms like Discourse-K8S need to have the ownership of the tables and other objects in a database to correctly run its migrations if a database from a previous Discourse installation is used, otherwise it will not complete the migrations and will throw an error. Also, the existing Discourse K8S test was marked as `unstable` in the past because that charm was migrated from the legacy to the modern relation interface.

## Solution
This is a port of https://github.com/canonical/postgresql-k8s-operator/pull/334.
`lib/charms/postgresql_k8s/v0/postgresql.py` is copied from the K8S charm.

If the relation between PostgreSQL and Discourse K8S (or any other charm), continue with the same behaviour, but after another instance of the charm is related to the PostgreSQL again, requesting the same database, check if there is no other application related and that previously requested the same database. If so, change the ownership of the objects in the database to the new user created for this relation. If there is already another application related to this database, just give permission to the database object, as we are already doing.

I manually tested these changes in a cross-model relation between this charm and Discourse-K8S.