### PR TITLE
[MISC] Disable tox requirements generation for check libraries flow

### DIFF
--- a/.github/workflows/lib-check.yaml
+++ b/.github/workflows/lib-check.yaml
@@ -26,17 +26,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up environment
-        run: |
-          pipx install tox
-          pipx install poetry
-          pipx inject poetry poetry-plugin-export
-          # TODO: Remove after https://github.com/python-poetry/poetry/pull/5980 is closed
-          poetry config warnings.export false
-      - name: Generate requirements
-        run: |
-          tox run -e build-wrapper
-          mv requirements-last-build.txt requirements.txt
       - name: Check libs
         uses: canonical/charming-actions/check-libraries@2.6.3
         with:


### PR DESCRIPTION
Check libs workflow also relied on the tox wrappers