### PR TITLE
build: use the Charmcraft poetry plugin

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,8 @@ jobs:
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v23.0.2
     with:
       cache: true
+      # Needed for the poetry plugin
+      charmcraft-snap-channel: latest/edge
 
   integration-test:
     strategy:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -10,7 +10,8 @@ bases:
     channel: "22.04"
     architectures: [arm64]
 parts:
-  charm:
+  rust-deps:
+    plugin: nil
     build-snaps:
       - rustup
     build-packages:
@@ -20,14 +21,23 @@ parts:
       - libpq-dev
     override-build: |
       rustup default stable
-
-      # Convert subset of poetry.lock to requirements.txt
+  poetry-deps:
+    plugin: nil
+    build-packages:
+      - curl
+    build-environment:
+      - POETRY_VERSION: "1.8.0"
+    override-build: |
       curl -sSL https://install.python-poetry.org | python3 -
-      /root/.local/bin/poetry export --only main,charm-libs --output requirements.txt
+      ln -sf $HOME/.local/bin/poetry /usr/local/bin/poetry
 
-      craftctl default
-    charm-strict-dependencies: true
-    charm-requirements: [requirements.txt]
+      /usr/bin/python3 -m pip install pip==24.2
+  charm:
+    after: [rust-deps, poetry-deps]
+    plugin: poetry
+    source: .
+    poetry-with:
+      - charm-libs
   libpq:
     build-packages:
       - libpq-dev


### PR DESCRIPTION
This modifies charmcraft.yaml to use Charmcraft 3.3's `poetry` plugin for building the charm.

The charm is currently bigger due to duplicated files (see: https://github.com/canonical/charmcraft/issues/1966), but will be ~5 MiB smaller than the original once that's fixed, mostly due to not vendoring `pip`.