### PR TITLE
[MISC] Set Pgbackrest spool dir to archive mount

### DIFF
--- a/src/backups.py
+++ b/src/backups.py
@@ -41,6 +41,7 @@ from constants import (
     PGBACKREST_EXECUTABLE,
     PGBACKREST_LOGROTATE_FILE,
     PGBACKREST_LOGS_PATH,
+    POSTGRESQL_ARCHIVE_PATH,
     POSTGRESQL_DATA_PATH,
     UNIT_SCOPE,
 )
@@ -1270,6 +1271,7 @@ Stderr:
             user=BACKUP_USER,
             retention_full=s3_parameters["delete-older-than-days"],
             process_max=max(os.cpu_count() - 2, 1),
+            archive_path=POSTGRESQL_ARCHIVE_PATH,
         )
         # Render pgBackRest config file.
         self.charm._patroni.render_file(f"{PGBACKREST_CONF_PATH}/pgbackrest.conf", rendered, 0o644)

--- a/src/constants.py
+++ b/src/constants.py
@@ -49,6 +49,8 @@ POSTGRESQL_CONF_PATH = f"{SNAP_CONF_PATH}/postgresql"
 POSTGRESQL_DATA_PATH = f"{SNAP_DATA_PATH}/postgresql"
 POSTGRESQL_LOGS_PATH = f"{SNAP_LOGS_PATH}/postgresql"
 
+POSTGRESQL_ARCHIVE_PATH = f"{SNAP_COMMON_PATH}/data/archive"
+
 UPDATE_CERTS_BIN_PATH = "/usr/sbin/update-ca-certificates"
 
 PGBACKREST_CONFIGURATION_FILE = f"--config={PGBACKREST_CONF_PATH}/pgbackrest.conf"

--- a/templates/pgbackrest.conf.j2
+++ b/templates/pgbackrest.conf.j2
@@ -1,6 +1,7 @@
 [global]
 backup-standby=y
 compress-type=zst
+spool-path={{ archive_path }}
 lock-path=/tmp
 log-path={{ log_path }}
 repo1-retention-full-type=time

--- a/tests/unit/test_backups.py
+++ b/tests/unit/test_backups.py
@@ -15,7 +15,7 @@ from tenacity import RetryError, wait_fixed
 
 from backups import ListBackupsError
 from charm import PostgresqlOperatorCharm
-from constants import PEER
+from constants import PEER, POSTGRESQL_ARCHIVE_PATH
 
 ANOTHER_CLUSTER_REPOSITORY_ERROR_MESSAGE = "the S3 repository has backups from another cluster"
 FAILED_TO_ACCESS_CREATE_BUCKET_ERROR_MESSAGE = (
@@ -1732,6 +1732,7 @@ def test_render_pgbackrest_conf_file(harness, tls_ca_chain_filename):
             user="backup",
             retention_full=30,
             process_max=max(cpu_count() - 2, 1),
+            archive_path=POSTGRESQL_ARCHIVE_PATH,
         )
 
         # Patch the `open` method with our mock.


### PR DESCRIPTION
Set Pgbackrest spool dir to the archive mount, so that the mount is used for transient restore usage

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
