### PR TITLE
Update README file's security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ To deploy on Kubernetes, please use [Charmed PostgreSQL K8s Operator](https://ch
 This operator provides a PostgreSQL database with replication enabled: one primary instance and one (or more) hot standby replicas. The Operator in this repository is a Python script which wraps PostgreSQL versions distributed by Ubuntu Jammy series and adding [Patroni](https://github.com/zalando/patroni) on top of it, providing lifecycle management and handling events (install, configure, integrate, remove, etc).
 
 ## README contents
+
 * [Basic usage](#basic-usage): Deploy and scale Charmerd PostgreSQL
 * [Integrations](#integrations-relations): Supported interfaces for integrations
 * [Contributing](#contributing)
@@ -20,6 +21,7 @@ This operator provides a PostgreSQL database with replication enabled: one prima
 ## Basic usage
 
 ### Deployment
+
 Bootstrap a [lxd controller](https://juju.is/docs/olm/lxd#heading--create-a-controller) and create a new Juju model:
 
 ```shell
@@ -46,7 +48,9 @@ To add replicas to an existing deployment, see the [Add replicas](#add-replicas)
 >It is generally recommended to have an odd number of units to avoid a "[split-brain](https://en.wikipedia.org/wiki/Split-brain_(computing))" scenario
 
 ### Primary replica
+
 To retrieve the primary replica, use the action `get-primary` on any of the units running PostgreSQL.
+
 ```shell
 juju run postgresql/leader get-primary
 ```
@@ -58,17 +62,21 @@ Similarly, the primary replica is displayed as a status message in `juju status`
 #### Add replicas
 
 To add more replicas one can use the `juju add-unit` functionality i.e.
+
 ```shell
 juju add-unit postgresql -n <number_of_units_to_add>
 ```
+
 The implementation of `add-unit` allows the operator to add more than one unit, but functions internally by adding one replica at a time. This is done to avoid multiple replicas syncing from the primary at the same time.
 
 #### Remove replicas
 
 To scale down the number of replicas the `juju remove-unit` functionality may be used i.e.
+
 ```shell
 juju remove-unit postgresql <name_of_unit_1> <name_of_unit_2>
 ```
+
 The implementation of `remove-unit` allows the operator to remove more than one unit. The functionality of `remove-unit` functions by removing one replica at a time to avoid downtime.
 
 ### Password rotation
@@ -76,9 +84,11 @@ The implementation of `remove-unit` allows the operator to remove more than one 
 #### Charm users
 
 To rotate the password of users internal to the Charmed PostgreSQL operator, use the `set-password` action as follows:
+
 ```shell
 juju run postgresql/leader set-password username=<user> password=<password>
 ```
+
 >[!NOTE]
 >Currently, internal users are `operator`, `replication`, `backup` and `rewind`. These users should not be used outside the operator.
 
@@ -90,7 +100,7 @@ To rotate the passwords of users created for integrated applications, the integr
 
 Supported [integrations](https://juju.is/docs/olm/relations):
 
-#### New `postgresql_client` interface:
+#### New `postgresql_client` interface
 
 Current charm relies on [Data Platform libraries](https://charmhub.io/data-platform-libs). Your
 application should define an interface in `metadata.yaml`:
@@ -125,14 +135,15 @@ To remove a relation:
 juju remove-relation postgresql <application_name>
 ```
 
-#### Legacy `pgsql` interface:
+#### Legacy `pgsql` interface
+
 We have also added support for the two database legacy relations from the [original version](https://launchpad.net/postgresql-charm) of the charm via the `pgsql` interface. Please note that these relations will be deprecated.
  ```shell
 juju relate postgresql:db mailman3-core
 juju relate postgresql:db-admin landscape-server
 ```
 
-#### `tls-certificates` interface:
+#### `tls-certificates` interface
 
 The Charmed PostgreSQL Operator also supports TLS encryption on internal and external connections. Below is an example of enabling TLS with the [self-signed certificates charm](https://charmhub.io/self-signed-certificates).
 
@@ -146,19 +157,23 @@ juju integrate postgresql self-signed-certificates
 # Disable TLS by removing relation.
 juju remove-relation postgresql self-signed-certificates
 ```
+
 >[!WARNING]
 >The TLS settings shown here are for self-signed-certificates, which are not recommended for production clusters. See the guide [Security with X.509 certificates](https://charmhub.io/topics/security-with-x-509-certificates) for an overview of available certificates charms.
 
 ## Security
+
 Security issues in the Charmed PostgreSQL Operator can be reported through [LaunchPad](https://wiki.ubuntu.com/DebuggingSecurity#How%20to%20File). Please do not use GitHub to submit security issues.
 
 ## Contributing
+
 * For best practices on how to write and contribute to charms, see the [Juju SDK docs](https://juju.is/docs/sdk/how-to)
 * For more specific developer guidance for contributions to Charmed PostgreSQL, see the file [CONTRIBUTING.md](CONTRIBUTING.md)
 * Report security issues for the Charmed PostgreSQL Operator through [LaunchPad](https://wiki.ubuntu.com/DebuggingSecurity#How%20to%20File).
 * Report technical issues, bug reports and feature requests through the [GitHub Issues tab](https://github.com/canonical/postgresql-operator/issues).
 
 ## Licensing and trademark
+
 The Charmed PostgreSQL Operator is distributed under the [Apache Software License, version 2.0](https://github.com/canonical/postgresql-operator/blob/main/LICENSE). It installs, operates and depends on [PostgreSQL](https://www.postgresql.org/ftp/source/), which is licensed under the [PostgreSQL License](https://www.postgresql.org/about/licence/), a liberal Open Source license similar to the BSD or MIT licenses.
 
 PostgreSQL is a trademark or registered trademark of PostgreSQL Global Development Group. Other trademarks are property of their respective owners.

--- a/README.md
+++ b/README.md
@@ -163,7 +163,8 @@ juju remove-relation postgresql self-signed-certificates
 
 ## Security
 
-Security issues in the Charmed PostgreSQL Operator can be reported through [LaunchPad](https://wiki.ubuntu.com/DebuggingSecurity#How%20to%20File). Please do not use GitHub to submit security issues.
+Security issues in the Charmed PostgreSQL Operator can be reported through [private security reports](https://github.com/canonical/postgresql-operator/security/advisories/new) on GitHub.
+For more information, see the [Security policy](SECURITY.md).
 
 ## Contributing
 


### PR DESCRIPTION
## Issue

Security section of the README contains an old link to the LaunchPad.
We are using GitHub Private vulnerability reporting now.

## Solution

Update the link and wording,
Additionally, minor refactoring for headings syntax.

## Checklist

- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
