### PR TITLE
Add redirects 16

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,7 @@ tox                      # runs 'lint' and 'unit' environments
 ## Build charm
 
 The build environment assumes that there are preinstalled on the system:
+
 * [tox](https://tox.wiki/) (version 4+ !!!)
 * [poetry](https://python-poetry.org/)
 * [charmcraft](https://snapcraft.io/charmcraft)
@@ -69,6 +70,7 @@ pipx install charmcraftcache
 ```
 
 Ensure local pip binaries are in your $PATH (otherwise re-login to your shell):
+
 ```shell
 charmcraftcache --help
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Charmed PostgreSQL VM Operator
+
 [![CharmHub Badge](https://charmhub.io/postgresql/badge.svg)](https://charmhub.io/postgresql)
 [![Release](https://github.com/canonical/postgresql-operator/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/postgresql-operator/actions/workflows/release.yaml)
 [![Tests](https://github.com/canonical/postgresql-operator/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/canonical/postgresql-operator/actions/workflows/ci.yaml?query=branch%3Amain)
@@ -131,6 +132,7 @@ juju integrate postgresql <application_name>
 ```
 
 To remove a relation:
+
 ```shell
 juju remove-relation postgresql <application_name>
 ```
@@ -138,6 +140,7 @@ juju remove-relation postgresql <application_name>
 #### Legacy `pgsql` interface
 
 We have also added support for the two database legacy relations from the [original version](https://launchpad.net/postgresql-charm) of the charm via the `pgsql` interface. Please note that these relations will be deprecated.
+
  ```shell
 juju relate postgresql:db mailman3-core
 juju relate postgresql:db-admin landscape-server

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -193,8 +193,9 @@ html_theme_options = {
 # NOTE: If undefined, set to None, or empty,
 #       the sphinx_reredirects extension will be disabled.
 
-redirects = {}
+# redirects = {}
 
+rediraffe_redirects = "redirects.txt"
 
 ###########################
 # Link checker exceptions #
@@ -258,6 +259,7 @@ extensions = [
     "sphinxcontrib.cairosvgconverter",
     "sphinx_last_updated_by_git",
     "sphinx.ext.intersphinx",
+    "sphinxext.rediraffe"
 ]
 
 # Excludes files or directories from processing

--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -13,91 +13,91 @@
 # redirect/from/file/ redirect/to/file/
 
 # Tutorials
-t-set-up	tutorial/
-t-deploy	tutorial/
-t-access	tutorial/
-t-scale	tutorial/
-t-manage-passwords	tutorial/
-t-integrate	tutorial/
-t-enable-tls	tutorial/
-t-clean-up	tutorial/
+t-set-up tutorial/
+t-deploy tutorial/
+t-access tutorial/
+t-scale tutorial/
+t-manage-passwords tutorial/
+t-integrate tutorial/
+t-enable-tls tutorial/
+t-clean-up tutorial/
 
 # How-to guides
-h-deploy	how-to/deploy
-h-deploy-sunbeam	how-to/deploy/sunbeam
-h-deploy-maas	how-to/deploy/maas
-h-deploy-ec2	how-to/deploy/aws-ec2
-h-deploy-gce	how-to/deploy/gce
-h-deploy-azure	how-to/deploy/azure
-h-deploy-multi-az	how-to/deploy/multi-az
-h-deploy-tls-vip-access	how-to/deploy/tls-vip-access
-h-deploy-terraform	how-to/deploy/terraform
-h-deploy-airgapped	how-to/deploy/air-gapped
-h-deploy-juju-storage	how-to/deploy/juju-storage
-h-deploy-juju-spaces	how-to/deploy/juju-spaces
+h-deploy how-to/deploy
+h-deploy-sunbeam how-to/deploy/sunbeam
+h-deploy-maas how-to/deploy/maas
+h-deploy-ec2 how-to/deploy/aws-ec2
+h-deploy-gce how-to/deploy/gce
+h-deploy-azure how-to/deploy/azure
+h-deploy-multi-az how-to/deploy/multi-az
+h-deploy-tls-vip-access how-to/deploy/tls-vip-access
+h-deploy-terraform how-to/deploy/terraform
+h-deploy-airgapped how-to/deploy/air-gapped
+h-deploy-juju-storage how-to/deploy/juju-storage
+h-deploy-juju-spaces how-to/deploy/juju-spaces
 
-h-integrate	how-to/integrate-with-another-application
-h-manage-passwords	how-to/manage-passwords
-h-external-access	how-to/external-network-access
-h-scale	how-to/scale-replicas
-h-switchover-failover	how-to/switchover-failover
-h-enable-tls	how-to/enable-tls
-h-enable-ldap	how-to/enable-ldap
+h-integrate how-to/integrate-with-another-application
+h-manage-passwords how-to/manage-passwords
+h-external-access how-to/external-network-access
+h-scale how-to/scale-replicas
+h-switchover-failover how-to/switchover-failover
+h-enable-tls how-to/enable-tls
+h-enable-ldap how-to/enable-ldap
 
-h-enable-plugins-extensions	how-to/enable-plugins-extensions
-h-plugins-timescaledb	how-to/enable-plugins-extensions/enable-timescaledb
+h-enable-plugins-extensions how-to/enable-plugins-extensions
+h-plugins-timescaledb how-to/enable-plugins-extensions/enable-timescaledb
 
-h-backup	how-to/back-up-and-restore/
-h-configure-s3-aws	how-to/back-up-and-restore/configure-s3-aws
-h-configure-s3-radosgw	how-to/back-up-and-restore/configure-s3-radosgw
-h-create-backup	how-to/back-up-and-restore/create-a-backup
-h-restore-backup	how-to/back-up-and-restore/restore-a-backup
-h-manage-backup-retention	how-to/back-up-and-restore/manage-backup-retention
-h-migrate-cluster	how-to/back-up-and-restore/migrate-a-cluster
+h-backup how-to/back-up-and-restore/
+h-configure-s3-aws how-to/back-up-and-restore/configure-s3-aws
+h-configure-s3-radosgw how-to/back-up-and-restore/configure-s3-radosgw
+h-create-backup how-to/back-up-and-restore/create-a-backup
+h-restore-backup how-to/back-up-and-restore/restore-a-backup
+h-manage-backup-retention how-to/back-up-and-restore/manage-backup-retention
+h-migrate-cluster how-to/back-up-and-restore/migrate-a-cluster
 
-h-monitor	how-to/monitoring-cos/
-h-enable-monitoring	how-to/monitoring-cos/enable-monitoring
-h-enable-alert-rules	how-to/monitoring-cos/enable-alert-rules
-h-enable-tracing	how-to/monitoring-cos/enable-tracing
-h-enable-profiling	how-to/monitoring-cos/enable-profiling
+h-monitor how-to/monitoring-cos/
+h-enable-monitoring how-to/monitoring-cos/enable-monitoring
+h-enable-alert-rules how-to/monitoring-cos/enable-alert-rules
+h-enable-tracing how-to/monitoring-cos/enable-tracing
+h-enable-profiling how-to/monitoring-cos/enable-profiling
 
-h-upgrade	how-to/upgrade/
+h-upgrade how-to/upgrade/
 
-h-async	how-to/cross-regional-async-replication/
-h-async-set-up	how-to/cross-regional-async-replication/set-up-clusters
-h-async-integrate	how-to/cross-regional-async-replication/integrate-with-a-client-app
-h-async-remove-recover	how-to/cross-regional-async-replication/remove-or-recover-a-cluster
+h-async how-to/cross-regional-async-replication/
+h-async-set-up how-to/cross-regional-async-replication/set-up-clusters
+h-async-integrate how-to/cross-regional-async-replication/integrate-with-a-client-app
+h-async-remove-recover how-to/cross-regional-async-replication/remove-or-recover-a-cluster
 
-h-development	how-to/development/
-h-development-integrate	how-to/development/integrate-with-your-charm
-h-migrate-pgdump	how-to/development/migrate-data-via-pg-dump
-h-migrate-backup-restore	how-to/development/migrate-data-via-backup-restore
+h-development how-to/development/
+h-development-integrate how-to/development/integrate-with-your-charm
+h-migrate-pgdump how-to/development/migrate-data-via-pg-dump
+h-migrate-backup-restore how-to/development/migrate-data-via-backup-restore
 
 # Reference
-r-releases	reference/releases
-r-versions	reference/versions
-r-system-requirements	reference/system-requirements
-r-software-testing	reference/software-testing
-r-performance	reference/performance-and-resources
+r-releases reference/releases
+r-versions reference/versions
+r-system-requirements reference/system-requirements
+r-software-testing reference/software-testing
+r-performance reference/performance-and-resources
 
-r-troubleshooting	reference/troubleshooting/
-r-sos-report	reference/troubleshooting/sos-report
-r-cli-helpers	reference/troubleshooting/cli-helpers
+r-troubleshooting reference/troubleshooting/
+r-sos-report reference/troubleshooting/sos-report
+r-cli-helpers reference/troubleshooting/cli-helpers
 
-r-plugins-extensions	reference/plugins-extensions
-r-alert-rules	reference/alert-rules
-r-statuses	reference/statuses
-r-contacts	reference/contacts
+r-plugins-extensions reference/plugins-extensions
+r-alert-rules reference/alert-rules
+r-statuses reference/statuses
+r-contacts reference/contacts
 
 # Explanation
-e-architecture	explanation/architecture
-e-interfaces-endpoints	explanation/interfaces-and-endpoints
-e-legacy-charm	explanation/legacy-charm
-e-units	explanation/units
-e-users	explanation/users
-e-roles	explanation/roles
-e-logs	explanation/logs
-e-connection-pooling	explanation/connection-pooling
+e-architecture explanation/architecture
+e-interfaces-endpoints explanation/interfaces-and-endpoints
+e-legacy-charm explanation/legacy-charm
+e-units explanation/units
+e-users explanation/users
+e-roles explanation/roles
+e-logs explanation/logs
+e-connection-pooling explanation/connection-pooling
 
-e-security	explanation/security/
-e-cryptography	explanation/security/cryptography
+e-security explanation/security/
+e-cryptography explanation/security/cryptography

--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -1,0 +1,103 @@
+# The redirects.txt file stores all the redirects for the published docs
+# If you change a filename, move or delete a file, you need a redirect here.
+# - Comment lines start with a hash (#) and are ignored
+# - Each redirect should appear on its own line
+
+# We are using the dirhtml builder, so files are treated as directories:
+# - A file is built like `filename/index.html`, not `filename.html`
+# - *Do* include a trailing slash at the end of the path
+# - *Do not* include a file extension or you'll get errors
+# - Paths don't need a slash in front of them
+
+# Example:
+# redirect/from/file/ redirect/to/file/
+
+# Tutorials
+t-set-up	tutorial/
+t-deploy	tutorial/
+t-access	tutorial/
+t-scale	tutorial/
+t-manage-passwords	tutorial/
+t-integrate	tutorial/
+t-enable-tls	tutorial/
+t-clean-up	tutorial/
+
+# How-to guides
+h-deploy	how-to/deploy
+h-deploy-sunbeam	how-to/deploy/sunbeam
+h-deploy-maas	how-to/deploy/maas
+h-deploy-ec2	how-to/deploy/aws-ec2
+h-deploy-gce	how-to/deploy/gce
+h-deploy-azure	how-to/deploy/azure
+h-deploy-multi-az	how-to/deploy/multi-az
+h-deploy-tls-vip-access	how-to/deploy/tls-vip-access
+h-deploy-terraform	how-to/deploy/terraform
+h-deploy-airgapped	how-to/deploy/air-gapped
+h-deploy-juju-storage	how-to/deploy/juju-storage
+h-deploy-juju-spaces	how-to/deploy/juju-spaces
+
+h-integrate	how-to/integrate-with-another-application
+h-manage-passwords	how-to/manage-passwords
+h-external-access	how-to/external-network-access
+h-scale	how-to/scale-replicas
+h-switchover-failover	how-to/switchover-failover
+h-enable-tls	how-to/enable-tls
+h-enable-ldap	how-to/enable-ldap
+
+h-enable-plugins-extensions	how-to/enable-plugins-extensions
+h-plugins-timescaledb	how-to/enable-plugins-extensions/enable-timescaledb
+
+h-backup	how-to/back-up-and-restore/
+h-configure-s3-aws	how-to/back-up-and-restore/configure-s3-aws
+h-configure-s3-radosgw	how-to/back-up-and-restore/configure-s3-radosgw
+h-create-backup	how-to/back-up-and-restore/create-a-backup
+h-restore-backup	how-to/back-up-and-restore/restore-a-backup
+h-manage-backup-retention	how-to/back-up-and-restore/manage-backup-retention
+h-migrate-cluster	how-to/back-up-and-restore/migrate-a-cluster
+
+h-monitor	how-to/monitoring-cos/
+h-enable-monitoring	how-to/monitoring-cos/enable-monitoring
+h-enable-alert-rules	how-to/monitoring-cos/enable-alert-rules
+h-enable-tracing	how-to/monitoring-cos/enable-tracing
+h-enable-profiling	how-to/monitoring-cos/enable-profiling
+
+h-upgrade	how-to/upgrade/
+
+h-async	how-to/cross-regional-async-replication/
+h-async-set-up	how-to/cross-regional-async-replication/set-up-clusters
+h-async-integrate	how-to/cross-regional-async-replication/integrate-with-a-client-app
+h-async-remove-recover	how-to/cross-regional-async-replication/remove-or-recover-a-cluster
+
+h-development	how-to/development/
+h-development-integrate	how-to/development/integrate-with-your-charm
+h-migrate-pgdump	how-to/development/migrate-data-via-pg-dump
+h-migrate-backup-restore	how-to/development/migrate-data-via-backup-restore
+
+# Reference
+r-releases	reference/releases
+r-versions	reference/versions
+r-system-requirements	reference/system-requirements
+r-software-testing	reference/software-testing
+r-performance	reference/performance-and-resources
+
+r-troubleshooting	reference/troubleshooting/
+r-sos-report	reference/troubleshooting/sos-report
+r-cli-helpers	reference/troubleshooting/cli-helpers
+
+r-plugins-extensions	reference/plugins-extensions
+r-alert-rules	reference/alert-rules
+r-statuses	reference/statuses
+r-contacts	reference/contacts
+
+# Explanation
+e-architecture	explanation/architecture
+e-interfaces-endpoints	explanation/interfaces-and-endpoints
+e-legacy-charm	explanation/legacy-charm
+e-units	explanation/units
+e-users	explanation/users
+e-roles	explanation/roles
+e-logs	explanation/logs
+e-connection-pooling	explanation/connection-pooling
+
+e-security	explanation/security/
+e-cryptography	explanation/security/cryptography

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 canonical-sphinx[full]
 sphinxcontrib-svg2pdfconverter[CairoSVG]
 sphinx-last-updated-by-git
+sphinxext-rediraffe


### PR DESCRIPTION
## Issue
The wildcard redirects configured by the web team for `charmhub.io/postgresql/docs/{path}` will point to `canonical-charmed-postgresql.readthedocs-hosted.com/{path}`.

Since it is using the paths (slugs) from Charmhub, which are different from the new slugs used by Read The Docs, these redirects will not work out of the box.

## Solution
Add the [rediraffe sphinx extension](https://github.com/sphinx-doc/sphinxext-rediraffe) and map all Charmhub slugs to new RTD slugs.

`charmhub.io` will take care of the initial external redirect, and `canonical-charmed-postgresql...` will process the internal redirect to the correct page.

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
