### PR TITLE
Fix unit tests

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2527,7 +2527,7 @@ version = "1.2.0"
 description = "A lil' TOML writer"
 optional = false
 python-versions = ">=3.9"
-groups = ["integration"]
+groups = ["integration", "unit"]
 files = [
     {file = "tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90"},
     {file = "tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021"},
@@ -2840,4 +2840,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "9a30c370c030732ae7e576f75bbf419eaac39d8d23ed9b36055504331e20ab91"
+content-hash = "7e1ed0d7c5bb6cb22106a966ecbcad5866d185269f385fa63cc598bdb0f700e6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ pytest = "^8.3.5"
 pytest-asyncio = "*"
 parameterized = "^0.9.0"
 jsonschema = "^4.23.0"
+tomli-w = "^1.2.0"
 
 [tool.poetry.group.integration]
 optional = true

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -3,10 +3,12 @@
 # See LICENSE file for licensing details.
 import pathlib
 import platform
+import shutil
 from unittest.mock import PropertyMock
 
 import pytest
 import tomli
+import tomli_w
 from charms.tempo_coordinator_k8s.v0.charm_tracing import charm_tracing_disabled
 
 
@@ -48,3 +50,18 @@ class _MockRefresh:
 @pytest.fixture(autouse=True)
 def patch(monkeypatch):
     monkeypatch.setattr("charm_refresh.Machines", _MockRefresh)
+
+    # Add charm version to refresh_versions.toml
+    path = pathlib.Path("refresh_versions.toml")
+    backup = pathlib.Path("refresh_versions.toml.backup")
+    shutil.copy(path, backup)
+    with path.open("rb") as file:
+        versions = tomli.load(file)
+    versions["charm"] = "16/0.0.0"
+    with path.open("wb") as file:
+        tomli_w.dump(versions, file)
+
+    yield
+
+    path.unlink()
+    shutil.move(backup, path)


### PR DESCRIPTION
Leftover after reverting hard-coded charm version in #866
