### PR TITLE
[MISC] Merge update_tls_flag into update_endpoints

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -1709,9 +1709,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             # in a bundle together with the TLS certificates operator. This flag is used to
             # know when to call the Patroni API using HTTP or HTTPS.
             self.unit_peer_data.update({"tls": "enabled" if enable_tls else ""})
-            self.postgresql_client_relation.update_tls_flag(
-                "True" if self.is_tls_enabled else "False"
-            )
+            self.postgresql_client_relation.update_endpoints()
             logger.debug("Early exit update_config: Workload not started yet")
             return True
 
@@ -1787,7 +1785,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             # Ignore the error, as it happens only to indicate that the configuration has not changed.
             pass
         self.unit_peer_data.update({"tls": "enabled" if enable_tls else ""})
-        self.postgresql_client_relation.update_tls_flag("True" if self.is_tls_enabled else "False")
+        self.postgresql_client_relation.update_endpoints()
 
         # Restart PostgreSQL if TLS configuration has changed
         # (so the both old and new connections use the configuration).

--- a/src/charm.py
+++ b/src/charm.py
@@ -822,6 +822,8 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
     @property
     def members_ips(self) -> set[str]:
         """Returns the list of IPs addresses of the current members of the cluster."""
+        if not self._peers:
+            return set()
         return set(json.loads(self._peers.data[self.app].get("members_ips", "[]")))
 
     def _add_to_members_ips(self, ip: str) -> None:

--- a/tests/unit/test_postgresql_provider.py
+++ b/tests/unit/test_postgresql_provider.py
@@ -142,7 +142,6 @@ def test_on_database_requested(harness):
             "password": "test-password",
             "version": POSTGRESQL_VERSION,
             "database": f"{DATABASE}",
-            "tls": "False",
         }
 
         # Assert no BlockedStatus was set.
@@ -154,7 +153,6 @@ def test_on_database_requested(harness):
         # No data is set in the databag by the database.
         assert harness.get_relation_data(rel_id, harness.charm.app.name) == {
             "data": f'{{"database": "{DATABASE}", "extra-user-roles": "{EXTRA_USER_ROLES}"}}',
-            "tls": "False",
         }
 
         # BlockedStatus due to a PostgreSQLCreateDatabaseError.
@@ -163,7 +161,6 @@ def test_on_database_requested(harness):
         # No data is set in the databag by the database.
         assert harness.get_relation_data(rel_id, harness.charm.app.name) == {
             "data": f'{{"database": "{DATABASE}", "extra-user-roles": "{EXTRA_USER_ROLES}"}}',
-            "tls": "False",
         }
 
         # BlockedStatus due to a PostgreSQLGetPostgreSQLVersionError.
@@ -256,6 +253,7 @@ def test_update_endpoints_with_event(harness):
             "endpoints": "1.1.1.1:5432",
             "read-only-endpoints": "2.2.2.2:5432",
             "uris": "postgresql://relation-2:test_password@1.1.1.1:5432/test_db",
+            "tls": "False",
         }
         assert harness.get_relation_data(another_rel_id, harness.charm.app.name) == {}
         _fetch_my_relation_data.assert_called_once_with([2], ["password"])
@@ -265,6 +263,7 @@ def test_update_endpoints_with_event(harness):
         assert harness.get_relation_data(rel_id, harness.charm.app.name) == {
             "endpoints": "1.1.1.1:5432",
             "uris": "postgresql://relation-2:test_password@1.1.1.1:5432/test_db",
+            "tls": "False",
         }
         assert harness.get_relation_data(another_rel_id, harness.charm.app.name) == {}
 
@@ -331,11 +330,13 @@ def test_update_endpoints_without_event(harness):
             "endpoints": "1.1.1.1:5432",
             "read-only-endpoints": "2.2.2.2:5432",
             "uris": "postgresql://relation-2:test_password@1.1.1.1:5432/test_db",
+            "tls": "False",
         }
         assert harness.get_relation_data(another_rel_id, harness.charm.app.name) == {
             "endpoints": "1.1.1.1:5432",
             "read-only-endpoints": "2.2.2.2:5432",
             "uris": "postgresql://relation-3:test_password@1.1.1.1:5432/test_db2",
+            "tls": "False",
         }
         _fetch_my_relation_data.assert_called_once_with(None, ["password"])
 
