### PR TITLE
[MISC] Define charm utility properties

### DIFF
--- a/src/backups.py
+++ b/src/backups.py
@@ -745,7 +745,7 @@ class PostgreSQLBackups(Object):
 
     def _on_s3_credential_changed(self, event: CredentialsChangedEvent):
         """Call the stanza initialization when the credentials or the connection info change."""
-        if "cluster_initialised" not in self.charm.app_peer_data:
+        if not self.charm.is_cluster_initialised:
             logger.debug("Cannot set pgBackRest configurations, PostgreSQL has not yet started.")
             event.defer()
             return

--- a/src/backups.py
+++ b/src/backups.py
@@ -757,10 +757,7 @@ class PostgreSQLBackups(Object):
             return
 
         # Prevents S3 change in the middle of restoring backup and patroni / pgbackrest errors caused by that.
-        if (
-            "restoring-backup" in self.charm.app_peer_data
-            or "restore-to-time" in self.charm.app_peer_data
-        ):
+        if self.charm.is_cluster_restoring_backup or self.charm.is_cluster_restoring_to_time:
             logger.info("Cannot change S3 configuration during restore")
             event.defer()
             return

--- a/src/charm.py
+++ b/src/charm.py
@@ -355,6 +355,11 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         return "restore-to-time" in self.app_peer_data
 
     @property
+    def is_unit_departing(self) -> bool:
+        """Returns whether the unit is departing."""
+        return "departing" in self.unit_peer_data
+
+    @property
     def postgresql(self) -> PostgreSQL:
         """Returns an instance of the object used to interact with the database."""
         return PostgreSQL(

--- a/src/charm.py
+++ b/src/charm.py
@@ -360,6 +360,11 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         return "departing" in self.unit_peer_data
 
     @property
+    def is_unit_stopped(self) -> bool:
+        """Returns whether the unit is stopped."""
+        return "stopped" in self.unit_peer_data
+
+    @property
     def postgresql(self) -> PostgreSQL:
         """Returns an instance of the object used to interact with the database."""
         return PostgreSQL(

--- a/src/relations/async_replication.py
+++ b/src/relations/async_replication.py
@@ -524,11 +524,11 @@ class PostgreSQLAsyncReplication(Object):
         if not self._stop_database(event):
             return
 
-        if not all(
+        if not (self.charm.is_unit_stopped or self._is_following_promoted_cluster()) or not all(
             "stopped" in self.charm._peers.data[unit]
             or self.charm._peers.data[unit].get("unit-promoted-cluster-counter")
             == self._get_highest_promoted_cluster_counter_value()
-            for unit in {*self.charm._peers.units, self.charm.unit}
+            for unit in self.charm._peers.units
         ):
             self.charm.unit.status = WaitingStatus(
                 "Waiting for the database to be stopped in all units"
@@ -694,10 +694,7 @@ class PostgreSQLAsyncReplication(Object):
 
     def _stop_database(self, event: RelationChangedEvent) -> bool:
         """Stop the database."""
-        if (
-            "stopped" not in self.charm._peers.data[self.charm.unit]
-            and not self._is_following_promoted_cluster()
-        ):
+        if not self.charm.is_unit_stopped and not self._is_following_promoted_cluster():
             if not self.charm.unit.is_leader() and not os.path.exists(POSTGRESQL_DATA_PATH):
                 logger.debug("Early exit on_async_relation_changed: following promoted cluster.")
                 return False

--- a/src/relations/async_replication.py
+++ b/src/relations/async_replication.py
@@ -482,7 +482,7 @@ class PostgreSQLAsyncReplication(Object):
         return self.charm.app == self._get_primary_cluster()
 
     def _on_async_relation_broken(self, _) -> None:
-        if not self.charm._peers or "departing" in self.charm._peers.data[self.charm.unit]:
+        if not self.charm._peers or self.charm.is_unit_departing:
             logger.debug("Early exit on_async_relation_broken: Skipping departing unit.")
             return
 

--- a/src/relations/db.py
+++ b/src/relations/db.py
@@ -281,7 +281,7 @@ class DbProvides(Object):
         # https://bugs.launchpad.net/juju/+bug/1979811.
         # Neither peer relation data nor stored state
         # are good solutions, just a temporary solution.
-        if "departing" in self.charm._peers.data[self.charm.unit]:
+        if self.charm.is_unit_departing:
             logger.debug("Early exit on_relation_broken: Skipping departing unit")
             return
 

--- a/src/relations/db.py
+++ b/src/relations/db.py
@@ -117,7 +117,7 @@ class DbProvides(Object):
             return
 
         if (
-            "cluster_initialised" not in self.charm._peers.data[self.charm.app]
+            not self.charm.is_cluster_initialised
             or not self.charm._patroni.member_started
             or not self.charm.primary_endpoint
         ):
@@ -240,7 +240,7 @@ class DbProvides(Object):
             return
 
         if (
-            "cluster_initialised" not in self.charm._peers.data[self.charm.app]
+            not self.charm.is_cluster_initialised
             or not self.charm._patroni.member_started
             or not self.charm.primary_endpoint
         ):
@@ -266,7 +266,7 @@ class DbProvides(Object):
         # Check for some conditions before trying to access the PostgreSQL instance.
         if (
             not self.charm.unit.is_leader()
-            or "cluster_initialised" not in self.charm._peers.data[self.charm.app]
+            or not self.charm.is_cluster_initialised
             or not self.charm._patroni.member_started
             or not self.charm.primary_endpoint
         ):

--- a/src/relations/postgresql_provider.py
+++ b/src/relations/postgresql_provider.py
@@ -72,7 +72,7 @@ class PostgreSQLProvider(Object):
             return
 
         if (
-            "cluster_initialised" not in self.charm._peers.data[self.charm.app]
+            not self.charm.is_cluster_initialised
             or not self.charm._patroni.member_started
             or not self.charm.primary_endpoint
         ):


### PR DESCRIPTION
This PR defines a set of charm properties to reduce the chance of introducing typos when checking for specific keys in the app / unit data-bags, as well as reduce the cognitive load of logical statements.

The **new** properties are:
- `is_cluster_restoring_backup`.
- `is_cluster_restoring_to_time`.
- `is_unit_departing`
- `is_unit_stopped`.

The **existing** properties, now used throughout the codebase are:
- `is_cluster_initialised`.