### PR TITLE
[DPE-4412] Use TLS CA chain for backups

### DIFF
--- a/src/backups.py
+++ b/src/backups.py
@@ -82,6 +82,14 @@ class PostgreSQLBackups(Object):
         """Stanza name, composed by model and cluster name."""
         return f"{self.model.name}.{self.charm.cluster_name}"
 
+    @property
+    def _tls_ca_chain_filename(self) -> str:
+        """Returns the path to the TLS CA chain file."""
+        s3_parameters, _ = self._retrieve_s3_parameters()
+        if s3_parameters.get("tls-ca-chain") is not None:
+            return f"{self.charm._storage_path}/pgbackrest-tls-ca-chain.crt"
+        return ""
+
     def _are_backup_settings_ok(self) -> Tuple[bool, Optional[str]]:
         """Validates whether backup settings are OK."""
         if self.model.get_relation(self.relation_name) is None:
@@ -233,7 +241,11 @@ class PostgreSQLBackups(Object):
         )
 
         try:
-            s3 = session.resource("s3", endpoint_url=self._construct_endpoint(s3_parameters))
+            s3 = session.resource(
+                "s3",
+                endpoint_url=self._construct_endpoint(s3_parameters),
+                verify=(self._tls_ca_chain_filename or None),
+            )
         except ValueError as e:
             logger.exception("Failed to create a session '%s' in region=%s.", bucket_name, region)
             raise e
@@ -835,6 +847,11 @@ Stderr:
             )
             return False
 
+        if self._tls_ca_chain_filename != "":
+            self.charm._patroni.render_file(
+                self._tls_ca_chain_filename, "\n".join(s3_parameters["tls-ca-chain"]), 0o644
+            )
+
         with open("templates/pgbackrest.conf.j2", "r") as file:
             template = Template(file.read())
         # Render the template file with the correct values.
@@ -848,6 +865,7 @@ Stderr:
             endpoint=s3_parameters["endpoint"],
             bucket=s3_parameters["bucket"],
             s3_uri_style=s3_parameters["s3-uri-style"],
+            tls_ca_chain=self._tls_ca_chain_filename,
             access_key=s3_parameters["access-key"],
             secret_key=s3_parameters["secret-key"],
             stanza=self.stanza_name,
@@ -968,7 +986,11 @@ Stderr:
                 region_name=s3_parameters["region"],
             )
 
-            s3 = session.resource("s3", endpoint_url=self._construct_endpoint(s3_parameters))
+            s3 = session.resource(
+                "s3",
+                endpoint_url=self._construct_endpoint(s3_parameters),
+                verify=(self._tls_ca_chain_filename or None),
+            )
             bucket = s3.Bucket(bucket_name)
 
             with tempfile.NamedTemporaryFile() as temp_file:

--- a/templates/pgbackrest.conf.j2
+++ b/templates/pgbackrest.conf.j2
@@ -10,6 +10,9 @@ repo1-s3-region={{ region }}
 repo1-s3-endpoint={{ endpoint }}
 repo1-s3-bucket={{ bucket }}
 repo1-s3-uri-style={{ s3_uri_style }}
+{%- if tls_ca_chain != '' %}
+repo1-s3-ca-file={{ tls_ca_chain }}
+{%- endif %}
 repo1-s3-key={{ access_key }}
 repo1-s3-key-secret={{ secret_key }}
 start-fast=y

--- a/tests/unit/test_backups.py
+++ b/tests/unit/test_backups.py
@@ -50,6 +50,33 @@ def test_stanza_name(harness):
     )
 
 
+def test_tls_ca_chain_filename(harness):
+    # Test when the TLS CA chain is not available.
+    tc.assertEqual(
+        harness.charm.backup._tls_ca_chain_filename,
+        "",
+    )
+
+    # Test when the TLS CA chain is available.
+    with harness.hooks_disabled():
+        remote_application = "s3-integrator"
+        s3_rel_id = harness.add_relation(S3_PARAMETERS_RELATION, remote_application)
+        harness.update_relation_data(
+            s3_rel_id,
+            remote_application,
+            {
+                "bucket": "fake-bucket",
+                "access-key": "fake-access-key",
+                "secret-key": "fake-secret-key",
+                "tls-ca-chain": '["fake-tls-ca-chain"]',
+            },
+        )
+    tc.assertEqual(
+        harness.charm.backup._tls_ca_chain_filename,
+        "/var/snap/charmed-postgresql/common/pgbackrest-tls-ca-chain.crt",
+    )
+
+
 def test_are_backup_settings_ok(harness):
     # Test without S3 relation.
     tc.assertEqual(
@@ -401,9 +428,17 @@ def test_construct_endpoint(harness):
     )
 
 
