### PR TITLE
Update charm-refresh-build-version to fix charm refresh version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -450,14 +450,14 @@ tomli = ">=2.0.1"
 
 [[package]]
 name = "charm-refresh-build-version"
-version = "0.1.4"
+version = "0.2.0"
 description = "Write `charm` version in refresh_versions.toml from git tag"
 optional = false
 python-versions = ">=3.8"
 groups = ["build-refresh-version"]
 files = [
-    {file = "charm_refresh_build_version-0.1.4-py3-none-any.whl", hash = "sha256:07cbef34a334e7c56ed9ab5da59243a5c72b3f00ef64e102b5883ddedf57e1c9"},
-    {file = "charm_refresh_build_version-0.1.4.tar.gz", hash = "sha256:0b929c3aaeb222ce75ec6323246af0d6294be94d8643d1e36a06a4dc7ebb0cff"},
+    {file = "charm_refresh_build_version-0.2.0-py3-none-any.whl", hash = "sha256:5a6965772e74549dddfa91eb6c9114605eb9f437ef98e610d7fb428bbd3a934c"},
+    {file = "charm_refresh_build_version-0.2.0.tar.gz", hash = "sha256:1ec97659f669f18fc1ff759b5e535ea4dba716c509116b05d8dc4d1f3e7d49a8"},
 ]
 
 [package.dependencies]
@@ -2840,4 +2840,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "7e1ed0d7c5bb6cb22106a966ecbcad5866d185269f385fa63cc598bdb0f700e6"
+content-hash = "dd400811465c2e1f1f1806be891de5687b5fe447a2aa4ccfce3eb3bd774e2a78"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ tomli-w = "^1.2.0"
 optional = true
 
 [tool.poetry.group.build-refresh-version.dependencies]
-charm-refresh-build-version = "^0.1.1"
+charm-refresh-build-version = "^0.2.0"
 
 # Testing tools configuration
 [tool.coverage.run]


### PR DESCRIPTION
0.1.4 does not include workaround for https://github.com/canonical/charmcraft/issues/2273
