### PR TITLE
[DPE-6042] Make tox commands resilient to white-space paths

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,13 +6,13 @@ no_package = True
 env_list = lint, unit
 
 [vars]
-src_path = {tox_root}/src
-tests_path = {tox_root}/tests
+src_path = "{tox_root}/src"
+tests_path = "{tox_root}/tests"
 all_path = {[vars]src_path} {[vars]tests_path}
 
 [testenv]
 set_env =
-    PYTHONPATH = {tox_root}/lib:{[vars]src_path}
+    PYTHONPATH = {tox_root}/lib:{tox_root}/src
     PY_COLORS = 1
 allowlist_externals =
     poetry


### PR DESCRIPTION
This PR fixes [tox.ini](https://github.com/canonical/postgresql-operator/blob/main/tox.ini) commands when the repository is cloned on a white-space containing path. The proposed approach quotes the paths where they are defined (central place), instead of where they are used (distributed throughout the file). However, we could go with the other approach if preferred.

### How to reproduce:
```shell
$ mkdir -p "Projects/Canonical/Data Platform/PostgreSQL"
$ cd "Projects/Canonical/Data Platform/PostgreSQL"
$ git clone https://github.com/canonical/postgresql-operator
$ cd postgresql-operator
$ tox run -e format
> ...
> /Users/<USERNAME>/Projects/Canonical/Data:1:1: E902 No such file or directory (os error 2)
> Platform/PostgreSQL/postgresql-operator/src:1:1: E902 No such file or directory (os error 2)
> Platform/PostgreSQL/postgresql-operator/tests:1:1: E902 No such file or directory (os error 2)

```

### Additional considerations
Using the quoted paths to set up the `PYTHONPATH` does not work. This can be tested by running the unit tests.

### References
- [Issue](https://github.com/tox-dev/tox/issues/121#issuecomment-407531282), from the tox repository.
- [Recommended approach](https://github.com/tox-dev/tox/issues/924#issuecomment-1396858349), from the tox repository.