### PR TITLE
[DPE-4759] Bump version

### DIFF
--- a/src/dependency.json
+++ b/src/dependency.json
@@ -3,12 +3,12 @@
     "dependencies": {"pgbouncer": ">0"},
     "name": "postgresql",
     "upgrade_supported": ">0",
-    "version": "1"
+    "version": "2"
   },
   "snap": {
     "dependencies": {},
     "name": "charmed-postgresql",
     "upgrade_supported": "^14",
-    "version": "14.9"
+    "version": "14.11"
   }
 }


### PR DESCRIPTION
## Issue
`_on_upgrade_charm_check_legacy()` logic is leading to a slow bootstrap of replicas.

This method is not needed anymore (only when upgrading from revision 288).

## Solution
Bump the version in `src/dependency.json` so that after the next stable, we can bump the restrictions (`upgrade_supported` field) to allow the upgrade only from the latest stable (which will allow us to remove `_on_upgrade_charm_check_legacy()`).