### PR TITLE
[DPE-4416] Fetch charm libs to the latest LIBPATCH (update dp-libs to v36 to fix secrets issue)

### DIFF
--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -331,7 +331,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 34
+LIBPATCH = 36
 
 PYDEPS = ["ops>=2.0.0"]
 
@@ -642,8 +642,8 @@ class CachedSecret:
             return
 
         # Create a new secret with the new label
-        old_meta = self._secret_meta
         content = self._secret_meta.get_content()
+        self._secret_uri = None
 
         # I wish we could just check if we are the owners of the secret...
         try:
@@ -651,7 +651,7 @@ class CachedSecret:
         except ModelError as err:
             if "this unit is not the leader" not in str(err):
                 raise
-        old_meta.remove_all_revisions()
+        self.current_label = None
 
     def set_content(self, content: Dict[str, str]) -> None:
         """Setting cached secret content."""
@@ -1586,7 +1586,7 @@ class RequirerData(Data):
         """
         label = self._generate_secret_label(relation_name, relation_id, group)
 
-        # Fetchin the Secret's meta information ensuring that it's locally getting registered with
+        # Fetching the Secret's meta information ensuring that it's locally getting registered with
         CachedSecret(self._model, self.component, label, secret_id).meta
 
     def _register_secrets_to_relation(self, relation: Relation, params_name_list: List[str]):
@@ -2309,7 +2309,7 @@ class RelationEventWithSecret(RelationEvent):
         return self._cached_secrets
 
     def _get_secret(self, group) -> Optional[Dict[str, str]]:
-        """Retrieveing secrets."""
+        """Retrieving secrets."""
         if not self.app:
             return
         if not self._secrets.get(group):
@@ -3016,7 +3016,7 @@ class KafkaRequiresEvents(CharmEvents):
 # Kafka Provides and Requires
 
 
-class KafkaProvidesData(ProviderData):
+class KafkaProviderData(ProviderData):
     """Provider-side of the Kafka relation."""
 
     def __init__(self, model: Model, relation_name: str) -> None:
@@ -3059,12 +3059,12 @@ class KafkaProvidesData(ProviderData):
         self.update_relation_data(relation_id, {"zookeeper-uris": zookeeper_uris})
 
 
-class KafkaProvidesEventHandlers(EventHandlers):
+class KafkaProviderEventHandlers(EventHandlers):
     """Provider-side of the Kafka relation."""
 
     on = KafkaProvidesEvents()  # pyright: ignore [reportAssignmentType]
 
-    def __init__(self, charm: CharmBase, relation_data: KafkaProvidesData) -> None:
+    def __init__(self, charm: CharmBase, relation_data: KafkaProviderData) -> None:
         super().__init__(charm, relation_data)
         # Just to keep lint quiet, can't resolve inheritance. The same happened in super().__init__() above
         self.relation_data = relation_data
@@ -3086,15 +3086,15 @@ class KafkaProvidesEventHandlers(EventHandlers):
             )
 
 
-class KafkaProvides(KafkaProvidesData, KafkaProvidesEventHandlers):
+class KafkaProvides(KafkaProviderData, KafkaProviderEventHandlers):
     """Provider-side of the Kafka relation."""
 
     def __init__(self, charm: CharmBase, relation_name: str) -> None:
-        KafkaProvidesData.__init__(self, charm.model, relation_name)
-        KafkaProvidesEventHandlers.__init__(self, charm, self)
+        KafkaProviderData.__init__(self, charm.model, relation_name)
+        KafkaProviderEventHandlers.__init__(self, charm, self)
 
 
-class KafkaRequiresData(RequirerData):
+class KafkaRequirerData(RequirerData):
     """Requirer-side of the Kafka relation."""
 
     def __init__(
@@ -3124,12 +3124,12 @@ class KafkaRequiresData(RequirerData):
         self._topic = value
 
 
-class KafkaRequiresEventHandlers(RequirerEventHandlers):
+class KafkaRequirerEventHandlers(RequirerEventHandlers):
     """Requires-side of the Kafka relation."""
 
     on = KafkaRequiresEvents()  # pyright: ignore [reportAssignmentType]
 
-    def __init__(self, charm: CharmBase, relation_data: KafkaRequiresData) -> None:
+    def __init__(self, charm: CharmBase, relation_data: KafkaRequirerData) -> None:
         super().__init__(charm, relation_data)
         # Just to keep lint quiet, can't resolve inheritance. The same happened in super().__init__() above
         self.relation_data = relation_data
@@ -3142,10 +3142,13 @@ class KafkaRequiresEventHandlers(RequirerEventHandlers):
             return
 
         # Sets topic, extra user roles, and "consumer-group-prefix" in the relation
-        relation_data = {
-            f: getattr(self, f.replace("-", "_"), "")
-            for f in ["consumer-group-prefix", "extra-user-roles", "topic"]
-        }
+        relation_data = {"topic": self.relation_data.topic}
+
+        if self.relation_data.extra_user_roles:
+            relation_data["extra-user-roles"] = self.relation_data.extra_user_roles
+
+        if self.relation_data.consumer_group_prefix:
+            relation_data["consumer-group-prefix"] = self.relation_data.consumer_group_prefix
 
         self.relation_data.update_relation_data(event.relation.id, relation_data)
 
@@ -3188,7 +3191,7 @@ class KafkaRequiresEventHandlers(RequirerEventHandlers):
             return
 
 
-class KafkaRequires(KafkaRequiresData, KafkaRequiresEventHandlers):
+class KafkaRequires(KafkaRequirerData, KafkaRequirerEventHandlers):
     """Provider-side of the Kafka relation."""
 
     def __init__(
@@ -3200,7 +3203,7 @@ class KafkaRequires(KafkaRequiresData, KafkaRequiresEventHandlers):
         consumer_group_prefix: Optional[str] = None,
         additional_secret_fields: Optional[List[str]] = [],
     ) -> None:
-        KafkaRequiresData.__init__(
+        KafkaRequirerData.__init__(
             self,
             charm.model,
             relation_name,
@@ -3209,7 +3212,7 @@ class KafkaRequires(KafkaRequiresData, KafkaRequiresEventHandlers):
             consumer_group_prefix,
             additional_secret_fields,
         )
-        KafkaRequiresEventHandlers.__init__(self, charm, self)
+        KafkaRequirerEventHandlers.__init__(self, charm, self)
 
 
 # Opensearch related events

--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -285,7 +285,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 15
+LIBPATCH = 16
 
 PYDEPS = ["pydantic>=1.10,<2", "poetry-core"]
 
@@ -501,7 +501,7 @@ class DataUpgrade(Object, ABC):
 
     STATES = ["recovery", "failed", "idle", "ready", "upgrading", "completed"]
 
-    on = UpgradeEvents()  # pyright: ignore [reportGeneralTypeIssues]
+    on = UpgradeEvents()  # pyright: ignore [reportAssignmentType]
 
     def __init__(
         self,
@@ -605,6 +605,21 @@ class DataUpgrade(Object, ABC):
 
         self.peer_relation.data[self.charm.app].update({"upgrade-stack": json.dumps(stack)})
         self._upgrade_stack = stack
+
+    @property
+    def other_unit_states(self) -> list:
+        """Current upgrade state for other units.
+
+        Returns:
+            Unsorted list of upgrade states for other units.
+        """
+        if not self.peer_relation:
+            return []
+
+        return [
+            self.peer_relation.data[unit].get("state", "")
+            for unit in list(self.peer_relation.units)
+        ]
 
     @property
     def unit_states(self) -> list:
@@ -926,11 +941,8 @@ class DataUpgrade(Object, ABC):
             return
 
         if self.substrate == "vm" and self.cluster_state == "recovery":
-            # Only defer for vm, that will set unit states to "ready" on upgrade-charm
-            # on k8s only the upgrading unit will receive the upgrade-charm event
-            # and deferring will prevent the upgrade stack from being popped
-            logger.debug("Cluster in recovery, deferring...")
-            event.defer()
+            # skip run while in recovery. The event will be retrigged when the cluster is ready
+            logger.debug("Cluster in recovery, skip...")
             return
 
         # if all units completed, mark as complete
@@ -981,6 +993,7 @@ class DataUpgrade(Object, ABC):
             self.charm.unit == top_unit
             and top_state in ["ready", "upgrading"]
             and self.cluster_state == "ready"
+            and "upgrading" not in self.other_unit_states
         ):
             logger.debug(
                 f"{top_unit.name} is next to upgrade, emitting `upgrade_granted` event and upgrading..."

--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -83,7 +83,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 
 # Regex to locate 7-bit C1 ANSI sequences
@@ -584,13 +584,16 @@ class Snap(object):
                     "Installing snap %s, revision %s, tracking %s", self._name, revision, channel
                 )
                 self._install(channel, cohort, revision)
-            else:
+                logger.info("The snap installation completed successfully")
+            elif revision is None or revision != self._revision:
                 # The snap is installed, but we are changing it (e.g., switching channels).
                 logger.info(
                     "Refreshing snap %s, revision %s, tracking %s", self._name, revision, channel
                 )
                 self._refresh(channel=channel, cohort=cohort, revision=revision, devmode=devmode)
-            logger.info("The snap installation completed successfully")
+                logger.info("The snap refresh completed successfully")
+            else:
+                logger.info("Refresh of snap %s was unnecessary", self._name)
 
         self._update_snap_apps()
         self._state = state

--- a/lib/charms/rolling_ops/v0/rollingops.py
+++ b/lib/charms/rolling_ops/v0/rollingops.py
@@ -49,7 +49,7 @@ class SomeCharm(...):
 
 To kick off the rolling restart, emit this library's AcquireLock event. The simplest way
 to do so would be with an action, though it might make sense to acquire the lock in
-response to another event. 
+response to another event.
 
 ```python
     def _on_trigger_restart(self, event):
@@ -88,7 +88,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 7
 
 
 class LockNoRelationError(Exception):
@@ -182,6 +182,7 @@ class Lock:
             # Active acquire request.
             return LockState.ACQUIRE
 
+        logger.debug("Lock state: %s %s", unit_state, app_state)
         return app_state  # Granted or unset/released
 
     @_state.setter
@@ -202,21 +203,27 @@ class Lock:
         if state is LockState.IDLE:
             self.relation.data[self.app].update({str(self.unit): state.value})
 
+        logger.debug("state: %s", state.value)
+
     def acquire(self):
         """Request that a lock be acquired."""
         self._state = LockState.ACQUIRE
+        logger.debug("Lock acquired.")
 
     def release(self):
         """Request that a lock be released."""
         self._state = LockState.RELEASE
+        logger.debug("Lock released.")
 
     def clear(self):
         """Unset a lock."""
         self._state = LockState.IDLE
+        logger.debug("Lock cleared.")
 
     def grant(self):
         """Grant a lock to a unit."""
         self._state = LockState.GRANTED
+        logger.debug("Lock granted.")
 
     def is_held(self):
         """This unit holds the lock."""
@@ -266,9 +273,11 @@ class AcquireLock(EventBase):
         self.callback_override = callback_override or ""
 
     def snapshot(self):
+        """Snapshot of lock event."""
         return {"callback_override": self.callback_override}
 
     def restore(self, snapshot):
+        """Restores lock event."""
         self.callback_override = snapshot["callback_override"]
 
 
@@ -288,7 +297,7 @@ class RollingOpsManager(Object):
             charm: the charm we are attaching this to.
             relation: an identifier, by convention based on the name of the relation in the
                 metadata.yaml, which identifies this instance of RollingOperatorsFactory,
-                distinct from other instances that may be hanlding other events.
+                distinct from other instances that may be handling other events.
             callback: a closure to run when we have a lock. (It must take a CharmBase object and
                 EventBase object as args.)
         """