-def test_create_bucket_if_not_exists(harness):
+@pytest.mark.parametrize(
+    "tls_ca_chain_filename",
+    ["", "/var/snap/charmed-postgresql/common/pgbackrest-tls-ca-chain.crt"],
+)
+def test_create_bucket_if_not_exists(harness, tls_ca_chain_filename):
     with (
         patch("boto3.session.Session.resource") as _resource,
+        patch(
+            "charm.PostgreSQLBackups._tls_ca_chain_filename",
+            new_callable=PropertyMock(return_value=tls_ca_chain_filename),
+        ) as _tls_ca_chain_filename,
         patch("charm.PostgreSQLBackups._retrieve_s3_parameters") as _retrieve_s3_parameters,
     ):
         # Test when there are missing S3 parameters.
@@ -427,11 +462,15 @@ def test_create_bucket_if_not_exists(harness):
             harness.charm.backup._create_bucket_if_not_exists()
 
         # Test when the bucket already exists.
+        _resource.reset_mock()
         _resource.side_effect = None
         head_bucket = _resource.return_value.Bucket.return_value.meta.client.head_bucket
         create = _resource.return_value.Bucket.return_value.create
         wait_until_exists = _resource.return_value.Bucket.return_value.wait_until_exists
         harness.charm.backup._create_bucket_if_not_exists()
+        _resource.assert_called_once_with(
+            "s3", endpoint_url="test-endpoint", verify=(tls_ca_chain_filename or None)
+        )
         head_bucket.assert_called_once()
         create.assert_not_called()
         wait_until_exists.assert_not_called()
@@ -1470,9 +1509,17 @@ def test_pre_restore_checks(harness):
 
 
 @patch_network_get(private_address="1.1.1.1")
-def test_render_pgbackrest_conf_file(harness):
+@pytest.mark.parametrize(
+    "tls_ca_chain_filename",
+    ["", "/var/snap/charmed-postgresql/common/pgbackrest-tls-ca-chain.crt"],
+)
+def test_render_pgbackrest_conf_file(harness, tls_ca_chain_filename):
     with (
         patch("charm.Patroni.render_file") as _render_file,
+        patch(
+            "charm.PostgreSQLBackups._tls_ca_chain_filename",
+            new_callable=PropertyMock(return_value=tls_ca_chain_filename),
+        ) as _tls_ca_chain_filename,
         patch("charm.PostgreSQLBackups._retrieve_s3_parameters") as _retrieve_s3_parameters,
     ):
         # Set up a mock for the `open` method, set returned data to postgresql.conf template.
@@ -1501,6 +1548,7 @@ def test_render_pgbackrest_conf_file(harness):
                 "region": "us-east-1",
                 "s3-uri-style": "path",
                 "delete-older-than-days": "30",
+                "tls-ca-chain": (["fake-tls-ca-chain"] if tls_ca_chain_filename != "" else ""),
             },
             [],
         )
@@ -1519,6 +1567,7 @@ def test_render_pgbackrest_conf_file(harness):
             endpoint="https://storage.googleapis.com",
             bucket="test-bucket",
             s3_uri_style="path",
+            tls_ca_chain=(tls_ca_chain_filename or ""),
             access_key="test-access-key",
             secret_key="test-secret-key",
             stanza=harness.charm.backup.stanza_name,
@@ -1536,11 +1585,16 @@ def test_render_pgbackrest_conf_file(harness):
         tc.assertEqual(mock.call_args_list[0][0], ("templates/pgbackrest.conf.j2", "r"))
 
         # Ensure the correct rendered template is sent to _render_file method.
-        _render_file.assert_called_once_with(
-            "/var/snap/charmed-postgresql/current/etc/pgbackrest/pgbackrest.conf",
-            expected_content,
-            0o644,
-        )
+        calls = [
+            call(
+                "/var/snap/charmed-postgresql/current/etc/pgbackrest/pgbackrest.conf",
+                expected_content,
+                0o644,
+            )
+        ]
+        if tls_ca_chain_filename != "":
+            calls.insert(0, call(tls_ca_chain_filename, "fake-tls-ca-chain", 0o644))
+        _render_file.assert_has_calls(calls)
 
 
 @patch_network_get(private_address="1.1.1.1")
@@ -1725,11 +1779,19 @@ def test_start_stop_pgbackrest_service(harness):
         restart.assert_called_once()
 
 
-def test_upload_content_to_s3(harness):
+@pytest.mark.parametrize(
+    "tls_ca_chain_filename",
+    ["", "/var/snap/charmed-postgresql/common/pgbackrest-tls-ca-chain.crt"],
+)
+def test_upload_content_to_s3(harness, tls_ca_chain_filename):
     with (
         patch("tempfile.NamedTemporaryFile") as _named_temporary_file,
         patch("charm.PostgreSQLBackups._construct_endpoint") as _construct_endpoint,
         patch("boto3.session.Session.resource") as _resource,
+        patch(
+            "charm.PostgreSQLBackups._tls_ca_chain_filename",
+            new_callable=PropertyMock(return_value=tls_ca_chain_filename),
+        ) as _tls_ca_chain_filename,
     ):
         # Set some parameters.
         content = "test-content"
@@ -1752,7 +1814,11 @@ def test_upload_content_to_s3(harness):
             harness.charm.backup._upload_content_to_s3(content, s3_path, s3_parameters),
             False,
         )
