### PR TITLE
[DPE-4401] Add retention time for full backups

### DIFF
--- a/src/backups.py
+++ b/src/backups.py
@@ -832,6 +832,7 @@ Stderr:
             stanza=self.stanza_name,
             storage_path=self.charm._storage_path,
             user=BACKUP_USER,
+            retention_full=s3_parameters["delete-older-than-days"],
         )
         # Render pgBackRest config file.
         self.charm._patroni.render_file(f"{PGBACKREST_CONF_PATH}/pgbackrest.conf", rendered, 0o644)
@@ -866,6 +867,7 @@ Stderr:
         s3_parameters.setdefault("region")
         s3_parameters.setdefault("path", "")
         s3_parameters.setdefault("s3-uri-style", "host")
+        s3_parameters.setdefault("delete-older-than-days", "9999999")
 
         # Strip whitespaces from all parameters.
         for key, value in s3_parameters.items():

--- a/templates/pgbackrest.conf.j2
+++ b/templates/pgbackrest.conf.j2
@@ -2,7 +2,8 @@
 backup-standby=y
 lock-path=/tmp
 log-path={{ log_path }}
-repo1-retention-full=9999999
+repo1-retention-full-type=time
+repo1-retention-full={{ retention_full }}
 repo1-type=s3
 repo1-path={{ path }}
 repo1-s3-region={{ region }}

--- a/tests/unit/test_backups.py
+++ b/tests/unit/test_backups.py
@@ -1453,6 +1453,7 @@ def test_render_pgbackrest_conf_file(harness):
                 "path": "test-path/",
                 "region": "us-east-1",
                 "s3-uri-style": "path",
+                "delete-older-than-days": "30",
             },
             [],
         )
@@ -1476,6 +1477,7 @@ def test_render_pgbackrest_conf_file(harness):
             stanza=harness.charm.backup.stanza_name,
             storage_path=harness.charm._storage_path,
             user="backup",
+            retention_full=30,
         )
 
         # Patch the `open` method with our mock.
@@ -1539,6 +1541,7 @@ def test_retrieve_s3_parameters(harness):
                 {
                     "access-key": "test-access-key",
                     "bucket": "test-bucket",
+                    "delete-older-than-days": "9999999",
                     "endpoint": "https://s3.amazonaws.com",
                     "path": "/",
                     "region": None,
@@ -1558,6 +1561,7 @@ def test_retrieve_s3_parameters(harness):
             "path": " test-path/ ",
             "region": " us-east-1 ",
             "s3-uri-style": " path ",
+            "delete-older-than-days": "30",
         }
         tc.assertEqual(
             harness.charm.backup._retrieve_s3_parameters(),
@@ -1570,6 +1574,7 @@ def test_retrieve_s3_parameters(harness):
                     "region": "us-east-1",
                     "s3-uri-style": "path",
                     "secret-key": "test-secret-key",
+                    "delete-older-than-days": "30",
                 },
                 [],
             ),


### PR DESCRIPTION
## Issue

Link to issue: https://warthogs.atlassian.net/browse/DPE-4401
Link to spec: https://docs.google.com/document/d/1WWMt_Q71cUIrpfYirp5TRCdkJXMjFSWCH6CTnKrO4YA/edit

The parameter `delete-older-than-days` (from s3-integrator) is used to set up retention time (in days) as a pgBackRest parameter, allowing for uses to configure a retention policy for their backups.

## Solution

see K8s version https://github.com/canonical/postgresql-k8s-operator/pull/477