@@ -309,6 +318,7 @@ class RollingOpsManager(Object):
         self.framework.observe(charm.on[self.name].acquire_lock, self._on_acquire_lock)
         self.framework.observe(charm.on[self.name].run_with_lock, self._on_run_with_lock)
         self.framework.observe(charm.on[self.name].process_locks, self._on_process_locks)
+        self.framework.observe(charm.on.leader_elected, self._on_process_locks)
 
     def _callback(self: CharmBase, event: EventBase) -> None:
         """Placeholder for the function that actually runs our event.
@@ -381,7 +391,7 @@ class RollingOpsManager(Object):
         """Request a lock."""
         try:
             Lock(self).acquire()  # Updates relation data
-            # emit relation changed event in the edge case where aquire does not
+            # emit relation changed event in the edge case where acquire does not
             relation = self.model.get_relation(self.name)
 
             # persist callback override for eventual run

--- a/lib/charms/rolling_ops/v0/rollingops.py
+++ b/lib/charms/rolling_ops/v0/rollingops.py
@@ -49,7 +49,7 @@ class SomeCharm(...):
 
 To kick off the rolling restart, emit this library's AcquireLock event. The simplest way
 to do so would be with an action, though it might make sense to acquire the lock in
-response to another event.
+response to another event. 
 
 ```python
     def _on_trigger_restart(self, event):
@@ -88,7 +88,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 5
 
 
 class LockNoRelationError(Exception):
@@ -182,7 +182,6 @@ class Lock:
             # Active acquire request.
             return LockState.ACQUIRE
 
-        logger.debug("Lock state: %s %s", unit_state, app_state)
         return app_state  # Granted or unset/released
 
     @_state.setter
@@ -203,27 +202,21 @@ class Lock:
         if state is LockState.IDLE:
             self.relation.data[self.app].update({str(self.unit): state.value})
 
-        logger.debug("state: %s", state.value)
-
     def acquire(self):
         """Request that a lock be acquired."""
         self._state = LockState.ACQUIRE
-        logger.debug("Lock acquired.")
 
     def release(self):
         """Request that a lock be released."""
         self._state = LockState.RELEASE
-        logger.debug("Lock released.")
 
     def clear(self):
         """Unset a lock."""
         self._state = LockState.IDLE
-        logger.debug("Lock cleared.")
 
     def grant(self):
         """Grant a lock to a unit."""
         self._state = LockState.GRANTED
-        logger.debug("Lock granted.")
 
     def is_held(self):
         """This unit holds the lock."""
@@ -273,11 +266,9 @@ class AcquireLock(EventBase):
         self.callback_override = callback_override or ""
 
     def snapshot(self):
-        """Snapshot of lock event."""
         return {"callback_override": self.callback_override}
 
     def restore(self, snapshot):
-        """Restores lock event."""
         self.callback_override = snapshot["callback_override"]
 
 
@@ -297,7 +288,7 @@ class RollingOpsManager(Object):
             charm: the charm we are attaching this to.
             relation: an identifier, by convention based on the name of the relation in the
                 metadata.yaml, which identifies this instance of RollingOperatorsFactory,
-                distinct from other instances that may be handling other events.
+                distinct from other instances that may be hanlding other events.
             callback: a closure to run when we have a lock. (It must take a CharmBase object and
                 EventBase object as args.)
         """
