### PR TITLE
[DPE-3591] Fix shared buffers validation

### DIFF
--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -579,9 +579,13 @@ END; $$;"""
                 f"Shared buffers config option should be at most 40% of the available memory, which is {shared_buffers_max_value_in_mb}MB"
             )
         if profile == "production":
-            # Use 25% of the available memory for shared_buffers.
-            # and the remaining as cache memory.
-            shared_buffers = int(available_memory * 0.25)
+            if "shared_buffers" in parameters:
+                # Convert to bytes to use in the calculation.
+                shared_buffers = parameters["shared_buffers"] * 8 * 10**3
+            else:
+                # Use 25% of the available memory for shared_buffers.
+                # and the remaining as cache memory.
+                shared_buffers = int(available_memory * 0.25)
             effective_cache_size = int(available_memory - shared_buffers)
             parameters.setdefault("shared_buffers", f"{int(shared_buffers/10**6)}MB")
             parameters.update({"effective_cache_size": f"{int(effective_cache_size/10**6)}MB"})

--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -35,7 +35,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 22
+LIBPATCH = 23
 
 INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE = "invalid role(s) for extra user roles"
 
@@ -572,10 +572,11 @@ END; $$;"""
             if parameter in ["date_style", "time_zone"]:
                 parameter = "".join(x.capitalize() for x in parameter.split("_"))
             parameters[parameter] = value
-        shared_buffers_max_value = int(int(available_memory * 0.4) / 10**6)
+        shared_buffers_max_value_in_mb = int(available_memory * 0.4 / 10**6)
+        shared_buffers_max_value = int(shared_buffers_max_value_in_mb * 10**3 / 8)
         if parameters.get("shared_buffers", 0) > shared_buffers_max_value:
             raise Exception(
-                f"Shared buffers config option should be at most 40% of the available memory, which is {shared_buffers_max_value}MB"
+                f"Shared buffers config option should be at most 40% of the available memory, which is {shared_buffers_max_value_in_mb}MB"
             )
         if profile == "production":
             # Use 25% of the available memory for shared_buffers.

--- a/src/charm.py
+++ b/src/charm.py
@@ -8,7 +8,6 @@ import logging
 import os
 import platform
 import subprocess
-import time
 from typing import Dict, List, Literal, Optional, Set, get_args
 
 from charms.data_platform_libs.v0.data_interfaces import DataPeer, DataPeerUnit
@@ -44,7 +43,7 @@ from ops.model import (
     Unit,
     WaitingStatus,
 )
-from tenacity import RetryError, Retrying, retry, stop_after_delay, wait_fixed
+from tenacity import RetryError, Retrying, retry, stop_after_attempt, stop_after_delay, wait_fixed
 
 from backups import PostgreSQLBackups
 from cluster import (
@@ -1436,20 +1435,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             }
         )
 
-        restart_postgresql = self.is_tls_enabled != self.postgresql.is_tls_enabled()
-        self._patroni.reload_patroni_configuration()
-        # Sleep the same time as Patroni's loop_wait default value, which tells how much time
-        # Patroni will wait before checking the configuration file again to reload it.
-        time.sleep(10)
-        restart_postgresql = restart_postgresql or self.postgresql.is_restart_pending()
-        self.unit_peer_data.update({"tls": "enabled" if enable_tls else ""})
-
-        # Restart PostgreSQL if TLS configuration has changed
-        # (so the both old and new connections use the configuration).
-        if restart_postgresql:
-            logger.info("PostgreSQL restart required")
-            self._peers.data[self.unit].pop("postgresql_restarted", None)
-            self.on[self.restart_manager.name].acquire_lock.emit()
+        self._handle_postgresql_restart_need(enable_tls)
 
         # Restart the monitoring service if the password was rotated
         cache = snap.SnapCache()
@@ -1488,6 +1474,31 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             and self.config.request_time_zone not in self.postgresql.get_postgresql_timezones()
         ):
             raise Exception("request_time_zone config option has an invalid value")
