### PR TITLE
DPE-6662 Fix pgbackrest logs names on logs rotation (#939)

### DIFF
--- a/templates/pgbackrest.logrotate.j2
+++ b/templates/pgbackrest.logrotate.j2
@@ -6,5 +6,5 @@
     daily
     create 0600 snap_daemon snap_daemon
     dateext
-    dateformat -%Y%m%d_%H:%M.log
+    dateformat -%Y%m%d_%H%M
 }


### PR DESCRIPTION
Backport https://github.com/canonical/postgresql-operator/pull/939 to PG14.

The pgBackRest activity (backup creation, stanza initialisation, etc) could take minutes, as a result every minute logs rotation could move the current log A.log to A.log_$date.log and will be moved further as logrorate rule operates all *.log files in the folder:

> /var/snap/charmed-postgresql/common/var/log/pgbackrest/*.log { ...

It results in:

-rw------- 1 postgres postgres     0 Feb 18 09:25 all-server.log
-rw------- 1 postgres postgres     0 Feb 18 09:19 all-server.log-20250218_09:18.log
-rw------- 1 postgres postgres     0 Feb 18 09:20 all-server.log-20250218_09:18.log-20250218_09:19.log
-rw------- 1 postgres postgres     0 Feb 18 09:21 all-server.log-20250218_09:18.log-20250218_09:19.log-20250218_09:20.log
-rw------- 1 postgres postgres     0 Feb 18 09:22 all-server.log-20250218_09:18.log-20250218_09:19.log-20250218_09:20.log-20250218_09:21.log
-rw------- 1 postgres postgres     0 Feb 18 09:23 all-server.log-20250218_09:18.log-20250218_09:19.log-20250218_09:20.log-20250218_09:21.log-20250218_09:22.log
-rw------- 1 postgres postgres  1793 Feb 18 09:24 all-server.log-20250218_09:18.log-20250218_09:19.log-20250218_09:20.log-20250218_09:21.log-20250218_09:22.log-20250218_09:23.log

The poposed fix:
 * move the log file to the new name without .log suffix.
 * use datetime format matching MySQL charms

Example:

-rw------- 1 postgres postgres    12 Feb 18 09:28 all-server.log
-rw------- 1 postgres postgres   322 Feb 18 09:29 all-server.log-20250218_0918
-rw------- 1 postgres postgres  7344 Feb 18 09:30 all-server.log-20250218_0918

(cherry picked from commit ffa77b299ff16b38f645164f1a39669949c277df)

## Issue

## Solution

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
