### PR TITLE
[DPE-5533] Add `max_locks_per_transaction` config option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -17,6 +17,14 @@ options:
       “pg_catalog.english”.
     type: string
     default: "pg_catalog.simple"
+  instance_max_locks_per_transaction:
+    description: |
+      Specifies the maximum amount of memory to be used by maintenance operations,
+      such as "VACUUM", "CREATE INDEX", and "ALTER TABLE ADD FOREIGN KEY".
+      If this value is specified without units, it is taken as kilobytes.
+      Allowed values are: from 64 to 2147483647.
+    type: int
+    default: 64
   instance_password_encryption:
     description: |
       Determines the algorithm to use to encrypt the password.

--- a/src/config.py
+++ b/src/config.py
@@ -20,6 +20,7 @@ class CharmConfig(BaseConfigModel):
 
     durability_synchronous_commit: str | None
     instance_default_text_search_config: str | None
+    instance_max_locks_per_transaction: int | None
     instance_password_encryption: str | None
     logging_log_connections: bool | None
     logging_log_disconnections: bool | None
@@ -128,6 +129,15 @@ class CharmConfig(BaseConfigModel):
         """Check instance_password_encryption config option is one of `md5` or `scram-sha-256`."""
         if value not in ["md5", "scram-sha-256"]:
             raise ValueError("Value not one of 'md5' or 'scram-sha-256'")
+
+        return value
+
+    @validator("instance_max_locks_per_transaction")
+    @classmethod
+    def instance_max_locks_per_transaction_values(cls, value: int) -> int | None:
+        """Check instance_max_locks_per_transaction config option is between 64 and 2147483647."""
+        if value < 64 or value > 2147483647:
+            raise ValueError("Value is not between 64 and 2147483647")
 
         return value
 

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -38,6 +38,9 @@ async def test_config_parameters(ops_test: OpsTest) -> None:
             "durability_synchronous_commit": [test_string, "on"]
         },  # config option is one of `on`, `remote_apply` or `remote_write`
         {
+            "instance_max_locks_per_transaction": ["-1", "64"]
+        },  # config option is between 64 and 2147483647
+        {
             "instance_password_encryption": [test_string, "scram-sha-256"]
         },  # config option is one of `md5` or `scram-sha-256`
         {


### PR DESCRIPTION
# Issue
The `max_locks_per_transaction ` PostgreSQL setting is not available for users to set.

# Solution
Create a config option to expose it to the users.

Port of https://github.com/canonical/postgresql-k8s-operator/pull/804.