### PR TITLE
Test against juju 3.6/candidate + upgrade dpw to v23.0.5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
             allure_on_amd64: false
           - agent: 3.4.6  # renovate: juju-agent-pin-minor
             allure_on_amd64: true
-          - snap_channel: 3.6/beta
+          - snap_channel: 3.6/candidate
             allure_on_amd64: false
         architecture:
           - amd64

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ on:
 jobs:
   lint:
     name: Lint
-    uses: canonical/data-platform-workflows/.github/workflows/lint.yaml@v23.0.4
+    uses: canonical/data-platform-workflows/.github/workflows/lint.yaml@v23.0.5
 
   unit-test:
     name: Unit test charm
@@ -45,7 +45,7 @@ jobs:
 
   build:
     name: Build charm
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v23.0.4
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v23.0.5
     with:
       cache: true
 
@@ -69,7 +69,7 @@ jobs:
               allure_on_amd64: true
             architecture: arm64
           - juju:
-              snap_channel: 3.6/beta
+              snap_channel: 3.6/candidate
               allure_on_amd64: false
             architecture: arm64
     name: Integration | ${{ matrix.juju.agent || matrix.juju.snap_channel }} | ${{ matrix.architecture }}
@@ -77,7 +77,7 @@ jobs:
       - lint
       - unit-test
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/integration_test_charm.yaml@v23.0.4
+    uses: canonical/data-platform-workflows/.github/workflows/integration_test_charm.yaml@v23.0.5
     with:
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
       architecture: ${{ matrix.architecture }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,14 +25,14 @@ jobs:
 
   build:
     name: Build charm
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v23.0.4
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v23.0.5
 
   release:
     name: Release charm
     needs:
       - ci-tests
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v23.0.4
+    uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v23.0.5
     with:
       channel: 14/edge
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}

--- a/.github/workflows/sync_docs.yaml
+++ b/.github/workflows/sync_docs.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   sync-docs:
     name: Sync docs from Discourse
-    uses: canonical/data-platform-workflows/.github/workflows/sync_docs.yaml@v23.0.4
+    uses: canonical/data-platform-workflows/.github/workflows/sync_docs.yaml@v23.0.5
     with:
       reviewers: a-velasco,izmalk
     permissions:


### PR DESCRIPTION
## Issue
1. There's a new juju release candidate, on 3.6/candidate
2. There's a new dpw version (which we need to update to before Nov 21 to avoid failing tests)

## Solution
1. Run nightly tests against juju 3.6/candidate
2. Upgrade to dpw v23.0.5