### PR TITLE
[MISC] Remove JujuVersion warning in 14/edge

### DIFF
--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -102,7 +102,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 10
+LIBPATCH = 11
 
 
 # Regex to locate 7-bit C1 ANSI sequences
@@ -576,6 +576,9 @@ class Snap:
 
         if revision:
             args.append(f'--revision="{revision}"')
+
+        if self.confinement == 'classic':
+            args.append('--classic')
 
         if devmode:
             args.append("--devmode")

--- a/lib/charms/tempo_coordinator_k8s/v0/charm_tracing.py
+++ b/lib/charms/tempo_coordinator_k8s/v0/charm_tracing.py
@@ -314,7 +314,7 @@ from typing import (
 import opentelemetry
 import ops
 from opentelemetry.exporter.otlp.proto.common._internal.trace_encoder import (
-    encode_spans,
+    encode_spans # type: ignore
 )
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.resources import Resource
@@ -348,7 +348,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 7
+LIBPATCH = 8
 
 PYDEPS = ["opentelemetry-exporter-otlp-proto-http==1.21.0"]
 
@@ -704,7 +704,14 @@ def _get_server_cert(
             f"{charm_type}.{server_cert_attr} is None; sending traces over INSECURE connection."
         )
         return
-    elif not Path(server_cert).is_absolute():
+    if not isinstance(server_cert, (str, Path)):
+        logger.warning(
+            f"{charm_type}.{server_cert_attr} has unexpected type {type(server_cert)}; "
+            f"sending traces over INSECURE connection."
+        )
+        return
+    path = Path(server_cert)
+    if not path.is_absolute() or not path.exists():
         raise ValueError(
             f"{charm_type}.{server_cert_attr} should resolve to a valid tls cert absolute path (string | Path)); "
             f"got {server_cert} instead."

--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -282,10 +282,10 @@ from ipaddress import IPv4Address
 from typing import Any, Dict, List, Literal, Optional, Union
 
 from cryptography import x509
-from cryptography.hazmat._oid import ExtensionOID
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.serialization import pkcs12
+from cryptography.x509.oid import ExtensionOID
 from jsonschema import exceptions, validate
 from ops.charm import (
     CharmBase,
@@ -307,7 +307,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 29
+LIBPATCH = 30
 
 PYDEPS = ["cryptography", "jsonschema"]
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -37,7 +37,7 @@ from charms.postgresql_k8s.v0.postgresql import (
 from charms.postgresql_k8s.v0.postgresql_tls import PostgreSQLTLS
 from charms.rolling_ops.v0.rollingops import RollingOpsManager, RunWithLock
 from charms.tempo_coordinator_k8s.v0.charm_tracing import trace_charm
-from ops import JujuVersion, main
+from ops import main
 from ops.charm import (
     ActionEvent,
     HookEvent,
@@ -180,8 +180,9 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             deleted_label=SECRET_DELETED_LABEL,
         )
 
-        juju_version = JujuVersion.from_environ()
-        run_cmd = "/usr/bin/juju-exec" if juju_version.major > 2 else "/usr/bin/juju-run"
+        run_cmd = (
+            "/usr/bin/juju-exec" if self.model.juju_version.major > 2 else "/usr/bin/juju-run"
+        )
         self._observer = ClusterTopologyObserver(self, run_cmd)
         self._rotate_logs = RotateLogs(self)
         self.framework.observe(
@@ -316,7 +317,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
 
     def _translate_field_to_secret_key(self, key: str) -> str:
         """Change 'key' to secrets-compatible key field."""
-        if not JujuVersion.from_environ().has_secrets:
+        if not self.model.juju_version.has_secrets:
             return key
         key = SECRET_KEY_OVERRIDES.get(key, key)
         new_key = key.replace("_", "-")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -11,7 +11,7 @@ from charms.tempo_coordinator_k8s.v0.charm_tracing import charm_tracing_disabled
 # charm.JujuVersion.has_secrets set as True or as False
 @pytest.fixture(params=[True, False], autouse=True)
 def _has_secrets(request, monkeypatch):
-    monkeypatch.setattr("charm.JujuVersion.has_secrets", PropertyMock(return_value=request.param))
+    monkeypatch.setattr("ops.JujuVersion.has_secrets", PropertyMock(return_value=request.param))
     return request.param
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1879,17 +1879,17 @@ def test_get_available_memory(harness):
 def test_juju_run_exec_divergence(harness):
     with (
         patch("charm.ClusterTopologyObserver") as _topology_observer,
-        patch("charm.JujuVersion") as _juju_version,
+        patch("ops.model.Model.juju_version", new_callable=PropertyMock) as _juju_version,
     ):
         # Juju 2
-        _juju_version.from_environ.return_value.major = 2
+        _juju_version.return_value.major = 2
         harness = Harness(PostgresqlOperatorCharm)
         harness.begin()
         _topology_observer.assert_called_once_with(harness.charm, "/usr/bin/juju-run")
         _topology_observer.reset_mock()
 
         # Juju 3
-        _juju_version.from_environ.return_value.major = 3
+        _juju_version.return_value.major = 3
         harness = Harness(PostgresqlOperatorCharm)
         harness.begin()
         _topology_observer.assert_called_once_with(harness.charm, "/usr/bin/juju-exec")


### PR DESCRIPTION
## Issue
Warning is annoying

## Solution
* Switch to the new way of getting the version
* Update libs

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
