### PR TITLE
Removed doc sync workflow badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 [![CharmHub Badge](https://charmhub.io/postgresql/badge.svg)](https://charmhub.io/postgresql)
 [![Release](https://github.com/canonical/postgresql-operator/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/postgresql-operator/actions/workflows/release.yaml)
 [![Tests](https://github.com/canonical/postgresql-operator/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/canonical/postgresql-operator/actions/workflows/ci.yaml?query=branch%3Amain)
-[![Docs](https://github.com/canonical/postgresql-operator/actions/workflows/sync_docs.yaml/badge.svg)](https://github.com/canonical/postgresql-operator/actions/workflows/sync_docs.yaml)
 
 ## Description
 


### PR DESCRIPTION
## Issue
Docs sync workflow is not yet added, so the badge doesn't render.

## Solution
Removing the badge for now, to be added after `discourse-gatekeeper` integration.