### PR TITLE
[MISC] Fix 16 track upgrade

### DIFF
--- a/tests/integration/ha_tests/test_upgrade.py
+++ b/tests/integration/ha_tests/test_upgrade.py
@@ -40,7 +40,7 @@ async def test_deploy_latest(ops_test: OpsTest) -> None:
         "-n",
         3,
         "--channel",
-        "16/edge/test-refresh-v3-workload2",  # TODO remove branch
+        "16/edge",
         "--config",
         "profile=testing",
         "--base",

--- a/tests/integration/ha_tests/test_upgrade_from_stable.py
+++ b/tests/integration/ha_tests/test_upgrade_from_stable.py
@@ -33,7 +33,7 @@ async def test_deploy_stable(ops_test: OpsTest) -> None:
         3,
         # TODO move to stable once we release refresh v3
         "--channel",
-        "16/edge/test-refresh-v3-workload2",
+        "16/edge",
         "--base",
         "ubuntu@24.04",
     )


### PR DESCRIPTION
## Issue
Upgrade tests are pointing to an outdated branch (and failing).

## Solution
Put the old `16/edge branch back`. Let's correctly update `test_upgrade_to_stable` later, when having a beta or candidate, to just unblock roles PR now.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
