### PR TITLE
Add workaround for charmcraft bug to fix charm refresh compatibility version

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -89,6 +89,9 @@ parts:
     build-packages:
       - git
     override-build: |
+      # Workaround for https://github.com/canonical/charmcraft/issues/2273
+      git restore charmcraft.yaml
+
       # Set `charm_version` in refresh_versions.toml from git tag
       python3 -m venv refresh-version-venv
       source refresh-version-venv/bin/activate


### PR DESCRIPTION
Currently, the charm refresh compatibility version gets marked as dirty since the working tree is not clean because of https://github.com/canonical/charmcraft/issues/2273

This causes all refreshes to get marked as incompatible

Follow up to #866 