### PR TITLE
[DPE-3544] Fix large objects ownership

### DIFF
--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -35,7 +35,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 22
+LIBPATCH = 23
 
 INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE = "invalid role(s) for extra user roles"
 
@@ -353,6 +353,13 @@ END; $$;"""
                     sql.Identifier(user),
                     sql.Identifier(user),
                     sql.Identifier(user),
+                )
+            )
+            statements.append(
+                """UPDATE pg_catalog.pg_largeobject_metadata
+SET lomowner = (SELECT oid FROM pg_roles WHERE rolname = '{}')
+WHERE lomowner = (SELECT oid FROM pg_roles WHERE rolname = '{}');""".format(
+                    user, self.user
                 )
             )
         else:

--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -35,7 +35,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 23
+LIBPATCH = 24
 
 INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE = "invalid role(s) for extra user roles"
 
@@ -579,15 +579,20 @@ WHERE lomowner = (SELECT oid FROM pg_roles WHERE rolname = '{}');""".format(
             if parameter in ["date_style", "time_zone"]:
                 parameter = "".join(x.capitalize() for x in parameter.split("_"))
             parameters[parameter] = value
-        shared_buffers_max_value = int(int(available_memory * 0.4) / 10**6)
+        shared_buffers_max_value_in_mb = int(available_memory * 0.4 / 10**6)
+        shared_buffers_max_value = int(shared_buffers_max_value_in_mb * 10**3 / 8)
         if parameters.get("shared_buffers", 0) > shared_buffers_max_value:
             raise Exception(
-                f"Shared buffers config option should be at most 40% of the available memory, which is {shared_buffers_max_value}MB"
+                f"Shared buffers config option should be at most 40% of the available memory, which is {shared_buffers_max_value_in_mb}MB"
             )
         if profile == "production":
-            # Use 25% of the available memory for shared_buffers.
-            # and the remaining as cache memory.
-            shared_buffers = int(available_memory * 0.25)
+            if "shared_buffers" in parameters:
+                # Convert to bytes to use in the calculation.
+                shared_buffers = parameters["shared_buffers"] * 8 * 10**3
+            else:
+                # Use 25% of the available memory for shared_buffers.
+                # and the remaining as cache memory.
+                shared_buffers = int(available_memory * 0.25)
             effective_cache_size = int(available_memory - shared_buffers)
             parameters.setdefault("shared_buffers", f"{int(shared_buffers/10**6)}MB")
             parameters.update({"effective_cache_size": f"{int(effective_cache_size/10**6)}MB"})


### PR DESCRIPTION
## Issue
If we relate a charm like the MAAS operator to the PostgreSQL operator, remove the relation and relate again, then MAAS doesn't have access to the previously created PostgreSQL large objects.

https://github.com/canonical/postgresql-operator/issues/348

## Solution
When a charm is related again to the PostgreSQL operator, give the ownership of the existing large objects to that charm user, as we already do for tables and other objects.