### PR TITLE
[DPE-6345] LDAP III: Define config and handlers

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -69,29 +69,12 @@ options:
       Enable synchronized sequential scans.
     type: boolean
     default: true
-  ldap_base_dn:
-    description: |
-      Root DN to begin the search for the user in.
-    type: string
-  ldap_bind_dn:
-    description: |
-      DN of user to bind to the directory with to perform the search.
-    type: string
-  ldap_bind_password:
-    description: |
-      Password for user to bind to the directory with to perform the search.
-    type: string
   ldap_search_filter:
     description: |
       The LDAP search filter to match users with.
       Example: (|(uid=$username)(email=$username))
     type: string
     default: "(uid=$username)"
-  ldap_url:
-    description: |
-      An RFC 4516 LDAP URL. Combines the LDAP scheme, host and port.
-      Example: ldap://ldap.example.net:3893
-    type: string
   logging_client_min_messages:
     description: |
       Sets the message levels that are sent to the client.

--- a/config.yaml
+++ b/config.yaml
@@ -69,6 +69,29 @@ options:
       Enable synchronized sequential scans.
     type: boolean
     default: true
+  ldap_base_dn:
+    description: |
+      Root DN to begin the search for the user in.
+    type: string
+  ldap_bind_dn:
+    description: |
+      DN of user to bind to the directory with to perform the search.
+    type: string
+  ldap_bind_password:
+    description: |
+      Password for user to bind to the directory with to perform the search.
+    type: string
+  ldap_search_filter:
+    description: |
+      The LDAP search filter to match users with.
+      Example: (|(uid=$username)(email=$username))
+    type: string
+    default: "(uid=$username)"
+  ldap_url:
+    description: |
+      An RFC 4516 LDAP URL. Combines the LDAP scheme, host and port.
+      Example: ldap://ldap.example.net:3893
+    type: string
   logging_client_min_messages:
     description: |
       Sets the message levels that are sent to the client.

--- a/src/charm.py
+++ b/src/charm.py
@@ -100,6 +100,7 @@ from constants import (
     USER,
     USER_PASSWORD_KEY,
 )
