### PR TITLE
fix: secret tests must only set app secrets as the leader

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1732,7 +1732,12 @@ class TestCharm(unittest.TestCase):
         assert self.harness.charm.get_secret(scope, "operator-password") == "bla"
 
         # Reset new secret
+        # Only the leader can set app secret content.
+        with self.harness.hooks_disabled():
+            self.harness.set_leader(True)
         self.harness.charm.set_secret(scope, "operator-password", "blablabla")
+        with self.harness.hooks_disabled():
+            self.harness.set_leader(is_leader)
         assert self.harness.charm.model.get_secret(label=f"postgresql.{scope}")
         assert self.harness.charm.get_secret(scope, "operator-password") == "blablabla"
         assert SECRET_INTERNAL_LABEL not in self.harness.get_relation_data(


### PR DESCRIPTION
With Juju secrets [only the leader unit has admin access to app secrets](https://discourse.charmhub.io/t/secret-access-permissions/12627), and ops 2.9 and above enforce this in `Harness` to match the Juju behaviour.

One test (`test_migration_from_single_secret`) currently does a `set_secret` call (via the charm's `set_secret method) when acting as a non-leader unit. This would not work in production, and fails in ops 2.9.

The PR simply calls `set_leader()` appropriately around the `set_secret` call, so that the rest of the test (in all three parameterised versions) remain unchanged.