-        _resource.assert_called_once_with("s3", endpoint_url="https://s3.us-east-1.amazonaws.com")
+        _resource.assert_called_once_with(
+            "s3",
+            endpoint_url="https://s3.us-east-1.amazonaws.com",
+            verify=(tls_ca_chain_filename or None),
+        )
         _named_temporary_file.assert_not_called()
         upload_file.assert_not_called()
 
@@ -1763,7 +1829,11 @@ def test_upload_content_to_s3(harness):
             harness.charm.backup._upload_content_to_s3(content, s3_path, s3_parameters),
             False,
         )
-        _resource.assert_called_once_with("s3", endpoint_url="https://s3.us-east-1.amazonaws.com")
+        _resource.assert_called_once_with(
+            "s3",
+            endpoint_url="https://s3.us-east-1.amazonaws.com",
+            verify=(tls_ca_chain_filename or None),
+        )
         _named_temporary_file.assert_called_once()
         upload_file.assert_called_once_with("/tmp/test-file", "test-path/test-file.")
 
@@ -1776,6 +1846,10 @@ def test_upload_content_to_s3(harness):
             harness.charm.backup._upload_content_to_s3(content, s3_path, s3_parameters),
             True,
         )
-        _resource.assert_called_once_with("s3", endpoint_url="https://s3.us-east-1.amazonaws.com")
+        _resource.assert_called_once_with(
+            "s3",
+            endpoint_url="https://s3.us-east-1.amazonaws.com",
+            verify=(tls_ca_chain_filename or None),
+        )
         _named_temporary_file.assert_called_once()
         upload_file.assert_called_once_with("/tmp/test-file", "test-path/test-file.")


### PR DESCRIPTION
## Issue
It's possible to configure a TLS CA chain in the S3 integrator charm. However, the PostgreSQL charm doesn't use that, so right now, it's not possible to connect to S3-compatible storages which provide a self-signed SSL certificate.

## Solution

Port of https://github.com/canonical/postgresql-k8s-operator/pull/493.

Push the TLS CA chain contents to a file and reference it in the pgBackRest configuration (and also in the boto3 calls), so it uses that CA when communicating with the S3-compatible storage.

Manual testing:
1. Build and install the MicroCeph snap from the https://github.com/marceloneppel/microceph/tree/rgw-https-support branch.
```sh
snapcraft -v
sudo snap install --dangerous microceph_*.snap
```
2. Generate the SSL files.
```sh
sudo openssl genrsa -out /var/snap/microceph/common/ca.key 2048
sudo openssl req -x509 -new -nodes -key /var/snap/microceph/common/ca.key -days 1024 -out /var/snap/microceph/common/ca.crt -outform PEM
sudo openssl genrsa -out /var/snap/microceph/common/server.key 2048
sudo openssl req -new -key /var/snap/microceph/common/server.key -out /var/snap/microceph/common/server.csr
export HOST_IP=$(lxc network list --format json | jq -r '.[]  | select(.name=="lxdbr0").config."ipv4.address"' | cut -d'/' -f1)
echo "subjectAltName = IP:$HOST_IP,DNS:$HOST_IP" > ~/extfile.cnf
sudo openssl x509 -req -in /var/snap/microceph/common/server.csr -CA /var/snap/microceph/common/ca.crt -CAkey /var/snap/microceph/common/ca.key -CAcreateserial -out /var/snap/microceph/common/server.crt -days 365 -extfile ~/extfile.cnf
```
3. Bootstrap the MicroCeph cluster, enable RadosGW, and create a user for RadosGW:
```sh
sudo microceph cluster bootstrap
sudo microceph disk add loop,4G,3
sudo microceph enable rgw --ssl-certificate=/var/snap/microceph/common/server.crt --ssl-private-key=/var/snap/microceph/common/server.key
sudo microceph.radosgw-admin user create --uid test --display-name test
```
4. Configure your access and secret keys in the AWS CLI, then create a bucket:
```sh
aws configure
aws --endpoint-url=http://localhost s3 mb s3://test --region ""
```
5. Deploy the charm from this PR along with the S3 integrator charm:
```sh
juju deploy s3-integrator

tox -e build-production && juju deploy ./*.charm

juju config s3-integrator endpoint="https://$(lxc network list --format json | jq -r '.[]  | select(.name=="lxdbr0").config."ipv4.address"' | cut -d'/' -f1)" bucket="test" path="/local" region="" s3-uri-style="path" tls-ca-chain="$(base64 -w0 /var/snap/microceph/common/ca.crt)"

juju run s3-integrator/leader sync-s3-credentials access-key=****** secret-key=******

juju relate postgresql s3-integrator
```
6. Run backup actions (like `create-backup`, `list-backups` and `restore`) as usual.

An integration test using MicroCeph will be added in another PR (because it depends on https://github.com/canonical/microceph/pull/355).

Fixes https://github.com/canonical/postgresql-operator/issues/471.