+from ldap import PostgreSQLLDAP
 from relations.async_replication import (
     REPLICATION_CONSUMER_RELATION,
     REPLICATION_OFFER_RELATION,
@@ -135,6 +136,7 @@ class CannotConnectError(Exception):
         PostgreSQL,
         PostgreSQLAsyncReplication,
         PostgreSQLBackups,
+        PostgreSQLLDAP,
         PostgreSQLProvider,
         PostgreSQLTLS,
         PostgreSQLUpgrade,
@@ -206,6 +208,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         self.legacy_db_relation = DbProvides(self, admin=False)
         self.legacy_db_admin_relation = DbProvides(self, admin=True)
         self.backup = PostgreSQLBackups(self, "s3-parameters")
+        self.ldap = PostgreSQLLDAP(self, "ldap")
         self.tls = PostgreSQLTLS(self, PEER)
         self.async_replication = PostgreSQLAsyncReplication(self)
         self.restart_manager = RollingOpsManager(
@@ -910,6 +913,28 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         )
 
     @property
+    def is_connectivity_enabled(self) -> bool:
+        """Return whether this unit can be connected externally."""
+        return self.unit_peer_data.get("connectivity", "on") == "on"
+
+    @property
+    def is_ldap_charm_related(self) -> bool:
+        """Return whether this unit has an LDAP charm related."""
+        return self.app_peer_data.get("ldap_enabled", "False") == "True"
+
+    @property
+    def is_ldap_config_provided(self) -> bool:
+        """Return whether this unit has LDAP config provided."""
+        return self.config.ldap_url is not None
+
+    @property
+    def is_ldap_enabled(self) -> bool:
+        """Return whether this unit has LDAP enabled."""
+        # fmt: off
+        return self.is_cluster_initialised and \
+            (self.is_ldap_charm_related or self.is_ldap_config_provided)
+
+    @property
     def is_primary(self) -> bool:
         """Return whether this unit is the primary instance."""
         return self.unit.name == self._patroni.get_primary(unit_name_pattern=True)
@@ -1407,12 +1432,16 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         If no user is provided, the password of the operator user is returned.
         """
         username = event.params.get("username", USER)
+        if username not in PASSWORD_USERS and self.is_ldap_enabled:
+            event.fail("The action can be run only for system users when LDAP is enabled")
+            return
         if username not in PASSWORD_USERS:
             event.fail(
-                f"The action can be run only for users used by the charm or Patroni:"
+                f"The action can be run only for system users or Patroni:"
                 f" {', '.join(PASSWORD_USERS)} not {username}"
             )
             return
+
         event.set_results({"password": self.get_secret(APP_SCOPE, f"{username}-password")})
 
     def _on_set_password(self, event: ActionEvent) -> None:
@@ -1423,9 +1452,12 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             return
 
         username = event.params.get("username", USER)
+        if username not in SYSTEM_USERS and self.is_ldap_enabled:
+            event.fail("The action can be run only for system users when LDAP is enabled")
+            return
         if username not in SYSTEM_USERS:
             event.fail(
-                f"The action can be run only for users used by the charm:"
+                f"The action can be run only for system users:"
                 f" {', '.join(SYSTEM_USERS)} not {username}"
             )
             return
@@ -1911,8 +1943,9 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
 
         # Update and reload configuration based on TLS files availability.
         self._patroni.render_patroni_yml_file(
-            connectivity=self.unit_peer_data.get("connectivity", "on") == "on",
+            connectivity=self.is_connectivity_enabled,
             is_creating_backup=is_creating_backup,
+            enable_ldap=self.is_ldap_enabled,
             enable_tls=enable_tls,
             backup_id=self.app_peer_data.get("restoring-backup"),
             pitr_target=self.app_peer_data.get("restore-to-time"),
@@ -2176,6 +2209,66 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             for ext in SPI_MODULE:
                 plugins.append(ext)
         return plugins
+
+    def _ldap_config_to_params(self) -> dict:
+        """Maps the charm configuration options into the Patroni template expected fields."""
+        params = {
+            "ldapbasedn": self.config.ldap_base_dn,
+            "ldapbinddn": self.config.ldap_bind_dn,
+            "ldapbindpasswd": self.config.ldap_bind_password,
+            "ldaptls": self.is_tls_enabled,
+            "ldapurl": self.config.ldap_url,
+        }
+
+        # LDAP authentication parameters that are exclusive to
+        # one of the two supported modes (simple bind or search+bind)
+        # must be put at the very end of the parameters string
+        params.update({
+            "ldapsearchfilter": self.config.ldap_search_filter,
+        })
+
+        return params
+
+    def _ldap_databag_to_params(self) -> dict:
+        """Maps the charm configuration options into the Patroni template expected fields."""
+        data = self.ldap.get_relation_data()
+        if data is None:
+            return {}
+
+        params = {
+            "ldapbasedn": data.base_dn,
+            "ldapbinddn": data.bind_dn,
+            "ldapbindpasswd": data.bind_password,
+            "ldaptls": data.starttls,
+            "ldapurl": data.urls[0],
+        }
+
+        # LDAP authentication parameters that are exclusive to
+        # one of the two supported modes (simple bind or search+bind)
+        # must be put at the very end of the parameters string
+        params.update({
+            "ldapsearchfilter": self.config.ldap_search_filter,
+        })
+
+        return params
+
+    def get_ldap_parameters(self) -> dict:
+        """Returns the LDAP configuration to use.
+
+        The charm configuration options take preference over the GLAuth relationship data
+        """
+        params = {}
+
+        if not self.is_ldap_enabled:
+            logger.debug("LDAP is not enabled")
+        elif self.is_ldap_config_provided:
+            logger.debug("LDAP is enabled by the charm configuration")
+            params = self._ldap_config_to_params()
+        elif self.is_ldap_charm_related:
+            logger.debug("LDAP is enabled by another charm relation")
+            params = self._ldap_databag_to_params()
+
+        return params
 
 
 if __name__ == "__main__":

--- a/src/charm.py
+++ b/src/charm.py
@@ -923,16 +923,9 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         return self.app_peer_data.get("ldap_enabled", "False") == "True"
 
     @property
-    def is_ldap_config_provided(self) -> bool:
-        """Return whether this unit has LDAP config provided."""
-        return self.config.ldap_url is not None
-
-    @property
     def is_ldap_enabled(self) -> bool:
         """Return whether this unit has LDAP enabled."""
-        # fmt: off
-        return self.is_cluster_initialised and \
-            (self.is_ldap_charm_related or self.is_ldap_config_provided)
+        return self.is_ldap_charm_related and self.is_cluster_initialised
 
     @property
     def is_primary(self) -> bool:
@@ -2210,27 +2203,14 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
                 plugins.append(ext)
         return plugins
 
-    def _ldap_config_to_params(self) -> dict:
-        """Maps the charm configuration options into the Patroni template expected fields."""
-        params = {
-            "ldapbasedn": self.config.ldap_base_dn,
-            "ldapbinddn": self.config.ldap_bind_dn,
-            "ldapbindpasswd": self.config.ldap_bind_password,
-            "ldaptls": self.is_tls_enabled,
-            "ldapurl": self.config.ldap_url,
-        }
+    def get_ldap_parameters(self) -> dict:
+        """Returns the LDAP configuration to use."""
+        if not self.is_cluster_initialised:
+            return {}
+        if not self.is_ldap_charm_related:
+            logger.debug("LDAP is not enabled")
+            return {}
 
-        # LDAP authentication parameters that are exclusive to
-        # one of the two supported modes (simple bind or search+bind)
-        # must be put at the very end of the parameters string
-        params.update({
-            "ldapsearchfilter": self.config.ldap_search_filter,
-        })
-
-        return params
-
-    def _ldap_databag_to_params(self) -> dict:
-        """Maps the charm configuration options into the Patroni template expected fields."""
         data = self.ldap.get_relation_data()
         if data is None:
             return {}
@@ -2249,24 +2229,6 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         params.update({
             "ldapsearchfilter": self.config.ldap_search_filter,
         })
-
-        return params
-
-    def get_ldap_parameters(self) -> dict:
-        """Returns the LDAP configuration to use.
-
-        The charm configuration options take preference over the GLAuth relationship data
-        """
-        params = {}
-
-        if not self.is_ldap_enabled:
-            logger.debug("LDAP is not enabled")
-        elif self.is_ldap_config_provided:
-            logger.debug("LDAP is enabled by the charm configuration")
-            params = self._ldap_config_to_params()
-        elif self.is_ldap_charm_related:
-            logger.debug("LDAP is enabled by another charm relation")
-            params = self._ldap_databag_to_params()
 
         return params
 

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -162,6 +162,17 @@ class Patroni:
         """Patroni REST API URL."""
         return f"{'https' if self.tls_enabled else 'http'}://{self.unit_ip}:8008"
 
+    @staticmethod
+    def _dict_to_hba_string(_dict: dict[str, Any]) -> str:
+        """Transform a dictionary into a Host Based Authentication valid string."""
+        for key, value in _dict.items():
+            if isinstance(value, bool):
+                _dict[key] = int(value)
+            if isinstance(value, str):
+                _dict[key] = f'"{value}"'
+
+        return " ".join(f"{key}={value}" for key, value in _dict.items())
+
     def bootstrap_cluster(self) -> bool:
         """Bootstrap a PostgreSQL cluster using Patroni."""
         # Render the configuration files and start the cluster.
@@ -610,6 +621,7 @@ class Patroni:
         self,
         connectivity: bool = False,
         is_creating_backup: bool = False,
+        enable_ldap: bool = False,
         enable_tls: bool = False,
         stanza: str | None = None,
         restore_stanza: str | None = None,
@@ -626,6 +638,7 @@ class Patroni:
         Args:
             connectivity: whether to allow external connections to the database.
             is_creating_backup: whether this unit is creating a backup.
+            enable_ldap: whether to enable LDAP authentication.
             enable_tls: whether to enable TLS.
             stanza: name of the stanza created by pgBackRest.
             restore_stanza: name of the stanza used when restoring a backup.
@@ -640,6 +653,9 @@ class Patroni:
         # Open the template patroni.yml file.
         with open("templates/patroni.yml.j2") as file:
             template = Template(file.read())
+
+        ldap_params = self.charm.get_ldap_parameters()
+
         # Render the template file with the correct values.
         rendered = template.render(
             conf_path=PATRONI_CONF_PATH,
@@ -648,6 +664,7 @@ class Patroni:
             log_path=PATRONI_LOGS_PATH,
             postgresql_log_path=POSTGRESQL_LOGS_PATH,
             data_path=POSTGRESQL_DATA_PATH,
+            enable_ldap=enable_ldap,
             enable_tls=enable_tls,
             member_name=self.member_name,
             partner_addrs=self.charm.async_replication.get_partner_addresses()
@@ -677,6 +694,7 @@ class Patroni:
             primary_cluster_endpoint=self.charm.async_replication.get_primary_cluster_endpoint(),
             extra_replication_endpoints=self.charm.async_replication.get_standby_endpoints(),
             raft_password=self.raft_password,
+            ldap_parameters=self._dict_to_hba_string(ldap_params),
             patroni_password=self.patroni_password,
         )
         self.render_file(f"{PATRONI_CONF_PATH}/patroni.yaml", rendered, 0o600)

--- a/src/config.py
+++ b/src/config.py
@@ -8,7 +8,7 @@ import logging
 from typing import Literal
 
 from charms.data_platform_libs.v0.data_models import BaseConfigModel
-from pydantic import PositiveInt, root_validator, validator
+from pydantic import PositiveInt, validator
 
 from locales import SNAP_LOCALES
 
@@ -29,11 +29,7 @@ class CharmConfig(BaseConfigModel):
     instance_max_locks_per_transaction: int | None
     instance_password_encryption: str | None
     instance_synchronize_seqscans: bool | None
-    ldap_base_dn: str | None
-    ldap_bind_dn: str | None
-    ldap_bind_password: str | None
     ldap_search_filter: str | None
-    ldap_url: str | None
     logging_client_min_messages: str | None
     logging_log_connections: bool | None
     logging_log_disconnections: bool | None
@@ -202,20 +198,6 @@ class CharmConfig(BaseConfigModel):
         """Return plugin config names in a iterable."""
         return filter(lambda x: x.startswith("plugin_"), cls.keys())
 
-    @root_validator(skip_on_failure=False)
-    @classmethod
-    def check_ldap_search_options(cls, values):
-        """Check all LDAP necessary config options are provided."""
-        ldap_url = values.get("ldap_url")
-        ldap_base_dn = values.get("ldap_base_dn")
-        ldap_bind_dn = values.get("ldap_bind_dn")
-        ldap_bind_password = values.get("ldap_bind_password")
-
-        if ldap_url and not all((ldap_base_dn, ldap_bind_dn, ldap_bind_password)):
-            raise ValueError("To use LDAP: base_dn, bind_dn and bind_password are required")
-
-        return values
-
     @validator("durability_synchronous_commit")
     @classmethod
     def durability_synchronous_commit_values(cls, value: str) -> str | None:
@@ -249,15 +231,6 @@ class CharmConfig(BaseConfigModel):
         """Check instance_max_locks_per_transaction config option is between 64 and 2147483647."""
         if value < 64 or value > 2147483647:
             raise ValueError("Value is not between 64 and 2147483647")
-
-        return value
-
-    @validator("ldap_url")
-    @classmethod
-    def ldap_url_values(cls, value: str) -> str | None:
-        """Check LDAP URL config option does not start with `ldaps`."""
-        if value.startswith("ldaps"):
-            raise ValueError("To use TLS encryption state the normal `ldap` scheme")
 
         return value
 

--- a/src/config.py
+++ b/src/config.py
@@ -8,7 +8,7 @@ import logging
 from typing import Literal
 
 from charms.data_platform_libs.v0.data_models import BaseConfigModel
-from pydantic import PositiveInt, validator
+from pydantic import PositiveInt, root_validator, validator
 
 from locales import SNAP_LOCALES
 
@@ -29,6 +29,11 @@ class CharmConfig(BaseConfigModel):
     instance_max_locks_per_transaction: int | None
     instance_password_encryption: str | None
     instance_synchronize_seqscans: bool | None
+    ldap_base_dn: str | None
+    ldap_bind_dn: str | None
+    ldap_bind_password: str | None
+    ldap_search_filter: str | None
+    ldap_url: str | None
     logging_client_min_messages: str | None
     logging_log_connections: bool | None
     logging_log_disconnections: bool | None
@@ -197,6 +202,20 @@ class CharmConfig(BaseConfigModel):
         """Return plugin config names in a iterable."""
         return filter(lambda x: x.startswith("plugin_"), cls.keys())
 
+    @root_validator(skip_on_failure=False)
+    @classmethod
+    def check_ldap_search_options(cls, values):
+        """Check all LDAP necessary config options are provided."""
+        ldap_url = values.get("ldap_url")
+        ldap_base_dn = values.get("ldap_base_dn")
+        ldap_bind_dn = values.get("ldap_bind_dn")
+        ldap_bind_password = values.get("ldap_bind_password")
+
+        if ldap_url and not all((ldap_base_dn, ldap_bind_dn, ldap_bind_password)):
+            raise ValueError("To use LDAP: base_dn, bind_dn and bind_password are required")
+
+        return values
+
     @validator("durability_synchronous_commit")
     @classmethod
     def durability_synchronous_commit_values(cls, value: str) -> str | None:
@@ -230,6 +249,15 @@ class CharmConfig(BaseConfigModel):
         """Check instance_max_locks_per_transaction config option is between 64 and 2147483647."""
         if value < 64 or value > 2147483647:
             raise ValueError("Value is not between 64 and 2147483647")
+
+        return value
+
+    @validator("ldap_url")
+    @classmethod
+    def ldap_url_values(cls, value: str) -> str | None:
+        """Check LDAP URL config option does not start with `ldaps`."""
+        if value.startswith("ldaps"):
+            raise ValueError("To use TLS encryption state the normal `ldap` scheme")
 
         return value
 

--- a/src/ldap.py
+++ b/src/ldap.py
@@ -1,0 +1,85 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""LDAP implementation."""
+
+import logging
+
+from charms.glauth_k8s.v0.ldap import (
+    LdapProviderData,
+    LdapReadyEvent,
+    LdapRequirer,
+    LdapUnavailableEvent,
+)
+from charms.postgresql_k8s.v0.postgresql_tls import (
+    TLS_TRANSFER_RELATION,
+)
+from ops import Relation
+from ops.framework import Object
+from ops.model import ActiveStatus, BlockedStatus
+
+logger = logging.getLogger(__name__)
+
+
+class PostgreSQLLDAP(Object):
+    """In this class, we manage PostgreSQL LDAP access."""
+
+    def __init__(self, charm, relation_name: str):
+        """Manager of PostgreSQL LDAP."""
+        super().__init__(charm, "ldap")
+        self.charm = charm
+        self.relation_name = relation_name
+
+        # LDAP relation handles the config options for LDAP access
+        self.ldap = LdapRequirer(self.charm, self.relation_name)
+        self.framework.observe(self.ldap.on.ldap_ready, self._on_ldap_ready)
+        self.framework.observe(self.ldap.on.ldap_unavailable, self._on_ldap_unavailable)
+
+    @property
+    def ca_transferred(self) -> bool:
+        """Return whether the CA certificate has been transferred."""
+        ca_transferred_relations = self.model.relations[TLS_TRANSFER_RELATION]
+
+        for relation in ca_transferred_relations:
+            if relation.app.name == self._relation.app.name:
+                return True
+
+        return False
+
+    @property
+    def _relation(self) -> Relation:
+        """Return the relation object."""
+        return self.model.get_relation(self.relation_name)
+
+    def _on_ldap_ready(self, event: LdapReadyEvent) -> None:
+        """Handler for the LDAP ready event."""
+        if not self.ca_transferred:
+            self.charm.unit.status = BlockedStatus("LDAP insecure. Send LDAP server certificate")
+            event.defer()
+            return
+
+        logger.debug("Enabling LDAP connection")
+        if self.charm.unit.is_leader():
+            self.charm.app_peer_data.update({"ldap_enabled": "True"})
+
+        self.charm.update_config()
+        self.charm.unit.status = ActiveStatus()
+
+    def _on_ldap_unavailable(self, _: LdapUnavailableEvent) -> None:
+        """Handler for the LDAP unavailable event."""
+        logger.debug("Disabling LDAP connection")
+        if self.charm.unit.is_leader():
+            self.charm.app_peer_data.update({"ldap_enabled": "False"})
+
+        self.charm.update_config()
+
+    def get_relation_data(self) -> LdapProviderData | None:
+        """Get the LDAP info from the LDAP Provider class."""
+        data = self.ldap.consume_ldap_relation_data(relation=self._relation)
+        if data is None:
+            logger.warning("LDAP relation is not ready")
+
+        if not self.charm.is_connectivity_enabled:
+            logger.warning("LDAP server will not be accessible")
+
+        return data

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -161,10 +161,14 @@ postgresql:
     {%- if not connectivity %}
     - {{ 'hostssl' if enable_tls else 'host' }} all all 0.0.0.0/0 reject
     - {{ 'hostssl' if enable_tls else 'host' }} all all {{ self_ip }} md5
-    {% else %}
-    - {{ 'hostssl' if enable_tls else 'host' }} replication replication 127.0.0.1/32 md5
-    {%- endif %}
+    {%- elif enable_ldap %}
+    - {{ 'hostssl' if enable_tls else 'host' }} all +identity_access 0.0.0.0/0 ldap {{ ldap_parameters }}
+    - {{ 'hostssl' if enable_tls else 'host' }} all +internal_access 0.0.0.0/0 md5
+    - {{ 'hostssl' if enable_tls else 'host' }} all +relation_access 0.0.0.0/0 md5
+    {%- else %}
     - {{ 'hostssl' if enable_tls else 'host' }} all all 0.0.0.0/0 md5
+    {%- endif %}
+    - {{ 'hostssl' if enable_tls else 'host' }} replication replication 127.0.0.1/32 md5
     # Allow replications connections from other cluster members.
     {%- for endpoint in extra_replication_endpoints %}
     - {{ 'hostssl' if enable_tls else 'host' }} replication replication {{ endpoint }}/32 md5

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -2851,24 +2851,13 @@ def test_on_promote_to_primary(harness):
 
 def test_get_ldap_parameters(harness):
     with (
-        patch("charm.PostgresqlOperatorCharm.config", new_callable=PropertyMock) as _config,
-        patch("charm.PostgresqlOperatorCharm._ldap_config_to_params") as _config_to_params,
-        patch("charm.PostgresqlOperatorCharm._ldap_databag_to_params") as _databag_to_params,
+        patch("charm.PostgreSQLLDAP.get_relation_data") as _get_relation_data,
         patch(
             target="charm.PostgresqlOperatorCharm.is_cluster_initialised",
             new_callable=PropertyMock,
             return_value=True,
         ) as _cluster_initialised,
     ):
-        # When LDAP is not configured or related, no params are returned
-        _config.return_value = MagicMock(ldap_url=None)
-
-        harness.charm.get_ldap_parameters()
-        _config_to_params.assert_not_called()
-        _databag_to_params.assert_not_called()
-
-        # When LDAP is configured, params string is built from the config values
-        _config.return_value = MagicMock(ldap_url="ldap://0.0.0.0:3893")
         with harness.hooks_disabled():
             harness.update_relation_data(
                 harness.model.get_relation(PEER).id,
@@ -2877,13 +2866,9 @@ def test_get_ldap_parameters(harness):
             )
 
         harness.charm.get_ldap_parameters()
-        _config_to_params.assert_called_once()
-        _config_to_params.reset_mock()
-        _databag_to_params.assert_not_called()
-        _databag_to_params.reset_mock()
+        _get_relation_data.assert_not_called()
+        _get_relation_data.reset_mock()
 
-        # When LDAP is related, params string is built from the databag values
-        _config.return_value = MagicMock(ldap_url=None)
         with harness.hooks_disabled():
             harness.update_relation_data(
                 harness.model.get_relation(PEER).id,
@@ -2892,7 +2877,5 @@ def test_get_ldap_parameters(harness):
             )
 
         harness.charm.get_ldap_parameters()
-        _config_to_params.assert_not_called()
-        _config_to_params.reset_mock()
-        _databag_to_params.assert_called_once()
-        _databag_to_params.reset_mock()
+        _get_relation_data.assert_called_once()
+        _get_relation_data.reset_mock()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1301,6 +1301,7 @@ def test_update_config(harness):
         _render_patroni_yml_file.assert_called_once_with(
             connectivity=True,
             is_creating_backup=False,
+            enable_ldap=False,
             enable_tls=False,
             backup_id=None,
             stanza=None,
@@ -1325,6 +1326,7 @@ def test_update_config(harness):
         _render_patroni_yml_file.assert_called_once_with(
             connectivity=True,
             is_creating_backup=False,
+            enable_ldap=False,
             enable_tls=True,
             backup_id=None,
             stanza=None,
@@ -2845,3 +2847,52 @@ def test_on_promote_to_primary(harness):
         harness.charm._on_promote_to_primary(event)
         _raft_reinitialisation.assert_called_once_with()
         assert harness.charm.unit_peer_data["raft_candidate"] == "True"
+
+
+def test_get_ldap_parameters(harness):
+    with (
+        patch("charm.PostgresqlOperatorCharm.config", new_callable=PropertyMock) as _config,
+        patch("charm.PostgresqlOperatorCharm._ldap_config_to_params") as _config_to_params,
+        patch("charm.PostgresqlOperatorCharm._ldap_databag_to_params") as _databag_to_params,
+        patch(
+            target="charm.PostgresqlOperatorCharm.is_cluster_initialised",
+            new_callable=PropertyMock,
+            return_value=True,
+        ) as _cluster_initialised,
+    ):
+        # When LDAP is not configured or related, no params are returned
+        _config.return_value = MagicMock(ldap_url=None)
+
+        harness.charm.get_ldap_parameters()
+        _config_to_params.assert_not_called()
+        _databag_to_params.assert_not_called()
+
+        # When LDAP is configured, params string is built from the config values
+        _config.return_value = MagicMock(ldap_url="ldap://0.0.0.0:3893")
+        with harness.hooks_disabled():
+            harness.update_relation_data(
+                harness.model.get_relation(PEER).id,
+                harness.charm.app.name,
+                {"ldap_enabled": "False"},
+            )
+
+        harness.charm.get_ldap_parameters()
+        _config_to_params.assert_called_once()
+        _config_to_params.reset_mock()
+        _databag_to_params.assert_not_called()
+        _databag_to_params.reset_mock()
+
+        # When LDAP is related, params string is built from the databag values
+        _config.return_value = MagicMock(ldap_url=None)
+        with harness.hooks_disabled():
+            harness.update_relation_data(
+                harness.model.get_relation(PEER).id,
+                harness.charm.app.name,
+                {"ldap_enabled": "True"},
+            )
+
+        harness.charm.get_ldap_parameters()
+        _config_to_params.assert_not_called()
+        _config_to_params.reset_mock()
+        _databag_to_params.assert_called_once()
+        _databag_to_params.reset_mock()

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -181,6 +181,24 @@ def test_get_postgresql_version(peers_ips, patroni):
         _get_installed_snaps.assert_called_once_with()
 
 
+def test_dict_to_hba_string(harness, patroni):
+    mock_data = {
+        "ldapbasedn": "dc=example,dc=net",
+        "ldapbinddn": "cn=serviceuser,dc=example,dc=net",
+        "ldapbindpasswd": "password",
+        "ldaptls": False,
+        "ldapurl": "ldap://0.0.0.0:3893",
+    }
+
+    assert patroni._dict_to_hba_string(mock_data) == (
+        'ldapbasedn="dc=example,dc=net" '
+        'ldapbinddn="cn=serviceuser,dc=example,dc=net" '
+        'ldapbindpasswd="password" '
+        "ldaptls=0 "
+        'ldapurl="ldap://0.0.0.0:3893"'
+    )
+
+
 def test_get_primary(peers_ips, patroni):
     with (
         patch("requests.get", side_effect=mocked_requests_get) as _get,

--- a/tests/unit/test_ldap.py
+++ b/tests/unit/test_ldap.py
@@ -3,7 +3,6 @@
 
 from unittest.mock import (
     MagicMock,
-    PropertyMock,
     patch,
 )
 
@@ -29,36 +28,16 @@ def harness():
     harness.cleanup()
 
 
-def test_on_ldap_ready_with_certificate(harness):
+def test_on_ldap_ready(harness):
     mock_event = MagicMock()
 
-    with (
-        patch("charm.PostgresqlOperatorCharm.update_config") as _update_config,
-        patch("charm.PostgreSQLLDAP.ca_transferred", new_callable=PropertyMock) as _ca_transferred,
-    ):
-        _ca_transferred.return_value = True
+    with patch("charm.PostgresqlOperatorCharm.update_config") as _update_config:
         harness.charm.ldap._on_ldap_ready(mock_event)
         _update_config.assert_called_once()
 
         peer_rel_id = harness.model.get_relation(PEER).id
         app_databag = harness.get_relation_data(peer_rel_id, harness.charm.app)
         assert "ldap_enabled" in app_databag
-
-
-def test_on_ldap_ready_without_certificate(harness):
-    mock_event = MagicMock()
-
-    with (
-        patch("charm.PostgresqlOperatorCharm.update_config") as _update_config,
-        patch("charm.PostgreSQLLDAP.ca_transferred", new_callable=PropertyMock) as _ca_transferred,
-    ):
-        _ca_transferred.return_value = False
-        harness.charm.ldap._on_ldap_ready(mock_event)
-        _update_config.assert_not_called()
-
-        peer_rel_id = harness.model.get_relation(PEER).id
-        app_databag = harness.get_relation_data(peer_rel_id, harness.charm.app)
-        assert "ldap_enabled" not in app_databag
 
 
 def test_on_ldap_unavailable(harness):

--- a/tests/unit/test_ldap.py
+++ b/tests/unit/test_ldap.py
@@ -1,0 +1,97 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from unittest.mock import (
+    MagicMock,
+    PropertyMock,
+    patch,
+)
+
+import pytest
+from charms.glauth_k8s.v0.ldap import LdapProviderData
+from ops.testing import Harness
+
+from charm import PostgresqlOperatorCharm
+from constants import PEER
+
+
+@pytest.fixture(autouse=True)
+def harness():
+    harness = Harness(PostgresqlOperatorCharm)
+
+    # Set up the initial relation and hooks.
+    peer_relation_id = harness.add_relation(PEER, "postgresql")
+    harness.add_relation_unit(peer_relation_id, "postgresql/0")
+    harness.set_leader(True)
+
+    harness.begin()
+    yield harness
+    harness.cleanup()
+
+
+def test_on_ldap_ready_with_certificate(harness):
+    mock_event = MagicMock()
+
+    with (
+        patch("charm.PostgresqlOperatorCharm.update_config") as _update_config,
+        patch("charm.PostgreSQLLDAP.ca_transferred", new_callable=PropertyMock) as _ca_transferred,
+    ):
+        _ca_transferred.return_value = True
+        harness.charm.ldap._on_ldap_ready(mock_event)
+        _update_config.assert_called_once()
+
+        peer_rel_id = harness.model.get_relation(PEER).id
+        app_databag = harness.get_relation_data(peer_rel_id, harness.charm.app)
+        assert "ldap_enabled" in app_databag
+
+
+def test_on_ldap_ready_without_certificate(harness):
+    mock_event = MagicMock()
+
+    with (
+        patch("charm.PostgresqlOperatorCharm.update_config") as _update_config,
+        patch("charm.PostgreSQLLDAP.ca_transferred", new_callable=PropertyMock) as _ca_transferred,
+    ):
+        _ca_transferred.return_value = False
+        harness.charm.ldap._on_ldap_ready(mock_event)
+        _update_config.assert_not_called()
+
+        peer_rel_id = harness.model.get_relation(PEER).id
+        app_databag = harness.get_relation_data(peer_rel_id, harness.charm.app)
+        assert "ldap_enabled" not in app_databag
+
+
+def test_on_ldap_unavailable(harness):
+    mock_event = MagicMock()
+
+    with patch("charm.PostgresqlOperatorCharm.update_config") as _update_config:
+        harness.charm.ldap._on_ldap_unavailable(mock_event)
+        _update_config.assert_called_once()
+
+        peer_rel_id = harness.model.get_relation(PEER).id
+        app_databag = harness.get_relation_data(peer_rel_id, harness.charm.app)
+        assert app_databag["ldap_enabled"] == "False"
+
+
+def test_get_relation_data(harness):
+    mock_data = LdapProviderData(
+        auth_method="simple",
+        base_dn="dc=example,dc=net",
+        bind_dn="cn=serviceuser,dc=example,dc=net",
+        bind_password="password",
+        bind_password_secret=None,
+        starttls=False,
+        ldaps_urls=[],
+        urls=[],
+    )
+
+    mock_data_dict = mock_data.model_dump(exclude_none=True)
+    mock_data_dict["bind_password"] = mock_data.bind_password
+
+    assert harness.charm.ldap.get_relation_data() is None
+
+    with harness.hooks_disabled():
+        ldap_relation_id = harness.add_relation("ldap", "glauth-k8s")
+        harness.update_relation_data(ldap_relation_id, "glauth-k8s", mock_data_dict)
+
+    assert harness.charm.ldap.get_relation_data() == mock_data


### PR DESCRIPTION
This is the 3rd PR to introduce LDAP support into PostgreSQL. The complete list of changes can be seen in [this branch](https://github.com/canonical/postgresql-operator/tree/sinclert/ldap-integration-all).

### Contents

This PR extends the charm configuration to include all the initially proposed configuration options, which are useful for local debugging (some of them will go away before marking the integration complete). In addition, it creates the [PostgreSQLLDAP](https://github.com/canonical/postgresql-operator/blob/ldap-integration/handler-methods/src/ldap.py) class to hold all the GLAuth related handlers, similar to how other classes within the charm hold all the handlers for a particular functionality (i.e. `PostgreSQLBackups`, `PostgreSQLUpgrades`, etc).

### References

- PostgreSQL-LDAP [specification](https://docs.google.com/document/d/1Wt9VhdYCVzPh6qfwYiKOcfQwQ6UW6765S09dFjnuBXY/edit?tab=t.0).

---

Depends on PRs https://github.com/canonical/postgresql-operator/pull/823 and https://github.com/canonical/postgresql-operator/pull/824.
