### PR TITLE
[DPE-6171] Fix typos in alert rules

### DIFF
--- a/src/prometheus_alert_rules/postgresql_rules.yaml
+++ b/src/prometheus_alert_rules/postgresql_rules.yaml
@@ -269,7 +269,7 @@ groups:
     # 2.2.21
     # warning -> critical
     - alert: PostgresqlInvalidIndex
-      expr: 'pg_genaral_index_info_pg_relation_size{indexrelname=~".*ccnew.*"}'
+      expr: 'pg_general_index_info_pg_relation_size{indexrelname=~".*ccnew.*"}'
       for: 6h
       labels:
         severity: critical

--- a/src/prometheus_alert_rules/postgresql_rules.yaml
+++ b/src/prometheus_alert_rules/postgresql_rules.yaml
@@ -203,7 +203,7 @@ groups:
 
     # 2.2.16
     - alert: PostgresqlConfigurationChanged
-      expr: '{__name__=~"pg_settings_.*"} != ON(__name__) {__name__=~"pg_settings_([^t]|t[^r]|tr[^a]|tra[^n]|tran[^s]|trans[^a]|transa[^c]|transac[^t]|transact[^i]|transacti[^o]|transactio[^n]|transaction[^_]|transaction_[^r]|transaction_r[^e]|transaction_re[^a]|transaction_rea[^d]|transaction_read[^_]|transaction_read_[^o]|transaction_read_o[^n]|transaction_read_on[^l]|transaction_read_onl[^y]).*"} OFFSET 5m'
+      expr: '{__name__=~"pg_settings_.*"} != ON(__name__, instance) {__name__=~"pg_settings_([^t]|t[^r]|tr[^a]|tra[^n]|tran[^s]|trans[^a]|transa[^c]|transac[^t]|transact[^i]|transacti[^o]|transactio[^n]|transaction[^_]|transaction_[^r]|transaction_r[^e]|transaction_re[^a]|transaction_rea[^d]|transaction_read[^_]|transaction_read_[^o]|transaction_read_o[^n]|transaction_read_on[^l]|transaction_read_onl[^y]).*"} OFFSET 5m'
       for: 0m
       labels:
         severity: info


### PR DESCRIPTION
Typo fixes on 2 alert rules, one of them being the root cause of https://github.com/canonical/postgresql-k8s-operator/issues/800