### PR TITLE
[MISC] Update snap due to outdated packages

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -32,7 +32,7 @@ SYSTEM_USERS = [BACKUP_USER, REPLICATION_USER, REWIND_USER, USER, MONITORING_USE
 # Snap constants.
 PGBACKREST_EXECUTABLE = "charmed-postgresql.pgbackrest"
 POSTGRESQL_SNAP_NAME = "charmed-postgresql"
-SNAP_PACKAGES = [(POSTGRESQL_SNAP_NAME, {"revision": "96"})]
+SNAP_PACKAGES = [(POSTGRESQL_SNAP_NAME, {"revision": "98"})]
 
 SNAP_COMMON_PATH = "/var/snap/charmed-postgresql/common"
 SNAP_CURRENT_PATH = "/var/snap/charmed-postgresql/current"


### PR DESCRIPTION
Outdated packages:
````
Revision r96 (amd64; channels: 14/edge)
 * libldap-2.5-0: 6616-1
 * libmysqlclient21: 6615-1
````