+
+    def _handle_postgresql_restart_need(self, enable_tls: bool) -> None:
+        """Handle PostgreSQL restart need based on the TLS configuration and configuration changes."""
+        restart_postgresql = self.is_tls_enabled != self.postgresql.is_tls_enabled()
+        self._patroni.reload_patroni_configuration()
+        # Wait for some more time than the Patroni's loop_wait default value (10 seconds),
+        # which tells how much time Patroni will wait before checking the configuration
+        # file again to reload it.
+        try:
+            for attempt in Retrying(stop=stop_after_attempt(5), wait=wait_fixed(3)):
+                with attempt:
+                    restart_postgresql = restart_postgresql or self.postgresql.is_restart_pending()
+                    if not restart_postgresql:
+                        raise Exception
+        except RetryError:
+            # Ignore the error, as it happens only to indicate that the configuration has not changed.
+            pass
+        self.unit_peer_data.update({"tls": "enabled" if enable_tls else ""})
+
+        # Restart PostgreSQL if TLS configuration has changed
+        # (so the both old and new connections use the configuration).
+        if restart_postgresql:
+            logger.info("PostgreSQL restart required")
+            self._peers.data[self.unit].pop("postgresql_restarted", None)
+            self.on[self.restart_manager.name].acquire_lock.emit()
 
     def _update_relation_endpoints(self) -> None:
         """Updates endpoints and read-only endpoint in all relations."""

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -819,7 +819,7 @@ async def add_unit_with_storage(ops_test, app, storage):
     return_code, _, _ = await ops_test.juju(*add_unit_cmd)
     assert return_code == 0, "Failed to add unit with storage"
     async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(apps=[app], status="active", timeout=1500)
+        await ops_test.model.wait_for_idle(apps=[app], status="active", timeout=2000)
     assert (
         len(ops_test.model.applications[app].units) == expected_units
     ), "New unit not added to model"

--- a/tests/integration/ha_tests/test_replication.py
+++ b/tests/integration/ha_tests/test_replication.py
@@ -18,7 +18,6 @@ from .helpers import (
 )
 
 
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest) -> None:

--- a/tests/integration/ha_tests/test_restore_cluster.py
+++ b/tests/integration/ha_tests/test_restore_cluster.py
@@ -29,7 +29,6 @@ logger = logging.getLogger(__name__)
 charm = None
 
 
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest) -> None:

--- a/tests/integration/ha_tests/test_self_healing.py
+++ b/tests/integration/ha_tests/test_self_healing.py
@@ -60,7 +60,6 @@ POSTGRESQL_PROCESS = "postgres"
 DB_PROCESSES = [POSTGRESQL_PROCESS, PATRONI_PROCESS]
 
 
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest) -> None:

--- a/tests/integration/ha_tests/test_upgrade.py
+++ b/tests/integration/ha_tests/test_upgrade.py
@@ -30,7 +30,6 @@ logger = logging.getLogger(__name__)
 TIMEOUT = 600
 
 
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_deploy_latest(ops_test: OpsTest) -> None:

--- a/tests/integration/ha_tests/test_upgrade_from_stable.py
+++ b/tests/integration/ha_tests/test_upgrade_from_stable.py
@@ -25,7 +25,6 @@ logger = logging.getLogger(__name__)
 TIMEOUT = 600
 
 
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_deploy_stable(ops_test: OpsTest) -> None:

--- a/tests/integration/new_relations/test_new_relations.py
+++ b/tests/integration/new_relations/test_new_relations.py
@@ -36,7 +36,6 @@ NO_DATABASE_RELATION_NAME = "no-database"
 INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE = "invalid role(s) for extra user roles"
 
 
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_deploy_charms(ops_test: OpsTest, charm):

--- a/tests/integration/test_backups.py
+++ b/tests/integration/test_backups.py
@@ -90,7 +90,6 @@ async def cloud_configs(ops_test: OpsTest, github_secrets) -> None:
             bucket_object.delete()
 
 
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 async def test_none() -> None:
     """Empty test so that the suite will not fail if all tests are skippedi."""

--- a/tests/integration/test_backups.py
+++ b/tests/integration/test_backups.py
@@ -132,7 +132,7 @@ async def test_backup(ops_test: OpsTest, cloud_configs: Tuple[Dict, Dict]) -> No
         await action.wait()
         async with ops_test.fast_forward(fast_interval="60s"):
             await ops_test.model.wait_for_idle(
-                apps=[database_app_name, S3_INTEGRATOR_APP_NAME], status="active", timeout=1000
+                apps=[database_app_name, S3_INTEGRATOR_APP_NAME], status="active", timeout=1200
             )
 
         primary = await get_primary(ops_test, f"{database_app_name}/0")

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -32,7 +32,6 @@ logger = logging.getLogger(__name__)
 UNIT_IDS = [0, 1, 2]
 
 
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 @pytest.mark.skip_if_deployed

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -313,7 +313,7 @@ async def test_persist_data_through_primary_deletion(ops_test: OpsTest):
 
     # Add the unit again.
     await ops_test.model.applications[DATABASE_APP_NAME].add_unit(count=1)
