### PR TITLE
[DPE-6345] LDAP V: Define mapping option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -69,6 +69,12 @@ options:
       Enable synchronized sequential scans.
     type: boolean
     default: true
+  ldap_map:
+    description: |
+      List of mapped LDAP group names to PostgreSQL group names, separated by commas.
+      The map is used to assign LDAP synchronized users to PostgreSQL authorization groups.
+      Example: <ldap_group_1>=<psql_group_1>,<ldap_group_2>=<psql_group_2>
+    type: string
   ldap_search_filter:
     description: |
       The LDAP search filter to match users with.

--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -35,7 +35,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 47
+LIBPATCH = 49
 
 # Groups to distinguish HBA access
 ACCESS_GROUP_IDENTITY = "identity_access"
@@ -777,6 +777,42 @@ END; $$;"""
                 connection.close()
 
     @staticmethod
+    def build_postgresql_group_map(group_map: Optional[str]) -> List[Tuple]:
+        """Build the PostgreSQL authorization group-map.
+
+        Args:
+            group_map: serialized group-map with the following format:
+                <ldap_group_1>=<psql_group_1>,
+                <ldap_group_2>=<psql_group_2>,
+                ...
+
+        Returns:
+            List of LDAP group to PostgreSQL group tuples.
+        """
+        if group_map is None:
+            return []
+
+        group_mappings = group_map.split(",")
+        group_mappings = (mapping.strip() for mapping in group_mappings)
+        group_map_list = []
+
+        for mapping in group_mappings:
+            mapping_parts = mapping.split("=")
+            if len(mapping_parts) != 2:
+                raise ValueError("The group-map must contain value pairs split by commas")
+
+            ldap_group = mapping_parts[0]
+            psql_group = mapping_parts[1]
+
+            if psql_group in [*ACCESS_GROUPS, PERMISSIONS_GROUP_ADMIN]:
+                logger.warning(f"Tried to assign LDAP users to forbidden group: {psql_group}")
+                continue
+
+            group_map_list.append((ldap_group, psql_group))
+
+        return group_map_list
+
+    @staticmethod
     def build_postgresql_parameters(
         config_options: dict, available_memory: int, limit_memory: Optional[int] = None
     ) -> Optional[dict]:
@@ -855,3 +891,34 @@ END; $$;"""
             return True
         except psycopg2.Error:
             return False
+
+    def validate_group_map(self, group_map: Optional[str]) -> bool:
+        """Validate the PostgreSQL authorization group-map.
+
+        Args:
+            group_map: serialized group-map with the following format:
+                <ldap_group_1>=<psql_group_1>,
+                <ldap_group_2>=<psql_group_2>,
+                ...
+
+        Returns:
+            Whether the group-map is valid.
+        """
+        if group_map is None:
+            return True
+
+        try:
+            group_map = self.build_postgresql_group_map(group_map)
+        except ValueError:
+            return False
+
+        for _, psql_group in group_map:
+            with self._connect_to_database() as connection, connection.cursor() as cursor:
+                query = SQL("SELECT TRUE FROM pg_roles WHERE rolname={};")
+                query = query.format(Literal(psql_group))
+                cursor.execute(query)
+
+                if cursor.fetchone() is None:
+                    return False
+
+        return True

--- a/src/config.py
+++ b/src/config.py
@@ -29,6 +29,7 @@ class CharmConfig(BaseConfigModel):
     instance_max_locks_per_transaction: int | None
     instance_password_encryption: str | None
     instance_synchronize_seqscans: bool | None
+    ldap_map: str | None
     ldap_search_filter: str | None
     logging_client_min_messages: str | None
     logging_log_connections: bool | None

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1445,6 +1445,7 @@ def test_validate_config_options(harness):
     ):
         _charm_lib.return_value.get_postgresql_text_search_configs.return_value = []
         _charm_lib.return_value.validate_date_style.return_value = False
+        _charm_lib.return_value.validate_group_map.return_value = False
         _charm_lib.return_value.get_postgresql_timezones.return_value = []
 
         # Test instance_default_text_search_config exception
@@ -1462,6 +1463,17 @@ def test_validate_config_options(harness):
         _charm_lib.return_value.get_postgresql_text_search_configs.return_value = [
             "pg_catalog.test"
         ]
+
+        # Test ldap_map exception
+        with harness.hooks_disabled():
+            harness.update_config({"ldap_map": "ldap_group="})
+
+        with pytest.raises(ValueError) as e:
+            harness.charm._validate_config_options()
+        assert str(e.value) == "ldap_map config option has an invalid value"
+
+        _charm_lib.return_value.validate_group_map.assert_called_once_with("ldap_group=")
+        _charm_lib.return_value.validate_group_map.return_value = True
 
         # Test request_date_style exception
         with harness.hooks_disabled():


### PR DESCRIPTION
This is the 5th PR to introduce LDAP support into PostgreSQL. The complete list of changes can be seen in [this branch](https://github.com/canonical/postgresql-operator/tree/sinclert/ldap-integration-all).

### Contents

This PR introduces the last configuration option for the integration: `ldap_map`. This configuration option will be used to specify a mapping between LDAP users coming from specific LDAP groups, to pre-created PostgreSQL authorization groups, so they can actually connect / query the database. The syntax has been copied from Percona's MySQL ([reference](https://docs.percona.com/percona-server/8.0/ldap-simple-variables.html#authentication_ldap_simple_group_role_mapping)).

### References

- PostgreSQL-LDAP [specification](https://docs.google.com/document/d/1Wt9VhdYCVzPh6qfwYiKOcfQwQ6UW6765S09dFjnuBXY/edit?tab=t.0).