### PR TITLE
[MISC] Delete runner password

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -74,6 +74,11 @@ backends:
     # each spread job & select a single job when running spread)
     # Derived from https://github.com/jnsgruk/zinc-k8s-operator/blob/a21eae8399eb3b9df4ddb934b837af25ef831976/spread.yaml#L47
     allocate: |
+      sudo tee /etc/ssh/sshd_config.d/10-spread-github-ci.conf << 'EOF'
+      PasswordAuthentication no
+      AuthenticationMethods publickey
+      EOF
+
       ssh-keygen -t ecdsa -b 256 -N "" -f ~/.ssh/id_ecdsa
       cp ~/.ssh/id_ecdsa.pub ~/.ssh/authorized_keys
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -76,9 +76,10 @@ backends:
     allocate: |
       sudo tee /etc/ssh/sshd_config.d/10-spread-github-ci.conf << 'EOF'
       PasswordAuthentication yes
+      PermitEmptyPasswords yes
       EOF
 
-      echo "qweqwe" | sudo passwd -s runner
+      sudo passwd -d runner
 
       ADDRESS localhost
     # HACK: spread does not pass environment variables set on runner
@@ -95,10 +96,8 @@ backends:
     systems:
       - ubuntu-24.04:
           username: runner
-          password: qweqwe
       - ubuntu-24.04-arm:
           username: runner
-          password: qweqwe
 
 suites:
   tests/spread/:

--- a/spread.yaml
+++ b/spread.yaml
@@ -74,7 +74,7 @@ backends:
     # each spread job & select a single job when running spread)
     # Derived from https://github.com/jnsgruk/zinc-k8s-operator/blob/a21eae8399eb3b9df4ddb934b837af25ef831976/spread.yaml#L47
     allocate: |
-      ssh-keygen -t ecdsa -b 256 -N ""
+      ssh-keygen -t ecdsa -b 256 -N "" -f ~/.ssh/id_ecdsa
       cp ~/.ssh/id_ecdsa.pub ~/.ssh/authorized_keys
 
       ADDRESS localhost

--- a/spread.yaml
+++ b/spread.yaml
@@ -74,10 +74,8 @@ backends:
     # each spread job & select a single job when running spread)
     # Derived from https://github.com/jnsgruk/zinc-k8s-operator/blob/a21eae8399eb3b9df4ddb934b837af25ef831976/spread.yaml#L47
     allocate: |
-      sudo tee /etc/ssh/sshd_config.d/10-spread-github-ci.conf << 'EOF'
-      PasswordAuthentication yes
-      PermitEmptyPasswords yes
-      EOF
+      ssh-keygen -t ecdsa -b 256 -N ""
+      cp ~/.ssh/id_ecdsa.pub ~/.ssh/authorized_keys
 
       ADDRESS localhost
     # HACK: spread does not pass environment variables set on runner

--- a/spread.yaml
+++ b/spread.yaml
@@ -75,15 +75,10 @@ backends:
     # Derived from https://github.com/jnsgruk/zinc-k8s-operator/blob/a21eae8399eb3b9df4ddb934b837af25ef831976/spread.yaml#L47
     allocate: |
       sudo tee /etc/ssh/sshd_config.d/10-spread-github-ci.conf << 'EOF'
-      PasswordAuthentication no
-      AuthenticationMethods publickey
+      PasswordAuthentication yes
       EOF
 
-      ssh-keygen -t ecdsa -b 256 -N "" -f ~/.ssh/id_ecdsa
-      cp ~/.ssh/id_ecdsa.pub ~/.ssh/authorized_keys
-      sudo chown runner:runner /home/runner/.ssh/authorized_keys
-      chmod 700 ~/.ssh
-      chmod 600 ~/.ssh/authorized_keys
+      sudo passwd runner -s < 'qweqwe'
 
       ADDRESS localhost
     # HACK: spread does not pass environment variables set on runner
@@ -100,8 +95,10 @@ backends:
     systems:
       - ubuntu-24.04:
           username: runner
+          password: qweqwe
       - ubuntu-24.04-arm:
           username: runner
+          password: qweqwe
 
 suites:
   tests/spread/:

--- a/spread.yaml
+++ b/spread.yaml
@@ -81,6 +81,9 @@ backends:
 
       ssh-keygen -t ecdsa -b 256 -N "" -f ~/.ssh/id_ecdsa
       cp ~/.ssh/id_ecdsa.pub ~/.ssh/authorized_keys
+      sudo chown runner:runner /home/runner/.ssh/authorized_keys
+      chmod 700 ~/.ssh
+      chmod 600 ~/.ssh/authorized_keys
 
       ADDRESS localhost
     # HACK: spread does not pass environment variables set on runner

--- a/spread.yaml
+++ b/spread.yaml
@@ -78,7 +78,7 @@ backends:
       PasswordAuthentication yes
       EOF
 
-      sudo passwd runner -s < 'qweqwe'
+      echo "qweqwe" | sudo passwd -s runner
 
       ADDRESS localhost
     # HACK: spread does not pass environment variables set on runner


### PR DESCRIPTION
Currently spread conf expects to be able to ssh into the runner user without a password. New images now have a password set, so it's removed to reenable CI.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
