### PR TITLE
Start ssh service on GitHub CI spread

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -79,6 +79,7 @@ backends:
       PermitEmptyPasswords yes
       EOF
 
+      sudo systemctl daemon-reload
       sudo systemctl start ssh
 
       ADDRESS localhost


### PR DESCRIPTION
Service appears to no longer be running by default in latest `ubuntu-latest` image

Context:
```
 + sudo systemctl reload ssh
ssh.service is not active, cannot reload.
```
https://github.com/canonical/postgresql-operator/actions/runs/15134118578/job/42542182971?pr=907#step:7:998
https://chat.canonical.com/canonical/pl/hggt4xy4ppb3ffcfnkwng8buda
