### PR TITLE
Fix 16/edge refresh tests (including refresh to the same snap revision)

### DIFF
--- a/tests/integration/ha_tests/test_upgrade.py
+++ b/tests/integration/ha_tests/test_upgrade.py
@@ -89,36 +89,44 @@ async def test_upgrade_from_edge(ops_test: OpsTest, continuous_writes, charm) ->
     await application.refresh(path=charm)
 
     logger.info("Wait for upgrade to start")
-    await ops_test.model.block_until(lambda: application.status == "blocked", timeout=TIMEOUT)
+    try:
+        # Blocked status is expected due to compatibility checks.
+        await ops_test.model.block_until(lambda: application.status == "blocked", timeout=60 * 3)
 
-    logger.info("Wait for refresh to block due to compatibility checks")
-    async with ops_test.fast_forward("60s"):
-        await ops_test.model.wait_for_idle(
-            apps=[DATABASE_APP_NAME], idle_period=30, timeout=TIMEOUT
+        logger.info("Wait for refresh to block due to compatibility checks")
+        async with ops_test.fast_forward("60s"):
+            await ops_test.model.wait_for_idle(
+                apps=[DATABASE_APP_NAME], idle_period=30, timeout=TIMEOUT
+            )
+
+        assert "Refresh incompatible" in application.status_message, (
+            "Application refresh not blocked due to incompatibility"
         )
 
-    assert "Refresh incompatible" in application.status_message, (
-        "Application refresh not blocked due to incompatibility"
-    )
-
-    # Highest to lowest unit number
-    refresh_order = sorted(
-        application.units, key=lambda unit: int(unit.name.split("/")[1]), reverse=True
-    )
-    action = await refresh_order[0].run_action(
-        "force-refresh-start", **{"check-compatibility": False}
-    )
-    await action.wait()
-
-    logger.info("Wait for first unit to upgrade")
-    async with ops_test.fast_forward("60s"):
-        await ops_test.model.wait_for_idle(
-            apps=[DATABASE_APP_NAME], idle_period=30, timeout=TIMEOUT
+        # Highest to lowest unit number
+        refresh_order = sorted(
+            application.units, key=lambda unit: int(unit.name.split("/")[1]), reverse=True
         )
+        action = await refresh_order[0].run_action(
+            "force-refresh-start", **{"check-compatibility": False}
+        )
+        await action.wait()
 
-    logger.info("Run resume-refresh action")
-    action = await refresh_order[1].run_action("resume-refresh")
-    await action.wait()
+        logger.info("Wait for first unit to upgrade")
+        async with ops_test.fast_forward("60s"):
+            await ops_test.model.wait_for_idle(
+                apps=[DATABASE_APP_NAME], idle_period=30, timeout=TIMEOUT
+            )
+
+        logger.info("Run resume-refresh action")
+        action = await refresh_order[1].run_action("resume-refresh")
+        await action.wait()
+    except TimeoutError:
+        # If the application didn't get into the blocked state, it should have upgraded only
+        # the charm code because the snap revision didn't change.
+        assert application.status == "active", (
+            "Application didn't reach blocked or active state after refresh attempt"
+        )
 
     logger.info("Wait for upgrade to complete")
     async with ops_test.fast_forward("60s"):

--- a/tests/integration/ha_tests/test_upgrade_from_stable.py
+++ b/tests/integration/ha_tests/test_upgrade_from_stable.py
@@ -82,36 +82,44 @@ async def test_upgrade_from_stable(ops_test: OpsTest, charm):
     await application.refresh(path=charm)
 
     logger.info("Wait for upgrade to start")
-    await ops_test.model.block_until(lambda: application.status == "blocked", timeout=TIMEOUT)
+    try:
+        # Blocked status is expected due to compatibility checks.
+        await ops_test.model.block_until(lambda: application.status == "blocked", timeout=60 * 3)
 
-    logger.info("Wait for refresh to block due to compatibility checks")
-    async with ops_test.fast_forward("60s"):
-        await ops_test.model.wait_for_idle(
-            apps=[DATABASE_APP_NAME], idle_period=30, timeout=TIMEOUT
+        logger.info("Wait for refresh to block due to compatibility checks")
+        async with ops_test.fast_forward("60s"):
+            await ops_test.model.wait_for_idle(
+                apps=[DATABASE_APP_NAME], idle_period=30, timeout=TIMEOUT
+            )
+
+        assert "Refresh incompatible" in application.status_message, (
+            "Application refresh not blocked due to incompatibility"
         )
 
-    assert "Refresh incompatible" in application.status_message, (
-        "Application refresh not blocked due to incompatibility"
-    )
-
-    # Highest to lowest unit number
-    refresh_order = sorted(
-        application.units, key=lambda unit: int(unit.name.split("/")[1]), reverse=True
-    )
-    action = await refresh_order[0].run_action(
-        "force-refresh-start", **{"check-compatibility": False}
-    )
-    await action.wait()
-
-    logger.info("Wait for first unit to upgrade")
-    async with ops_test.fast_forward("60s"):
-        await ops_test.model.wait_for_idle(
-            apps=[DATABASE_APP_NAME], idle_period=30, timeout=TIMEOUT
+        # Highest to lowest unit number
+        refresh_order = sorted(
+            application.units, key=lambda unit: int(unit.name.split("/")[1]), reverse=True
         )
+        action = await refresh_order[0].run_action(
+            "force-refresh-start", **{"check-compatibility": False}
+        )
+        await action.wait()
 
-    logger.info("Run resume-refresh action")
-    action = await refresh_order[1].run_action("resume-refresh")
-    await action.wait()
+        logger.info("Wait for first unit to upgrade")
+        async with ops_test.fast_forward("60s"):
+            await ops_test.model.wait_for_idle(
+                apps=[DATABASE_APP_NAME], idle_period=30, timeout=TIMEOUT
+            )
+
+        logger.info("Run resume-refresh action")
+        action = await refresh_order[1].run_action("resume-refresh")
+        await action.wait()
+    except TimeoutError:
+        # If the application didn't get into the blocked state, it should have upgraded only
+        # the charm code because the snap revision didn't change.
+        assert application.status == "active", (
+            "Application didn't reach blocked or active state after refresh attempt"
+        )
 
     logger.info("Wait for upgrade to complete")
     async with ops_test.fast_forward("60s"):


### PR DESCRIPTION
## Issue
Refresh tests currently rely on a specific charm revision to exist - tests fail on 16/edge as the charm version and workload version do not change when upgrading from 16/edge to a locally built charm, leading to a no-op in refresh.

## Solution
Use the logic from https://github.com/canonical/postgresql-operator/pull/910 to handle incompatible refreshes while also handling the case where a no-op refresh happens (refresh to the same snap revision, where only the charm code is refreshed, not needing to restart the workload).

Difference from https://github.com/canonical/postgresql-operator/pull/910 (in which this PR is based on):
* This PR tests if a blocked state is reached in a smaller timeout, and if not, it checks whether the upgrade completed (active state in case of the same snap revision).

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
