### PR TITLE
(WIP) [DPE-5303] Update endpoints faster when snap is stopped

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -825,6 +825,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         elif ip_to_remove:
             ips.remove(ip_to_remove)
         self._peers.data[self.app]["members_ips"] = json.dumps(ips)
+        self._observer.restart_observer()
 
     @retry(
         stop=stop_after_delay(60),

--- a/src/charm.py
+++ b/src/charm.py
@@ -860,6 +860,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
     def _on_cluster_topology_change(self, _):
         """Updates endpoints and (optionally) certificates when the cluster topology changes."""
         logger.info("Cluster topology changed")
+        self._observer.restart_observer()
         if self.primary_endpoint:
             self._update_relation_endpoints()
             self.unit.status = ActiveStatus()

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -210,7 +210,7 @@ class Patroni:
         # Request info from cluster endpoint (which returns all members of the cluster).
         for attempt in Retrying(stop=stop_after_attempt(2 * len(self.peers_ips) + 1)):
             with attempt:
-                url = self._get_alternative_patroni_url(attempt)
+                url = self._get_alternative_patroni_url(attempt.retry_state.attempt_number)
                 cluster_status = requests.get(
                     f"{url}/{PATRONI_CLUSTER_STATUS_ENDPOINT}",
                     verify=self.verify,
@@ -234,7 +234,7 @@ class Patroni:
         # Request info from cluster endpoint (which returns all members of the cluster).
         for attempt in Retrying(stop=stop_after_attempt(2 * len(self.peers_ips) + 1)):
             with attempt:
-                url = self._get_alternative_patroni_url(attempt)
+                url = self._get_alternative_patroni_url(attempt.retry_state.attempt_number)
                 cluster_status = requests.get(
                     f"{url}/{PATRONI_CLUSTER_STATUS_ENDPOINT}",
                     verify=self.verify,
@@ -259,7 +259,7 @@ class Patroni:
         # Request info from cluster endpoint (which returns all members of the cluster).
         for attempt in Retrying(stop=stop_after_attempt(2 * len(self.peers_ips) + 1)):
             with attempt:
-                url = self._get_alternative_patroni_url(attempt, alternative_endpoints)
+                url = self._get_alternative_patroni_url(attempt.retry_state.attempt_number, alternative_endpoints)
                 cluster_status = requests.get(
                     f"{url}/{PATRONI_CLUSTER_STATUS_ENDPOINT}",
                     verify=self.verify,
@@ -289,7 +289,7 @@ class Patroni:
         # Request info from cluster endpoint (which returns all members of the cluster).
         for attempt in Retrying(stop=stop_after_attempt(2 * len(self.peers_ips) + 1)):
             with attempt:
-                url = self._get_alternative_patroni_url(attempt)
+                url = self._get_alternative_patroni_url(attempt.retry_state.attempt_number)
                 cluster_status = requests.get(
                     f"{url}/{PATRONI_CLUSTER_STATUS_ENDPOINT}",
                     verify=self.verify,
@@ -313,7 +313,7 @@ class Patroni:
         # Request info from cluster endpoint (which returns all members of the cluster).
         for attempt in Retrying(stop=stop_after_attempt(2 * len(self.peers_ips) + 1)):
             with attempt:
-                url = self._get_alternative_patroni_url(attempt)
+                url = self._get_alternative_patroni_url(attempt.retry_state.attempt_number)
                 r = requests.get(f"{url}/cluster", verify=self.verify, auth=self._patroni_auth)
                 for member in r.json()["members"]:
                     if member["role"] == "sync_standby":
@@ -321,7 +321,7 @@ class Patroni:
         return sync_standbys
 
     def _get_alternative_patroni_url(
-        self, attempt: AttemptManager, alternative_endpoints: List[str] = None
+        self, attempt_number: int, alternative_endpoints: List[str] = None
     ) -> str:
         """Get an alternative REST API URL from another member each time.
 
@@ -330,9 +330,9 @@ class Patroni:
         """
         if alternative_endpoints is not None:
             return self._patroni_url.replace(
-                self.unit_ip, alternative_endpoints[attempt.retry_state.attempt_number - 1]
+                self.unit_ip, alternative_endpoints[attempt_number - 1]
             )
-        attempt_number = attempt.retry_state.attempt_number
+        attempt_number = attempt_number
         if attempt_number > 1:
             url = self._patroni_url
             # Build the URL using http and later using https for each peer.

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -16,7 +16,6 @@ import requests
 from charms.operator_libs_linux.v2 import snap
 from jinja2 import Template
 from tenacity import (
-    AttemptManager,
     RetryError,
     Retrying,
     retry,
@@ -259,7 +258,9 @@ class Patroni:
         # Request info from cluster endpoint (which returns all members of the cluster).
         for attempt in Retrying(stop=stop_after_attempt(2 * len(self.peers_ips) + 1)):
             with attempt:
-                url = self._get_alternative_patroni_url(attempt.retry_state.attempt_number, alternative_endpoints)
+                url = self._get_alternative_patroni_url(
+                    attempt.retry_state.attempt_number, alternative_endpoints
+                )
                 cluster_status = requests.get(
                     f"{url}/{PATRONI_CLUSTER_STATUS_ENDPOINT}",
                     verify=self.verify,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1348,6 +1348,7 @@ def test_on_cluster_topology_change(harness):
         patch(
             "charm.PostgresqlOperatorCharm.primary_endpoint", new_callable=PropertyMock
         ) as _primary_endpoint,
+        patch("charm.ClusterTopologyObserver.restart_observer") as _restart_observer,
     ):
         # Mock the property value.
         _primary_endpoint.side_effect = [None, "1.1.1.1"]
@@ -1371,6 +1372,7 @@ def test_on_cluster_topology_change_keep_blocked(harness):
         patch(
             "charm.PostgresqlOperatorCharm._update_relation_endpoints"
         ) as _update_relation_endpoints,
+        patch("charm.ClusterTopologyObserver.restart_observer") as _restart_observer,
     ):
         harness.model.unit.status = WaitingStatus(PRIMARY_NOT_REACHABLE_MESSAGE)
 
@@ -1392,6 +1394,7 @@ def test_on_cluster_topology_change_clear_blocked(harness):
         patch(
             "charm.PostgresqlOperatorCharm._update_relation_endpoints"
         ) as _update_relation_endpoints,
+        patch("charm.ClusterTopologyObserver.restart_observer") as _restart_observer,
     ):
         harness.model.unit.status = WaitingStatus(PRIMARY_NOT_REACHABLE_MESSAGE)
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -208,7 +208,7 @@ def test_primary_endpoint_no_peers(harness):
 
 @patch_network_get(private_address="1.1.1.1")
 def test_on_leader_elected(harness):
-    with patch(
+    with patch("charm.ClusterTopologyObserver.start_observer") as _start_observer, patch(
         "charm.PostgresqlOperatorCharm._update_relation_endpoints", new_callable=PropertyMock
     ) as _update_relation_endpoints, patch(
         "charm.PostgresqlOperatorCharm.primary_endpoint",
@@ -573,6 +573,7 @@ def test_enable_disable_extensions(harness, caplog):
 @patch_network_get(private_address="1.1.1.1")
 def test_on_start(harness):
     with (
+        patch("charm.ClusterTopologyObserver.start_observer") as _start_observer,
         patch(
             "charm.PostgresqlOperatorCharm._restart_services_after_reboot"
         ) as _restart_services_after_reboot,
@@ -737,6 +738,7 @@ def test_on_start_replica(harness):
 @patch_network_get(private_address="1.1.1.1")
 def test_on_start_no_patroni_member(harness):
     with (
+        patch("charm.ClusterTopologyObserver.start_observer") as _start_observer,
         patch("subprocess.check_output", return_value=b"C"),
         patch("charm.snap.SnapCache") as _snap_cache,
         patch("charm.PostgresqlOperatorCharm.postgresql") as _postgresql,
@@ -787,7 +789,10 @@ def test_on_start_after_blocked_state(harness):
 
 @patch_network_get(private_address="1.1.1.1")
 def test_on_get_password(harness):
-    with patch("charm.PostgresqlOperatorCharm.update_config"):
+    with (
+        patch("charm.ClusterTopologyObserver.start_observer") as _start_observer,
+        patch("charm.PostgresqlOperatorCharm.update_config"),
+    ):
         rel_id = harness.model.get_relation(PEER).id
         # Create a mock event and set passwords in peer relation data.
         harness.set_leader(True)

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -85,19 +85,14 @@ def patroni(harness, peers_ips):
 
 
 def test_get_alternative_patroni_url(peers_ips, patroni):
-    # Mock tenacity attempt.
-    retry = tenacity.Retrying()
-    retry_state = tenacity.RetryCallState(retry, None, None, None)
-    attempt = tenacity.AttemptManager(retry_state)
-
     # Test the first URL that is returned (it should have the current unit IP).
-    url = patroni._get_alternative_patroni_url(attempt)
+    attempt_number = 1
+    url = patroni._get_alternative_patroni_url(attempt_number)
     tc.assertEqual(url, f"http://{patroni.unit_ip}:8008")
 
     # Test returning the other servers URLs.
-    for attempt_number in range(attempt.retry_state.attempt_number + 1, len(peers_ips) + 2):
-        attempt.retry_state.attempt_number = attempt_number
-        url = patroni._get_alternative_patroni_url(attempt)
+    for attempt_number in range(attempt_number + 1, len(peers_ips) + 2):
+        url = patroni._get_alternative_patroni_url(attempt_number)
         assert url.split("http://")[1].split(":8008")[0] in peers_ips
 
 

--- a/tests/unit/test_cluster_topology_observer.py
+++ b/tests/unit/test_cluster_topology_observer.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 import signal
-from typing import Optional
+from typing import List, Optional
 from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
@@ -50,6 +50,10 @@ class MockCharm(CharmBase):
     @property
     def _patroni(self) -> Patroni:
         return Mock(_patroni_url="http://1.1.1.1:8008/", verify=True)
+
+    @property
+    def _peer_members_ips(self) -> List[str]:
+        return []
 
     @property
     def _peers(self) -> Optional[Relation]:


### PR DESCRIPTION
## Issue
If the snap services are stopped manually by calling `snap stop charmed.postgresql`, the endpoints are not updated in the `database` relation endpoint, causing errors in the client charm side.

## Solution
Improve the Cluster Topology Observer to check other members' REST API when the current member's REST API is not accessible.

This will allow the endpoint to be changed to the IP of the new primary before the `update-status` hook is called the next time.

I'm still working on making this more robust.