### PR TITLE
[DPE-5306] Data Interafces v40

### DIFF
--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -331,7 +331,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 39
+LIBPATCH = 40
 
 PYDEPS = ["ops>=2.0.0"]
 
@@ -389,6 +389,10 @@ class SecretsIllegalUpdateError(SecretError):
 
 class IllegalOperationError(DataInterfacesError):
     """To be used when an operation is not allowed to be performed."""
+
+
+class PrematureDataAccessError(DataInterfacesError):
+    """To be raised when the Relation Data may be accessed (written) before protocol init complete."""
 
 
 ##############################################################################
@@ -1453,6 +1457,8 @@ class EventHandlers(Object):
 class ProviderData(Data):
     """Base provides-side of the data products relation."""
 
+    DATABASE_FIELD = "database"
+
     def __init__(
         self,
         model: Model,
@@ -1618,6 +1624,15 @@ class ProviderData(Data):
     def _update_relation_data(self, relation: Relation, data: Dict[str, str]) -> None:
         """Set values for fields not caring whether it's a secret or not."""
         req_secret_fields = []
+
+        keys = set(data.keys())
+        if self.fetch_relation_field(relation.id, self.DATABASE_FIELD) is None and (
+            keys - {"endpoints", "read-only-endpoints", "replset"}
+        ):
+            raise PrematureDataAccessError(
+                "Premature access to relation data, update is forbidden before the connection is initialized."
+            )
+
         if relation.app:
             req_secret_fields = get_encoded_list(relation, relation.app, REQ_SECRET_FIELDS)
 
@@ -3290,6 +3305,8 @@ class KafkaRequiresEvents(CharmEvents):
 class KafkaProviderData(ProviderData):
     """Provider-side of the Kafka relation."""
 
+    DATABASE_FIELD = "topic"
+
     def __init__(self, model: Model, relation_name: str) -> None:
         super().__init__(model, relation_name)
 
@@ -3538,6 +3555,8 @@ class OpenSearchRequiresEvents(CharmEvents):
 
 class OpenSearchProvidesData(ProviderData):
     """Provider-side of the OpenSearch relation."""
+
+    DATABASE_FIELD = "index"
 
     def __init__(self, model: Model, relation_name: str) -> None:
         super().__init__(model, relation_name)

--- a/tests/unit/test_postgresql_provider.py
+++ b/tests/unit/test_postgresql_provider.py
@@ -292,7 +292,17 @@ def test_update_endpoints_without_event(harness):
         rel_id = harness.add_relation(RELATION_NAME, "application")
         another_rel_id = harness.add_relation(RELATION_NAME, "application")
 
+        relation_ids = [rel.id for rel in harness.charm.model.relations[RELATION_NAME]]
+        other_rel_ids = set(relation_ids) - set({rel_id, another_rel_id})
+
         with harness.hooks_disabled():
+            for relation_id in other_rel_ids:
+                harness.update_relation_data(
+                    relation_id,
+                    "application",
+                    {"database": "some_db", "extra-user-roles": ""},
+                )
+
             harness.update_relation_data(
                 rel_id,
                 "application",


### PR DESCRIPTION
Data Interfaces v40 introduces a blocking mechanism, to avoid write operations on Relation Data before the relation is inialized.

This is important so that `Provider` would never try to add data before `Requirer` clearly indicating if Juju Secrest are to be used or not. (The `Provider` is adding this information within its `relation-created` handler).

NOTE: Any calls on `update_relation_data()` before this stage may appear as plain text. Thus the blocking behavior introduced.

Without fixes on the code, tests publishing `uri` premature may fail.
https://github.com/canonical/postgresql-operator/actions/runs/11002875807/job/30551092035
Note that in real life this is not a valid scenario, since `uris` contain credentials. Now, before credentials are distributed (which happens correctly in the charm, after secrets initialization) the `uris` can't be publshed. This is the proof why there has been no risk in real life usage.