@@ -344,8 +345,10 @@ def test_update_endpoints_without_event(harness):
         assert harness.get_relation_data(rel_id, harness.charm.app.name) == {
             "endpoints": "1.1.1.1:5432",
             "uris": "postgresql://relation-2:test_password@1.1.1.1:5432/test_db",
+            "tls": "False",
         }
         assert harness.get_relation_data(another_rel_id, harness.charm.app.name) == {
             "endpoints": "1.1.1.1:5432",
             "uris": "postgresql://relation-3:test_password@1.1.1.1:5432/test_db2",
+            "tls": "False",
         }


### PR DESCRIPTION
Early setting of the tls flags can cause errors when setting too early. [E.g.](https://github.com/canonical/pgbouncer-operator/actions/runs/11788944012/job/32837736355)
```
 Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-postgresql-0/charm/./src/charm.py", line 1952, in <module>
    main(PostgresqlOperatorCharm)
  File "/var/lib/juju/agents/unit-postgresql-0/charm/venv/ops/__init__.py", line 343, in __call__
    return _main.main(charm_class=charm_class, use_juju_for_storage=use_juju_for_storage)
  File "/var/lib/juju/agents/unit-postgresql-0/charm/venv/ops/_main.py", line 543, in main
    manager.run()
  File "/var/lib/juju/agents/unit-postgresql-0/charm/venv/ops/_main.py", line 529, in run
    self._emit()
  File "/var/lib/juju/agents/unit-postgresql-0/charm/venv/ops/_main.py", line 518, in _emit
    _emit_charm_event(self.charm, self.dispatcher.event_name, self._juju_context)
  File "/var/lib/juju/agents/unit-postgresql-0/charm/venv/ops/_main.py", line 134, in _emit_charm_event
    event_to_emit.emit(*args, **kwargs)
  File "/var/lib/juju/agents/unit-postgresql-0/charm/venv/ops/framework.py", line 347, in emit
    framework._emit(event)
  File "/var/lib/juju/agents/unit-postgresql-0/charm/venv/ops/framework.py", line 857, in _emit
    self._reemit(event_path)
  File "/var/lib/juju/agents/unit-postgresql-0/charm/venv/ops/framework.py", line 947, in _reemit
    custom_handler(event)
  File "/var/lib/juju/agents/unit-postgresql-0/charm/lib/charms/tempo_coordinator_k8s/v0/charm_tracing.py", line 735, in wrapped_function
    return callable(*args, **kwargs)  # type: ignore
  File "/var/lib/juju/agents/unit-postgresql-0/charm/./src/charm.py", line 958, in _on_leader_elected
    self.update_config()
  File "/var/lib/juju/agents/unit-postgresql-0/charm/lib/charms/tempo_coordinator_k8s/v0/charm_tracing.py", line 735, in wrapped_function
    return callable(*args, **kwargs)  # type: ignore
  File "/var/lib/juju/agents/unit-postgresql-0/charm/./src/charm.py", line 1712, in update_config
    self.postgresql_client_relation.update_tls_flag(
  File "/var/lib/juju/agents/unit-postgresql-0/charm/lib/charms/tempo_coordinator_k8s/v0/charm_tracing.py", line 735, in wrapped_function
    return callable(*args, **kwargs)  # type: ignore
  File "/var/lib/juju/agents/unit-postgresql-0/charm/src/relations/postgresql_provider.py", line 238, in update_tls_flag
    self.database_provides.set_tls(relation.id, tls)
  File "/var/lib/juju/agents/unit-postgresql-0/charm/lib/charms/data_platform_libs/v0/data_interfaces.py", line 1683, in set_tls
    self.update_relation_data(relation_id, ***"tls": tls***)
  File "/var/lib/juju/agents/unit-postgresql-0/charm/lib/charms/data_platform_libs/v0/data_interfaces.py", line 496, in wrapper
    return f(self, *args, **kwargs)
  File "/var/lib/juju/agents/unit-postgresql-0/charm/lib/charms/data_platform_libs/v0/data_interfaces.py", line 1407, in update_relation_data
    return self._update_relation_data(relation, data)
  File "/var/lib/juju/agents/unit-postgresql-0/charm/lib/charms/data_platform_libs/v0/data_interfaces.py", line 1632, in _update_relation_data
    raise PrematureDataAccessError(
charms.data_platform_libs.v0.data_interfaces.PrematureDataAccessError: Premature access to relation data, update is forbidden before the connection is initialized.
```

This PR merges update_tls_flag into update_endpoints to reuse the checks for `PrematureDataAccessError`