### PR TITLE
[DPE-5512] postgresql.conf hardening

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -27,12 +27,12 @@ options:
     description: |
       Logs each successful connection.
     type: boolean
-    default: false
+    default: true
   logging_log_disconnections:
     description: |
       Logs end of a session, including duration.
     type: boolean
-    default: false
+    default: true
   logging_log_lock_waits:
     description: |
       Logs long lock waits.

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -81,10 +81,8 @@ bootstrap:
         lc_messages: 'en_US.UTF8'
         log_autovacuum_min_duration: 60000
         log_checkpoints: 'on'
-        log_connections: 'on'
         log_destination: 'stderr'
         log_directory: '{{ postgresql_log_path }}'
-        log_disconnections: 'on'
         log_error_verbosity: 'verbose'
         log_file_mode: '0600'
         log_filename: 'postgresql-%w_%H%M.log'

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -73,18 +73,25 @@ bootstrap:
         {%- endif %}
         archive_mode: on
         autovacuum: true
+        debug_print_plan: 'off'
+        debug_print_parse: 'off'
+        debug_print_rewritten: 'off'
         fsync: true
         full_page_writes: true
         lc_messages: 'en_US.UTF8'
         log_autovacuum_min_duration: 60000
         log_checkpoints: 'on'
+        log_connections: 'on'
         log_destination: 'stderr'
         log_directory: '{{ postgresql_log_path }}'
+        log_disconnections: 'on'
+        log_error_verbosity: 'verbose'
         log_file_mode: '0600'
         log_filename: 'postgresql-%w_%H%M.log'
         log_hostname: 'off'
         log_line_prefix: '%t [%p]: user=%u,db=%d,app=%a,client=%h,line=%l '
         log_min_duration_sample: -1
+        log_min_error_statement: 'warning'
         log_recovery_conflict_waits: 'on'
         log_replication_commands: 'on'
         log_rotation_age: 1


### PR DESCRIPTION
## Issue
Some of the `postgresql.conf` parameter values don't have the PM desired value for correctly hardening the charm.

Those are the following:
* log_connections
* log_disconnections
* log_error_verbosity
* log_min_error_statement
* debug_print_plan
* debug_print_parse
* debug_print_rewritten

## Solution
Change the default value for the `logging_log_connections` and `logging_log_disconnections` charm config options to `true` and set the right value to the other parameters in the Patroni configuration file template.

There is more info in the Jira ticket.

This is a port of https://github.com/canonical/postgresql-k8s-operator/pull/702.