### PR TITLE
[MISC] No default scope in promote action

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -30,7 +30,6 @@ promote-to-primary:
   params:
     scope:
       type: string
-      default: cluster
       description: Whether to promote a unit or a cluster. Must be set to either unit or cluster.
     force:
       type: boolean


### PR DESCRIPTION
Make scope mandatory for promote to primary action

## Checklist
- [ ] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
