### PR TITLE
[DPE-3845] Update operator_libs_linux library to version 2.5

### DIFF
--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -83,7 +83,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 
 # Regex to locate 7-bit C1 ANSI sequences
@@ -580,10 +580,17 @@ class Snap(object):
             # We are installing or refreshing a snap.
             if self._state not in (SnapState.Present, SnapState.Latest):
                 # The snap is not installed, so we install it.
+                logger.info(
+                    "Installing snap %s, revision %s, tracking %s", self._name, revision, channel
+                )
                 self._install(channel, cohort, revision)
             else:
                 # The snap is installed, but we are changing it (e.g., switching channels).
+                logger.info(
+                    "Refreshing snap %s, revision %s, tracking %s", self._name, revision, channel
+                )
                 self._refresh(channel=channel, cohort=cohort, revision=revision, devmode=devmode)
+            logger.info("The snap installation completed successfully")
 
         self._update_snap_apps()
         self._state = state


### PR DESCRIPTION
## Motivation
After [this merged PR](https://github.com/canonical/operator-libs-linux/pull/119) we should update our lib version in order to use the new logging feature. 

## Change

`charmcraft fetch-lib charms.operator_libs_linux.v2.snap`