### PR TITLE
[MISC] Fix cluster initialize on primary

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -1324,10 +1324,10 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             self.unit.status = BlockedStatus("failed to start Patroni")
             return
 
-        # Assert the member is up and running before marking it as initialised.
-        if not self._patroni.member_started:
-            logger.debug("Deferring on_start: awaiting for member to start")
-            self.unit.status = WaitingStatus("awaiting for member to start")
+        # Assert the primary is up and running before marking it as initialised.
+        if not self.primary_endpoint:
+            logger.debug("Deferring on_start: awaiting for primary endpoint to be ready")
+            self.unit.status = WaitingStatus("awaiting for primary endpoint to be ready")
             event.defer()
             return
 


### PR DESCRIPTION
This PR fixes a subtle bug, where upon cluster initialization, the primary instance was waiting on Patroni `member_started`, instead on the primary endpoint being available.

This approach falls short when performing further operations on the `_start_primary` [method](https://github.com/canonical/postgresql-operator/blob/d35b18dd19fb61b1cea25e37e95ee1f67b388cc6/src/charm.py#L1320-L1376), as the default database cannot be connected to when trying to list users / groups (see failing [CI job](https://github.com/canonical/postgresql-operator/actions/runs/14311792544/job/40157790705)). The problem has been surfaced after **correctly** closing the connection on the PostgreSQL `list_users` charm lib [method](https://github.com/canonical/postgresql-k8s-operator/blob/5041520156a0a5cb005687acd7a137820b0a0b87/lib/charms/postgresql_k8s/v0/postgresql.py#L657-L659).