### PR TITLE
[DPE-7627] Allow `charmed_dba` role members to connect to other databases

### DIFF
--- a/lib/charms/postgresql_k8s/v1/postgresql.py
+++ b/lib/charms/postgresql_k8s/v1/postgresql.py
@@ -361,9 +361,7 @@ class PostgreSQL:
                 f"GRANT execute ON FUNCTION pg_switch_wal TO {ROLE_BACKUP}",
             ],
             ROLE_DBA: [
-                f"CREATE ROLE {ROLE_DBA} NOSUPERUSER CREATEDB NOCREATEROLE NOLOGIN NOREPLICATION;",
-                f"GRANT CONNECT ON DATABASE postgres TO {ROLE_DBA};",
-                f"GRANT CONNECT ON DATABASE template1 TO {ROLE_DBA};"
+                f"CREATE ROLE {ROLE_DBA} NOSUPERUSER CREATEDB NOCREATEROLE NOLOGIN NOREPLICATION;"
             ],
         }
 

--- a/lib/charms/postgresql_k8s/v1/postgresql.py
+++ b/lib/charms/postgresql_k8s/v1/postgresql.py
@@ -361,7 +361,9 @@ class PostgreSQL:
                 f"GRANT execute ON FUNCTION pg_switch_wal TO {ROLE_BACKUP}",
             ],
             ROLE_DBA: [
-                f"CREATE ROLE {ROLE_DBA} NOSUPERUSER CREATEDB NOCREATEROLE NOLOGIN NOREPLICATION;"
+                f"CREATE ROLE {ROLE_DBA} NOSUPERUSER CREATEDB NOCREATEROLE NOLOGIN NOREPLICATION;",
+                f"GRANT CONNECT ON DATABASE postgres TO {ROLE_DBA};",
+                f"GRANT CONNECT ON DATABASE template1 TO {ROLE_DBA};"
             ],
         }
 

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -164,6 +164,7 @@ postgresql:
     - local all backup peer map=operator
     - local all operator scram-sha-256
     - local all monitoring password
+    - {{ 'hostssl' if enable_tls else 'host' }} all +charmed_dba 0.0.0.0/0 scram-sha-256
     {%- if not connectivity %}
     - {{ 'hostssl' if enable_tls else 'host' }} all all {{ self_ip }} md5
     - {{ 'hostssl' if enable_tls else 'host' }} all all 0.0.0.0/0 reject


### PR DESCRIPTION
## Issue
Users who are members of the `charmed_dba` role cannot connect to other databases.

## Solution
Allow members of the `charmed_dba` role to connect to other databases via HBA rules.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
