### PR TITLE
[MISC] Remove runner password

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -79,6 +79,8 @@ backends:
       PermitEmptyPasswords yes
       EOF
 
+      sudo passwd -d runner
+
       ADDRESS localhost
     # HACK: spread does not pass environment variables set on runner
     # Manually pass specific environment variables


### PR DESCRIPTION
Copy of https://github.com/canonical/postgresql-operator/pull/912 for PG 14.

Delete the runner user pass to reenable amd64 ci.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
