### PR TITLE
[DPE-5714] Filter out degraded read only endpoints

### DIFF
--- a/src/cluster.py
+++ b/src/cluster.py
@@ -524,6 +524,23 @@ class Patroni:
 
         return len(cluster_status.json()["members"]) == 0
 
+    def are_replicas_up(self) -> dict[str, bool] | None:
+        """Check if cluster members are running or streaming."""
+        try:
+            response = requests.get(
+                f"{self._patroni_url}/cluster",
+                verify=self.verify,
+                auth=self._patroni_auth,
+                timeout=PATRONI_TIMEOUT,
+            )
+            return {
+                member["host"]: member["state"] in ["running", "streaming"]
+                for member in response.json()["members"]
+            }
+        except Exception:
+            logger.exception("Unable to get the state of the cluster")
+            return
+
     def promote_standby_cluster(self) -> None:
         """Promote a standby cluster to be a regular cluster."""
         config_response = requests.get(

--- a/src/relations/postgresql_provider.py
+++ b/src/relations/postgresql_provider.py
@@ -184,6 +184,11 @@ class PostgreSQLProvider(Object):
         # If there are no replicas, remove the read-only endpoint.
         replicas_endpoint = list(self.charm.members_ips - {self.charm.primary_endpoint})
         replicas_endpoint.sort()
+        cluster_state = self.charm._patroni.are_replicas_up()
+        if cluster_state:
+            replicas_endpoint = [
+                replica for replica in replicas_endpoint if cluster_state.get(replica, False)
+            ]
         read_only_endpoints = (
             ",".join(f"{x}:{DATABASE_PORT}" for x in replicas_endpoint)
             if len(replicas_endpoint) > 0

--- a/tests/integration/new_relations/test_new_relations.py
+++ b/tests/integration/new_relations/test_new_relations.py
@@ -220,7 +220,7 @@ async def test_filter_out_degraded_replicas(ops_test: OpsTest):
             assert data is None
 
     await start_machine(ops_test, machine)
-    await ops_test.model.wait_for_idle(apps=DATABASE_APP_NAME, status="active", timeout=200)
+    await ops_test.model.wait_for_idle(apps=[DATABASE_APP_NAME], status="active", timeout=200)
 
 
 @pytest.mark.group("new_relations_tests")

--- a/tests/integration/new_relations/test_new_relations.py
+++ b/tests/integration/new_relations/test_new_relations.py
@@ -13,7 +13,16 @@ import yaml
 from pytest_operator.plugin import OpsTest
 
 from .. import markers
-from ..helpers import CHARM_BASE, assert_sync_standbys, get_leader_unit, scale_application
+from ..helpers import (
+    CHARM_BASE,
+    assert_sync_standbys,
+    get_leader_unit,
+    get_machine_from_unit,
+    get_primary,
+    scale_application,
+    start_machine,
+    stop_machine,
+)
 from ..juju_ import juju_major_version
 from .helpers import (
     build_connection_string,
@@ -182,6 +191,33 @@ async def test_database_relation_with_charm_libraries(ops_test: OpsTest):
         # Try to alter some data in a read-only transaction.
         with pytest.raises(psycopg2.errors.ReadOnlySqlTransaction):
             cursor.execute("DROP TABLE test;")
+
+
+@pytest.mark.group("new_relations_tests")
+@pytest.mark.abort_on_fail
+async def test_filter_out_degraded_replicas(ops_test: OpsTest):
+    primary = await get_primary(ops_test, f"{DATABASE_APP_NAME}/0")
+    replica = next(
+        unit.name
+        for unit in ops_test.model.applications[DATABASE_APP_NAME].units
+        if unit.name != primary
+    )
+    machine = await get_machine_from_unit(ops_test, replica)
+    await stop_machine(ops_test, machine)
+
+    # Topology observer runs every half a minute
+    await asyncio.sleep(60)
+
+    data = await get_application_relation_data(
+        ops_test,
+        APPLICATION_APP_NAME,
+        FIRST_DATABASE_RELATION_NAME,
+        "read-only-endpoints",
+    )
+    assert len(data.split(",")) == 1
+
+    await start_machine(ops_test, machine)
+    await ops_test.model.wait_for_idle(apps=DATABASE_APP_NAME, status="active", timeout=200)
 
 
 @pytest.mark.group("new_relations_tests")


### PR DESCRIPTION
Currently, the charm sets all replica units as readonly endpoints to clients, no matter if the unit is functioning or not.

The PR adds filtering for the read only endpoints based on Patroni's cluster endpoint.