### PR TITLE
[DPE-3895] Handle get patroni health exception

### DIFF
--- a/src/cluster.py
+++ b/src/cluster.py
@@ -313,7 +313,7 @@ class Patroni:
                     timeout=API_REQUEST_TIMEOUT,
                 )
 
-        return r.json()
+                return r.json()
 
     @property
     def is_creating_backup(self) -> bool:


### PR DESCRIPTION
Try to catch the exception in https://github.com/canonical/postgresql-operator/issues/419

There are already handlers for RetryErrors, but we do not try to parse the json response within the tenacity attempt. There may be more underlying issues here, since patroni isn't responding with a valid json.