### PR TITLE
[DPE-3570] Save one min on charm deploy (by skipping _on_upgrade_charm_check_legacy() on early stage)

### DIFF
--- a/src/upgrade.py
+++ b/src/upgrade.py
@@ -115,8 +115,10 @@ class PostgreSQLUpgrade(DataUpgrade):
 
         peers_state = list(filter(lambda state: state != "", self.unit_states))
 
-        if len(peers_state) == len(self.peer_relation.units) and (
-            set(peers_state) == {"ready"} or len(peers_state) == 0
+        if (
+            len(peers_state) == len(self.peer_relation.units)
+            and (set(peers_state) == {"ready"} or len(peers_state) == 0)
+            and self.charm.is_cluster_initialised
         ):
             if self.charm._patroni.member_started:
                 # All peers have set the state to ready


### PR DESCRIPTION
Issue:
* the charm was sleeping one minute on deployment waiting for patroni on `install` hook, before patroni is installed.

Solution:
* Avoid waiting for not-yet-started patroni before the cluster is initialized.