### PR TITLE
[DPE-6345] LDAP IV: Define snap service

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -3,8 +3,14 @@
 
 """A collection of utility functions that are used in the charm."""
 
+import platform
 import secrets
 import string
+
+from constants import (
+    POSTGRESQL_SNAP_NAME,
+    SNAP_PACKAGES,
+)
 
 
 def new_password() -> str:
@@ -16,3 +22,16 @@ def new_password() -> str:
     choices = string.ascii_letters + string.digits
     password = "".join([secrets.choice(choices) for i in range(16)])
     return password
+
+
+def snap_refreshed(target_rev: str) -> bool:
+    """Whether the snap was refreshed to the target version."""
+    arch = platform.machine()
+
+    for snap_package in SNAP_PACKAGES:
+        snap_name = snap_package[0]
+        snap_revs = snap_package[1]["revision"]
+        if snap_name == POSTGRESQL_SNAP_NAME and target_rev != snap_revs.get(arch):
+            return False
+
+    return True

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1274,6 +1274,12 @@ def test_update_config(harness):
         patch(
             "charm.PostgresqlOperatorCharm._handle_postgresql_restart_need"
         ) as _handle_postgresql_restart_need,
+        patch(
+            "charm.PostgresqlOperatorCharm._restart_metrics_service"
+        ) as _restart_metrics_service,
+        patch(
+            "charm.PostgresqlOperatorCharm._restart_ldap_sync_service"
+        ) as _restart_ldap_sync_service,
         patch("charm.Patroni.bulk_update_parameters_controller_by_patroni"),
         patch("charm.Patroni.member_started", new_callable=PropertyMock) as _member_started,
         patch(
@@ -1313,10 +1319,14 @@ def test_update_config(harness):
             no_peers=False,
         )
         _handle_postgresql_restart_need.assert_called_once_with(False)
+        _restart_ldap_sync_service.assert_called_once()
+        _restart_metrics_service.assert_called_once()
         assert "tls" not in harness.get_relation_data(rel_id, harness.charm.unit.name)
 
         # Test with TLS files available.
         _handle_postgresql_restart_need.reset_mock()
+        _restart_ldap_sync_service.reset_mock()
+        _restart_metrics_service.reset_mock()
         harness.update_relation_data(
             rel_id, harness.charm.unit.name, {"tls": ""}
         )  # Mock some data in the relation to test that it change.
@@ -1338,6 +1348,8 @@ def test_update_config(harness):
             no_peers=False,
         )
         _handle_postgresql_restart_need.assert_called_once()
+        _restart_ldap_sync_service.assert_called_once()
+        _restart_metrics_service.assert_called_once()
         assert "tls" not in harness.get_relation_data(
             rel_id, harness.charm.unit.name
         )  # The "tls" flag is set in handle_postgresql_restart_need.
@@ -1347,6 +1359,8 @@ def test_update_config(harness):
             rel_id, harness.charm.unit.name, {"tls": ""}
         )  # Mock some data in the relation to test that it change.
         _handle_postgresql_restart_need.reset_mock()
+        _restart_ldap_sync_service.reset_mock()
+        _restart_metrics_service.reset_mock()
         harness.charm.update_config()
         _handle_postgresql_restart_need.assert_not_called()
         assert harness.get_relation_data(rel_id, harness.charm.unit.name)["tls"] == "enabled"
@@ -1357,6 +1371,8 @@ def test_update_config(harness):
         )  # Mock some data in the relation to test that it doesn't change.
         harness.charm.update_config()
         _handle_postgresql_restart_need.assert_not_called()
+        _restart_ldap_sync_service.assert_not_called()
+        _restart_metrics_service.assert_not_called()
         assert "tls" not in harness.get_relation_data(rel_id, harness.charm.unit.name)
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1270,6 +1270,7 @@ def test_restart(harness):
 def test_update_config(harness):
     with (
         patch("subprocess.check_output", return_value=b"C"),
+        patch("charm.snap_refreshed", return_value=True),
         patch("charm.snap.SnapCache"),
         patch(
             "charm.PostgresqlOperatorCharm._handle_postgresql_restart_need"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -2,8 +2,10 @@
 # See LICENSE file for licensing details.
 
 import re
+from unittest.mock import patch
 
-from utils import new_password
+from constants import POSTGRESQL_SNAP_NAME
+from utils import new_password, snap_refreshed
 
 
 def test_new_password():
@@ -16,3 +18,19 @@ def test_new_password():
     second_password = new_password()
     assert re.fullmatch("[a-zA-Z0-9\b]{16}$", second_password) is not None
     assert second_password != first_password
+
+
+def test_snap_refreshed():
+    with patch(
+        "utils.SNAP_PACKAGES",
+        [(POSTGRESQL_SNAP_NAME, {"revision": {"aarch64": "100", "x86_64": "100"}})],
+    ):
+        assert snap_refreshed("100") is True
+        assert snap_refreshed("200") is False
+
+    with patch(
+        "utils.SNAP_PACKAGES",
+        [(POSTGRESQL_SNAP_NAME, {"revision": {}})],
+    ):
+        assert snap_refreshed("100") is False
+        assert snap_refreshed("200") is False


### PR DESCRIPTION
This is the 4th PR to introduce LDAP support into PostgreSQL. The complete list of changes can be seen in [this branch](https://github.com/canonical/postgresql-operator/tree/sinclert/ldap-integration-all).

### Contents

This PR leverages the upcoming `ldap-sync` snap service in order to start the synchronization of LDAP users whenever the PostgreSQL-K8s charm relates to the GLAuth-K8s one.

### References

- PostgreSQL-LDAP [specification](https://docs.google.com/document/d/1Wt9VhdYCVzPh6qfwYiKOcfQwQ6UW6765S09dFjnuBXY/edit?tab=t.0).