### PR TITLE
[DPE-4336] Reset active status when removing extensions dependency block

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -972,6 +972,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             extensions[extension] = enable
         if self.is_blocked and self.unit.status.message == EXTENSIONS_DEPENDENCY_MESSAGE:
             self.unit.status = ActiveStatus()
+            original_status = self.unit.status
         self.unit.status = WaitingStatus("Updating extensions")
         try:
             self.postgresql.enable_disable_extensions(extensions, database)


### PR DESCRIPTION
The charm should not restore the blocked status if the blocking condition is no longer valid

Related to https://github.com/canonical/postgresql-operator/issues/466