-    await ops_test.model.wait_for_idle(apps=[DATABASE_APP_NAME], status="active", timeout=1500)
+    await ops_test.model.wait_for_idle(apps=[DATABASE_APP_NAME], status="active", timeout=2000)
 
     # Testing write occurred to every postgres instance by reading from them
     for unit in ops_test.model.applications[DATABASE_APP_NAME].units:

--- a/tests/integration/test_db.py
+++ b/tests/integration/test_db.py
@@ -39,7 +39,6 @@ ROLES_BLOCKING_MESSAGE = (
 )
 
 
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 async def test_mailman3_core_db(ops_test: OpsTest, charm: str) -> None:
     """Deploy Mailman3 Core to test the 'db' relation."""

--- a/tests/integration/test_db_admin.py
+++ b/tests/integration/test_db_admin.py
@@ -34,7 +34,6 @@ RELATION_NAME = "db-admin"
 
 
 @pytest.mark.group(1)
-@pytest.mark.skip(reason="DB Admin tests are currently broken")
 async def test_landscape_scalable_bundle_db(ops_test: OpsTest, charm: str) -> None:
     """Deploy Landscape Scalable Bundle to test the 'db-admin' relation."""
     await ops_test.model.deploy(

--- a/tests/integration/test_db_admin.py
+++ b/tests/integration/test_db_admin.py
@@ -33,7 +33,6 @@ DATABASE_UNITS = 3
 RELATION_NAME = "db-admin"
 
 
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.skip(reason="DB Admin tests are currently broken")
 async def test_landscape_scalable_bundle_db(ops_test: OpsTest, charm: str) -> None:

--- a/tests/integration/test_password_rotation.py
+++ b/tests/integration/test_password_rotation.py
@@ -21,7 +21,6 @@ from .helpers import (
 APP_NAME = METADATA["name"]
 
 
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 @pytest.mark.skip_if_deployed

--- a/tests/integration/test_plugins.py
+++ b/tests/integration/test_plugins.py
@@ -85,7 +85,6 @@ VECTOR_EXTENSION_STATEMENT = (
 )
 
 
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_plugins(ops_test: OpsTest) -> None:

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -38,7 +38,6 @@ else:
     TLS_CONFIG = {"ca-common-name": "Test CA"}
 
 
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 @pytest.mark.skip_if_deployed

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -24,7 +24,7 @@ from ops.model import (
 )
 from ops.testing import Harness
 from parameterized import parameterized
-from tenacity import RetryError
+from tenacity import RetryError, wait_fixed
 
 from charm import EXTENSIONS_DEPENDENCY_MESSAGE, NO_PRIMARY_MESSAGE, PostgresqlOperatorCharm
 from cluster import RemoveRaftMemberFailedError
@@ -1132,24 +1132,22 @@ class TestCharm(unittest.TestCase):
     @patch_network_get(private_address="1.1.1.1")
     @patch("subprocess.check_output", return_value=b"C")
     @patch("charm.snap.SnapCache")
-    @patch("charms.rolling_ops.v0.rollingops.RollingOpsManager._on_acquire_lock")
-    @patch("charm.Patroni.reload_patroni_configuration")
+    @patch("charm.PostgresqlOperatorCharm._handle_postgresql_restart_need")
     @patch("charm.Patroni.bulk_update_parameters_controller_by_patroni")
     @patch("charm.PostgresqlOperatorCharm._validate_config_options")
     @patch("charm.Patroni.member_started", new_callable=PropertyMock)
     @patch("charm.PostgresqlOperatorCharm._is_workload_running", new_callable=PropertyMock)
     @patch("charm.Patroni.render_patroni_yml_file")
-    @patch("charms.postgresql_k8s.v0.postgresql_tls.PostgreSQLTLS.get_tls_files")
+    @patch("charm.PostgresqlOperatorCharm.is_tls_enabled", new_callable=PropertyMock)
     def test_update_config(
         self,
-        _get_tls_files,
+        _is_tls_enabled,
         _render_patroni_yml_file,
         _is_workload_running,
         _member_started,
         _,
         __,
-        _reload_patroni_configuration,
-        _restart,
+        _handle_postgresql_restart_need,
         ___,
         ____,
     ):
@@ -1178,10 +1176,9 @@ class TestCharm(unittest.TestCase):
 
             # Test without TLS files available.
             self.harness.update_config(unset={"profile-limit-memory", "profile_limit_memory"})
-            self.harness.update_relation_data(
-                self.rel_id, self.charm.unit.name, {"tls": "enabled"}
-            )  # Mock some data in the relation to test that it change.
-            _get_tls_files.return_value = [None]
+            with self.harness.hooks_disabled():
+                self.harness.update_relation_data(self.rel_id, self.charm.unit.name, {"tls": ""})
+            _is_tls_enabled.return_value = False
             self.charm.update_config()
             _render_patroni_yml_file.assert_called_once_with(
                 connectivity=True,
@@ -1192,20 +1189,18 @@ class TestCharm(unittest.TestCase):
                 restore_stanza=None,
                 parameters={"test": "test"},
             )
-            _reload_patroni_configuration.assert_called_once()
-            _restart.assert_called_once()
+            _handle_postgresql_restart_need.assert_called_once_with(False)
             self.assertNotIn(
                 "tls", self.harness.get_relation_data(self.rel_id, self.charm.unit.name)
             )
 
             # Test with TLS files available.
-            _restart.reset_mock()
+            _handle_postgresql_restart_need.reset_mock()
             self.harness.update_relation_data(
                 self.rel_id, self.charm.unit.name, {"tls": ""}
             )  # Mock some data in the relation to test that it change.
-            _get_tls_files.return_value = ["something"]
+            _is_tls_enabled.return_value = True
             _render_patroni_yml_file.reset_mock()
-            _reload_patroni_configuration.reset_mock()
             self.charm.update_config()
             _render_patroni_yml_file.assert_called_once_with(
                 connectivity=True,
@@ -1216,20 +1211,21 @@ class TestCharm(unittest.TestCase):
                 restore_stanza=None,
                 parameters={"test": "test"},
             )
-            _reload_patroni_configuration.assert_called_once()
-            _restart.assert_called_once()
-            self.assertEqual(
-                self.harness.get_relation_data(self.rel_id, self.charm.unit.name)["tls"], "enabled"
+            _handle_postgresql_restart_need.assert_called_once()
+            self.assertNotIn(
+                "tls",
+                self.harness.get_relation_data(
+                    self.rel_id, self.charm.unit.name
+                ),  # The "tls" flag is set in handle_postgresql_restart_need.
             )
 
             # Test with workload not running yet.
             self.harness.update_relation_data(
                 self.rel_id, self.charm.unit.name, {"tls": ""}
             )  # Mock some data in the relation to test that it change.
-            _reload_patroni_configuration.reset_mock()
+            _handle_postgresql_restart_need.reset_mock()
             self.charm.update_config()
-            _reload_patroni_configuration.assert_not_called()
-            _restart.assert_called_once()
+            _handle_postgresql_restart_need.assert_not_called()
             self.assertEqual(
                 self.harness.get_relation_data(self.rel_id, self.charm.unit.name)["tls"], "enabled"
             )
@@ -1239,8 +1235,7 @@ class TestCharm(unittest.TestCase):
                 self.rel_id, self.charm.unit.name, {"tls": ""}
             )  # Mock some data in the relation to test that it doesn't change.
             self.charm.update_config()
-            _reload_patroni_configuration.assert_not_called()
-            _restart.assert_called_once()
+            _handle_postgresql_restart_need.assert_not_called()
             self.assertNotIn(
                 "tls", self.harness.get_relation_data(self.rel_id, self.charm.unit.name)
             )
@@ -1934,3 +1929,52 @@ class TestCharm(unittest.TestCase):
         assert SECRET_INTERNAL_LABEL not in self.harness.get_relation_data(
             self.rel_id, getattr(self.charm, scope).name
         )
+
+    @patch("charms.rolling_ops.v0.rollingops.RollingOpsManager._on_acquire_lock")
+    @patch("charm.wait_fixed", return_value=wait_fixed(0))
+    @patch("charm.Patroni.reload_patroni_configuration")
+    @patch("charm.PostgresqlOperatorCharm._unit_ip")
+    @patch("charm.PostgresqlOperatorCharm.is_tls_enabled", new_callable=PropertyMock)
+    def test_handle_postgresql_restart_need(
+        self, _is_tls_enabled, _, _reload_patroni_configuration, __, _restart
+    ):
+        with patch.object(PostgresqlOperatorCharm, "postgresql", Mock()) as postgresql_mock:
+            for values in itertools.product(
+                [True, False], [True, False], [True, False], [True, False], [True, False]
+            ):
+                _restart.reset_mock()
+                with self.harness.hooks_disabled():
+                    self.harness.update_relation_data(
+                        self.rel_id, self.charm.unit.name, {"tls": ""}
+                    )
+                    self.harness.update_relation_data(
+                        self.rel_id,
+                        self.charm.unit.name,
+                        {"postgresql_restarted": ("True" if values[4] else "")},
+                    )
+
+                _is_tls_enabled.return_value = values[1]
+                postgresql_mock.is_tls_enabled = PropertyMock(return_value=values[2])
+                postgresql_mock.is_restart_pending = PropertyMock(return_value=values[3])
+
+                self.charm._handle_postgresql_restart_need(values[0])
+                self.assertIn(
+                    "tls", self.harness.get_relation_data(self.rel_id, self.charm.unit)
+                ) if values[0] else self.assertNotIn(
+                    "tls", self.harness.get_relation_data(self.rel_id, self.charm.unit)
+                )
+                if (values[1] != values[2]) or values[3]:
+                    self.assertNotIn(
+                        "postgresql_restarted",
+                        self.harness.get_relation_data(self.rel_id, self.charm.unit),
+                    )
+                    _restart.assert_called_once()
+                else:
+                    self.assertIn(
+                        "postgresql_restarted",
+                        self.harness.get_relation_data(self.rel_id, self.charm.unit),
+                    ) if values[4] else self.assertNotIn(
+                        "postgresql_restarted",
+                        self.harness.get_relation_data(self.rel_id, self.charm.unit),
+                    )
+                    _restart.assert_not_called()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1942,6 +1942,7 @@ class TestCharm(unittest.TestCase):
             for values in itertools.product(
                 [True, False], [True, False], [True, False], [True, False], [True, False]
             ):
+                _reload_patroni_configuration.reset_mock()
                 _restart.reset_mock()
                 with self.harness.hooks_disabled():
                     self.harness.update_relation_data(
@@ -1958,6 +1959,7 @@ class TestCharm(unittest.TestCase):
                 postgresql_mock.is_restart_pending = PropertyMock(return_value=values[3])
 
                 self.charm._handle_postgresql_restart_need(values[0])
+                _reload_patroni_configuration.assert_called_once()
                 self.assertIn(
                     "tls", self.harness.get_relation_data(self.rel_id, self.charm.unit)
                 ) if values[0] else self.assertNotIn(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1130,7 +1130,6 @@ class TestCharm(unittest.TestCase):
         mock_event.defer.assert_not_called()
 
     @patch_network_get(private_address="1.1.1.1")
-    @patch("charm.time.sleep", return_value=None)
     @patch("subprocess.check_output", return_value=b"C")
     @patch("charm.snap.SnapCache")
     @patch("charms.rolling_ops.v0.rollingops.RollingOpsManager._on_acquire_lock")
@@ -1153,7 +1152,6 @@ class TestCharm(unittest.TestCase):
         _restart,
         ___,
         ____,
-        _____,
     ):
         with patch.object(PostgresqlOperatorCharm, "postgresql", Mock()) as postgresql_mock:
             # Mock some properties.


### PR DESCRIPTION
## Issue
The validation for the `shared_buffers` parameter was not correct. The calculus of the maximum allowed shared buffers value was not correctly converting the available memory for that to the same unit as the `shared_buffers` parameter that the user informs.

Also, the `effective_cache_size` parameter did not consider the user-provided `shared_buffers` value.

One last issue: sometimes, the restart of the PostgreSQL database was not triggered because Patroni hadn't finished reloading the configuration (even after 10 seconds).

## Solution
Fix the calculus of the maximum allowed shared buffers value to be in the same unit as the user-provided value.

Considered the user-provided shared buffers value for the effective cache size parameter calculus.

An improved retry mechanism was added to check whether a restart is needed after a configuration change.

Unit tests for the library file are being updated to the [K8S charm](https://github.com/canonical/postgresql-k8s-operator/pull/396), which owns the library.