@@ -318,7 +309,6 @@ class RollingOpsManager(Object):
         self.framework.observe(charm.on[self.name].acquire_lock, self._on_acquire_lock)
         self.framework.observe(charm.on[self.name].run_with_lock, self._on_run_with_lock)
         self.framework.observe(charm.on[self.name].process_locks, self._on_process_locks)
-        self.framework.observe(charm.on.leader_elected, self._on_process_locks)
 
     def _callback(self: CharmBase, event: EventBase) -> None:
         """Placeholder for the function that actually runs our event.
@@ -391,7 +381,7 @@ class RollingOpsManager(Object):
         """Request a lock."""
         try:
             Lock(self).acquire()  # Updates relation data
-            # emit relation changed event in the edge case where acquire does not
+            # emit relation changed event in the edge case where aquire does not
             relation = self.model.get_relation(self.name)
 
             # persist callback override for eventual run


### PR DESCRIPTION
Issue:
It is impossible to upgrade charm from the current 14/stable to 14/candidate due to the issue https://warthogs.atlassian.net/browse/DPE-4416

Solution:
Fix dp-library in revision 36 https://github.com/canonical/data-platform-libs/pull/170
Update all libraries to the latest fixes/LIBPATCH.
Original issue is no longer reproducible and the new charm passed the internal testing.