### PR TITLE
Enable ARM integration tests on nightly CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ on:
 jobs:
   lint:
     name: Lint
-    uses: canonical/data-platform-workflows/.github/workflows/lint.yaml@v13.3.5
+    uses: canonical/data-platform-workflows/.github/workflows/lint.yaml@v14.0.0
 
   unit-test:
     name: Unit test charm
@@ -42,7 +42,7 @@ jobs:
 
   build:
     name: Build charm
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v13.3.5
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v14.0.0
     with:
       cache: true
 
@@ -68,7 +68,7 @@ jobs:
       - lint
       - unit-test
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/integration_test_charm.yaml@v13.3.5
+    uses: canonical/data-platform-workflows/.github/workflows/integration_test_charm.yaml@v14.0.0
     with:
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
       architecture: ${{ matrix.architecture }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,14 +24,14 @@ jobs:
 
   build:
     name: Build charm
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v13.3.5
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v14.0.0
 
   release:
     name: Release charm
     needs:
       - ci-tests
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v13.3.5
+    uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v14.0.0
     with:
       channel: 14/edge
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}

--- a/.github/workflows/sync_issue_to_jira.yaml
+++ b/.github/workflows/sync_issue_to_jira.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   sync:
     name: Sync GitHub issue to Jira
-    uses: canonical/data-platform-workflows/.github/workflows/sync_issue_to_jira.yaml@v13.3.5
+    uses: canonical/data-platform-workflows/.github/workflows/sync_issue_to_jira.yaml@v14.0.0
     with:
       jira-base-url: https://warthogs.atlassian.net
       jira-project-key: DPE

--- a/poetry.lock
+++ b/poetry.lock
@@ -31,8 +31,8 @@ pytest = "*"
 [package.source]
 type = "git"
 url = "https://github.com/canonical/data-platform-workflows"
-reference = "v13.3.5"
-resolved_reference = "4885220b28fecc7ee684b6b59b55c58cbd92995f"
+reference = "v14.0.0"
+resolved_reference = "59afebbfa1a372140df6fc63e7d747cfc013adc5"
 subdirectory = "python/pytest_plugins/allure_pytest_collection_report"
 
 [[package]]
@@ -1482,8 +1482,8 @@ develop = false
 [package.source]
 type = "git"
 url = "https://github.com/canonical/data-platform-workflows"
-reference = "v13.3.5"
-resolved_reference = "4885220b28fecc7ee684b6b59b55c58cbd92995f"
+reference = "v14.0.0"
+resolved_reference = "59afebbfa1a372140df6fc63e7d747cfc013adc5"
 subdirectory = "python/pytest_plugins/github_secrets"
 
 [[package]]
@@ -1520,8 +1520,8 @@ pyyaml = "*"
 [package.source]
 type = "git"
 url = "https://github.com/canonical/data-platform-workflows"
-reference = "v13.3.5"
-resolved_reference = "4885220b28fecc7ee684b6b59b55c58cbd92995f"
+reference = "v14.0.0"
+resolved_reference = "59afebbfa1a372140df6fc63e7d747cfc013adc5"
 subdirectory = "python/pytest_plugins/pytest_operator_cache"
 
 [[package]]
@@ -1539,8 +1539,8 @@ pytest = "*"
 [package.source]
 type = "git"
 url = "https://github.com/canonical/data-platform-workflows"
-reference = "v13.3.5"
-resolved_reference = "4885220b28fecc7ee684b6b59b55c58cbd92995f"
+reference = "v14.0.0"
+resolved_reference = "59afebbfa1a372140df6fc63e7d747cfc013adc5"
 subdirectory = "python/pytest_plugins/pytest_operator_groups"
 
 [[package]]
@@ -2071,4 +2071,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "8c03a8baf1c1edabaed0984bac0152801a022f935f26f05c507e7abbf92c5b17"
+content-hash = "5eba2796328eeaad07e90fb8f2beebffedb191089e204af6cf7ff538155e948d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,10 +66,10 @@ optional = true
 
 [tool.poetry.group.integration.dependencies]
 pytest = "^8.2.0"
-pytest-github-secrets = {git = "https://github.com/canonical/data-platform-workflows", tag = "v13.3.5", subdirectory = "python/pytest_plugins/github_secrets"}
+pytest-github-secrets = {git = "https://github.com/canonical/data-platform-workflows", tag = "v14.0.0", subdirectory = "python/pytest_plugins/github_secrets"}
 pytest-operator = "^0.35.0"
-pytest-operator-cache = {git = "https://github.com/canonical/data-platform-workflows", tag = "v13.3.5", subdirectory = "python/pytest_plugins/pytest_operator_cache"}
-pytest-operator-groups = {git = "https://github.com/canonical/data-platform-workflows", tag = "v13.3.5", subdirectory = "python/pytest_plugins/pytest_operator_groups"}
+pytest-operator-cache = {git = "https://github.com/canonical/data-platform-workflows", tag = "v14.0.0", subdirectory = "python/pytest_plugins/pytest_operator_cache"}
+pytest-operator-groups = {git = "https://github.com/canonical/data-platform-workflows", tag = "v14.0.0", subdirectory = "python/pytest_plugins/pytest_operator_groups"}
 # renovate caret doesn't work: https://github.com/renovatebot/renovate/issues/26940
 juju = "<=3.4.0.0"
 boto3 = "*"
@@ -78,7 +78,7 @@ landscape-api-py3 = "^0.9.0"
 mailmanclient = "^3.3.5"
 psycopg2-binary = "^2.9.9"
 allure-pytest = "^2.13.5"
-allure-pytest-collection-report = {git = "https://github.com/canonical/data-platform-workflows", tag = "v13.3.5", subdirectory = "python/pytest_plugins/allure_pytest_collection_report"}
+allure-pytest-collection-report = {git = "https://github.com/canonical/data-platform-workflows", tag = "v14.0.0", subdirectory = "python/pytest_plugins/allure_pytest_collection_report"}
 
 # Testing tools configuration
 [tool.coverage.run]


### PR DESCRIPTION
ARM integration tests were disabled on nightly CI, PR CI, and release CI/CD in #244 to save costs (on GitHub-hosted ARM runners) while waiting for IS-hosted ARM runner stabilization

Re-enable GitHub-hosted ARM runners only on nightly CI