### PR TITLE
Add conditional expose directive

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -16,4 +16,9 @@ resource "juju_application" "machine_postgresql" {
   units       = var.units
   constraints = var.constraints
   config      = var.config
+
+  dynamic "expose" {
+    for_each = var.enable_expose ? [1] : []
+    content {}
+  }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -50,3 +50,9 @@ variable "config" {
   type        = map(string)
   default     = {}
 }
+
+variable "enable_expose" {
+  type        = bool
+  default     = true
+  description = "Whether to expose the application"
+}


### PR DESCRIPTION
## Issue
The current terraform configuration does not include the option to expose the postgresql application. Since this module is used by [hockeypuck](https://github.com/canonical/hockeypuck-k8s-operator/blob/73052786638e36ea011e0dcead39ea583ce8558d/terraform/product/main.tf#L27) charm in the staginge environment, this is a requirement for the hockeypuck terraform files to work. The expose directive needs to be enabled to allow cross model relation between postgresql charm and the hockeypuck charm.

## Solution
Add a variable `enable_expose` that adds `expose {}` only if it is set to `True`.

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
