### PR TITLE
Create new folder for v1 of postgresql charm lib

### DIFF
--- a/lib/charms/postgresql_k8s/v1/postgresql.py
+++ b/lib/charms/postgresql_k8s/v1/postgresql.py
@@ -138,7 +138,6 @@ class PostgreSQLGrantDatabasePrivilegesToUserError(Exception):
     """Exception raised when granting database privileges to user."""
 
 
-
 class PostgreSQL:
     """Class to encapsulate all operations related to interacting with PostgreSQL instance."""
 
@@ -340,7 +339,6 @@ class PostgreSQL:
             logger.error(f"Failed to create user: {e}")
             raise PostgreSQLCreateUserError() from e
 
-
     def create_predefined_roles(self) -> None:
         """Create predefined roles."""
         role_to_queries = {
@@ -380,13 +378,19 @@ class PostgreSQL:
             logger.error(f"Failed to create predefined roles: {e}")
             raise PostgreSQLCreatePredefinedRolesError() from e
 
-    def grant_database_privileges_to_user(self, user: str, database: str, privileges: list[str]) -> None:
-        """Grant the specified priviliges on the provided database for the user."""
+    def grant_database_privileges_to_user(
+        self, user: str, database: str, privileges: list[str]
+    ) -> None:
+        """Grant the specified privileges on the provided database for the user."""
         try:
             with self._connect_to_database() as connection, connection.cursor() as cursor:
-                cursor.execute(SQL("GRANT {} ON DATABASE {} TO {};").format(Identifier(", ".join(privileges)), Identifier(database), Identifier(user)))
+                cursor.execute(
+                    SQL("GRANT {} ON DATABASE {} TO {};").format(
+                        Identifier(", ".join(privileges)), Identifier(database), Identifier(user)
+                    )
+                )
         except psycopg2.Error as e:
-            logger.error(f"Faield to grant privileges to user: {e}")
+            logger.error(f"Failed to grant privileges to user: {e}")
             raise PostgreSQLGrantDatabasePrivilegesToUserError() from e
 
     def delete_user(self, user: str) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -29,7 +29,7 @@ from charms.data_platform_libs.v0.data_interfaces import DataPeerData, DataPeerU
 from charms.data_platform_libs.v1.data_models import TypedCharmBase
 from charms.grafana_agent.v0.cos_agent import COSAgentProvider, charm_tracing_config
 from charms.operator_libs_linux.v2 import snap
-from charms.postgresql_k8s.v0.postgresql import (
+from charms.postgresql_k8s.v1.postgresql import (
     ACCESS_GROUP_IDENTITY,
     ACCESS_GROUPS,
     REQUIRED_PLUGINS,

--- a/src/relations/postgresql_provider.py
+++ b/src/relations/postgresql_provider.py
@@ -10,7 +10,7 @@ from charms.data_platform_libs.v0.data_interfaces import (
     DatabaseProvides,
     DatabaseRequestedEvent,
 )
-from charms.postgresql_k8s.v0.postgresql import (
+from charms.postgresql_k8s.v1.postgresql import (
     ACCESS_GROUP_RELATION,
     ACCESS_GROUPS,
     INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -13,7 +13,7 @@ import psycopg2
 import pytest
 import tomli
 from charms.operator_libs_linux.v2 import snap
-from charms.postgresql_k8s.v0.postgresql import (
+from charms.postgresql_k8s.v1.postgresql import (
     PostgreSQLCreateUserError,
     PostgreSQLEnableDisableExtensionError,
 )
@@ -922,7 +922,7 @@ def test_on_update_status_after_restore_operation(harness):
         ) as _handle_processes_failures,
         patch("charm.PostgreSQLBackups.can_use_s3_repository") as _can_use_s3_repository,
         patch(
-            "charms.postgresql_k8s.v0.postgresql.PostgreSQL.get_current_timeline"
+            "charms.postgresql_k8s.v1.postgresql.PostgreSQL.get_current_timeline"
         ) as _get_current_timeline,
         patch("charm.PostgresqlOperatorCharm.update_config") as _update_config,
         patch("charm.Patroni.member_started", new_callable=PropertyMock) as _member_started,

--- a/tests/unit/test_postgresql_provider.py
+++ b/tests/unit/test_postgresql_provider.py
@@ -4,7 +4,7 @@
 from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
-from charms.postgresql_k8s.v0.postgresql import (
+from charms.postgresql_k8s.v1.postgresql import (
     ACCESS_GROUP_RELATION,
     PostgreSQLCreateDatabaseError,
     PostgreSQLCreateUserError,


### PR DESCRIPTION
## Issue
We missed creating a new folder and file for the v1 postgresql charm lib in the predefined instance level roles PR.
https://github.com/canonical/postgresql-operator/pull/881

## Solution
Retroactively create new file and folder for the major version bump

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
