### PR TITLE
[DPE-6965] Bump snap revision to amd64=192 for testing

### DIFF
--- a/refresh_versions.toml
+++ b/refresh_versions.toml
@@ -6,6 +6,6 @@ name = "charmed-postgresql"
 
 [snap.revisions]
 # amd64
-x86_64 = "183"
+x86_64 = "192"
 # arm64
 aarch64 = "185"


### PR DESCRIPTION
## Issue

## Solution

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
