### PR TITLE
[DPE-7558] Fixes for predefined roles (backporting fixes from PgBouncer to PostgreSQL)

### DIFF
--- a/lib/charms/postgresql_k8s/v1/postgresql.py
+++ b/lib/charms/postgresql_k8s/v1/postgresql.py
@@ -307,7 +307,7 @@ class PostgreSQL:
                     f"WITH LOGIN{' SUPERUSER' if admin else ''} ENCRYPTED PASSWORD '{password}'"
                 )
                 if in_role:
-                    user_definition += f" IN ROLE {in_role}"
+                    user_definition += f" IN ROLE \"{in_role}\""
                 if can_create_database:
                     user_definition += " CREATEDB"
                 if privileges:


### PR DESCRIPTION
## Issue
While working on making PgBouncer compatible with PG 16 through https://github.com/canonical/pgbouncer-operator/pull/549, it was noted that some logic from the PostgreSQL charm library doesn't work as expected when used by PgBouncer (and also when the client app requests a database with the name containing a hyphen).

## Solution
* Reset PgBouncer role when needed (to have superuser privileges and be able to perform some restricted operations).
* Handle database names containing a hyphen (like `test-database`).

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
