### PR TITLE
[DPE-7511] Fix the auth username pattern

### DIFF
--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -830,7 +830,7 @@ CREATE OR REPLACE FUNCTION update_pg_hba()
                   END IF;
                 END LOOP;
                 -- Remove users that don't exist anymore from the pg_hba file.
-                FOR rec IN SELECT h.lines FROM pg_hba AS h LEFT JOIN relation_users AS r ON SPLIT_PART(h.lines, ' ', 3) = r.user WHERE r.user IS NULL AND (SPLIT_PART(h.lines, ' ', 3) LIKE 'relation_id_%' OR SPLIT_PART(h.lines, ' ', 3) LIKE 'pgbouncer_auth_relation_id_%' OR SPLIT_PART(h.lines, ' ', 3) LIKE '%_user_%_%')
+                FOR rec IN SELECT h.lines FROM pg_hba AS h LEFT JOIN relation_users AS r ON SPLIT_PART(h.lines, ' ', 3) = r.user WHERE r.user IS NULL AND (SPLIT_PART(h.lines, ' ', 3) LIKE 'relation_id_%' OR SPLIT_PART(h.lines, ' ', 3) LIKE 'pgbouncer_auth_relation_%' OR SPLIT_PART(h.lines, ' ', 3) LIKE '%_user_%_%')
                 LOOP
                   DELETE FROM pg_hba WHERE lines = rec.lines;
                   changes := changes + 1;


### PR DESCRIPTION
## Issue
There is no `id` in the pattern used to create the PgBouncer auth user, so PostgreSQL don't put the auth user in the `pg_hba.conf` file, blocking when a client app tries to connect to the database through PgBouncer. Example: https://github.com/canonical/pgbouncer-operator/actions/runs/15491636927/job/43618945337?pr=549#step:7:1681 (the error seems different, but it's due to a misconfigured `pg_hba.conf` file).

PgBouncer K8s: https://github.com/canonical/pgbouncer-k8s-operator/blob/d4f4144a57a8d833411439434e8a5eab6d517695/src/relations/backend_database.py#L149

PgBouncer VM: https://github.com/canonical/pgbouncer-operator/blob/2f8d372760e4f66876a8311de43d659b9eaf0258/src/relations/backend_database.py#L418

## Solution
Port of https://github.com/canonical/postgresql-k8s-operator/pull/987.

Fix the pattern used to identify the auth user in the charm library.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
