### PR TITLE
[DPE-5029] Wait for exact number of units after scale down

### DIFF
--- a/tests/integration/ha_tests/test_async_replication.py
+++ b/tests/integration/ha_tests/test_async_replication.py
@@ -476,7 +476,11 @@ async def test_async_replication_failover_in_main_cluster(
     async with ops_test.fast_forward(FAST_INTERVAL), fast_forward(second_model, FAST_INTERVAL):
         await gather(
             first_model.wait_for_idle(
-                apps=[DATABASE_APP_NAME], status="active", idle_period=IDLE_PERIOD, timeout=TIMEOUT
+                apps=[DATABASE_APP_NAME],
+                status="active",
+                idle_period=IDLE_PERIOD,
+                timeout=TIMEOUT,
+                wait_for_exact_units=(CLUSTER_SIZE - 1),
             ),
             second_model.wait_for_idle(
                 apps=[DATABASE_APP_NAME], status="active", idle_period=IDLE_PERIOD, timeout=TIMEOUT


### PR DESCRIPTION
## Issue
The `test_async_replication_failover_in_main_cluster` test often fails with the following error:
```sh
File "/home/runner/actions-runner/_work/postgresql-operator/postgresql-operator/tests/integration/ha_tests/test_async_replication.py", line 489, in test_async_replication_failover_in_main_cluster
    assert new_sync_standby != sync_standby, "Sync-standby is the same as before"
AssertionError: Sync-standby is the same as before
assert 'postgresql-1' != 'postgresql-1'
```

## Solution
Wait for the scale in operation to finish before checking whether the sync standby changed.