### PR TITLE
[DPE-7691] Bump snap revision to 197/198 to use _daemon_ (584792)

### DIFF
--- a/docs/explanation/logs.md
+++ b/docs/explanation/logs.md
@@ -11,25 +11,25 @@ PostgreSQL and Patroni logs can be found in `/var/snap/charmed-postgresql/common
 ```text
 > ls -alh /var/snap/charmed-postgresql/common/var/log/postgresql
 total 20K
-drwxr-xr-x 2 snap_daemon root        4.0K Oct 11 15:09 .
-drwxr-xr-x 6 snap_daemon root        4.0K Oct 11 15:04 ..
--rw------- 1 snap_daemon snap_daemon 4.3K Oct 11 15:05 postgresql-3_1505.log
--rw------- 1 snap_daemon snap_daemon    0 Oct 11 15:06 postgresql-3_1506.log
--rw------- 1 snap_daemon snap_daemon    0 Oct 11 15:07 postgresql-3_1507.log
--rw------- 1 snap_daemon snap_daemon  817 Oct 11 15:08 postgresql-3_1508.log
--rw------- 1 snap_daemon snap_daemon    0 Oct 11 15:09 postgresql-3_1509.log
+drwxr-xr-x 2 _daemon_ root        4.0K Oct 11 15:09 .
+drwxr-xr-x 6 _daemon_ root        4.0K Oct 11 15:04 ..
+-rw------- 1 _daemon_ _daemon_ 4.3K Oct 11 15:05 postgresql-3_1505.log
+-rw------- 1 _daemon_ _daemon_    0 Oct 11 15:06 postgresql-3_1506.log
+-rw------- 1 _daemon_ _daemon_    0 Oct 11 15:07 postgresql-3_1507.log
+-rw------- 1 _daemon_ _daemon_  817 Oct 11 15:08 postgresql-3_1508.log
+-rw------- 1 _daemon_ _daemon_    0 Oct 11 15:09 postgresql-3_1509.log
 ```
 
 ```text
 >  ls -alh /var/snap/charmed-postgresql/common/var/log/patroni/
 total 28K
-drwxr-xr-x 2 snap_daemon root        4.0K Oct 11 15:29 .
-drwxr-xr-x 6 snap_daemon root        4.0K Oct 11 15:25 ..
--rw-r--r-- 1 snap_daemon snap_daemon  356 Oct 11 15:29 patroni.log
--rw-r--r-- 1 snap_daemon snap_daemon  534 Oct 11 15:28 patroni.log.1
--rw-r--r-- 1 snap_daemon snap_daemon  520 Oct 11 15:27 patroni.log.2
--rw-r--r-- 1 snap_daemon snap_daemon  584 Oct 11 15:27 patroni.log.3
--rw-r--r-- 1 snap_daemon snap_daemon  464 Oct 11 15:27 patroni.log.4
+drwxr-xr-x 2 _daemon_ root        4.0K Oct 11 15:29 .
+drwxr-xr-x 6 _daemon_ root        4.0K Oct 11 15:25 ..
+-rw-r--r-- 1 _daemon_ _daemon_  356 Oct 11 15:29 patroni.log
+-rw-r--r-- 1 _daemon_ _daemon_  534 Oct 11 15:28 patroni.log.1
+-rw-r--r-- 1 _daemon_ _daemon_  520 Oct 11 15:27 patroni.log.2
+-rw-r--r-- 1 _daemon_ _daemon_  584 Oct 11 15:27 patroni.log.3
+-rw-r--r-- 1 _daemon_ _daemon_  464 Oct 11 15:27 patroni.log.4
 ```
 
 The PostgreSQL log naming convention  is `postgresql-<weekday>_<hour><minute>.log`. The log message format is `<date> <time> UTC [<pid>]: <connection details> <level>: <message>`. E.g:
@@ -64,11 +64,11 @@ If S3 backups are enabled, Pgbackrest logs would be located in `/var/snap/charme
 ```text
 > ls -alh  /var/snap/charmed-postgresql/common/var/log/pgbackrest/
 total 20K
-drwxr-xr-x 2 snap_daemon root        4.0K Oct 11 15:14 .
-drwxr-xr-x 6 snap_daemon root        4.0K Oct 11 15:04 ..
--rw-r----- 1 snap_daemon snap_daemon 1.7K Oct 11 15:14 pg.pg-backup.log
--rw-r----- 1 snap_daemon snap_daemon  717 Oct 11 15:14 pg.pg-expire.log
--rw-r----- 1 snap_daemon snap_daemon  859 Oct 11 15:08 pg.pg-stanza-create.log
+drwxr-xr-x 2 _daemon_ root        4.0K Oct 11 15:14 .
+drwxr-xr-x 6 _daemon_ root        4.0K Oct 11 15:04 ..
+-rw-r----- 1 _daemon_ _daemon_ 1.7K Oct 11 15:14 pg.pg-backup.log
+-rw-r----- 1 _daemon_ _daemon_  717 Oct 11 15:14 pg.pg-expire.log
+-rw-r----- 1 _daemon_ _daemon_  859 Oct 11 15:08 pg.pg-stanza-create.log
 ```
 
 The naming convention of the Pgbackrest logs is `<model name>.patroni-<postgresql app name>-<action>.log`. Log output should look similar to:

--- a/docs/how-to/switchover-failover.md
+++ b/docs/how-to/switchover-failover.md
@@ -73,7 +73,7 @@ Find the current primary/standby/replica:
 
 ```text
 > juju ssh postgresql/0
-ubuntu@juju-422c1a-0:~$ sudo -u snap_daemon patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml list
+ubuntu@juju-422c1a-0:~$ sudo -u _daemon_ patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml list
 + Cluster: postgresql (7499430436963402504) ---+-----------+----+-----------+
 | Member       | Host           | Role         | State     | TL | Lag in MB |
 +--------------+----------------+--------------+-----------+----+-----------+

--- a/docs/reference/troubleshooting/cli-helpers.md
+++ b/docs/reference/troubleshooting/cli-helpers.md
@@ -21,7 +21,7 @@ Learn more about Patroni in the [Architecture](/explanation/architecture) page.
 
 The main Patroni tool is `patronictl`. 
 
-**It should only be used under the snap context**, via the user `snap_daemon`.
+**It should only be used under the snap context**, via the user `_daemon_`.
 
 #### Cluster status
 
@@ -34,7 +34,7 @@ The main Patroni tool is `patronictl`.
 > juju ssh postgresql/2
 ...
 
-ubuntu@juju-b87344-2:~$ sudo -u snap_daemon patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml topology
+ubuntu@juju-b87344-2:~$ sudo -u _daemon_ patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml topology
 + Cluster: postgresql (7496847632512033809) ------+-----------+----+-----------+
 | Member          | Host           | Role         | State     | TL | Lag in MB |
 +-----------------+----------------+--------------+-----------+----+-----------+
@@ -53,7 +53,7 @@ Use `--help` to find all the available Patroni actions.
 <details><summary>Example: Patroni actions</summary>
 
 ```text
->  sudo -u snap_daemon patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml --help
+>  sudo -u _daemon_ patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml --help
 ...
   failover     Failover to a replica
   history      Show the history of failovers/switchovers
@@ -78,7 +78,7 @@ Patroni can perform a low-level [switchover/failover](https://patroni.readthedoc
 <details><summary>Example: switchover (healthy cluster only)</summary>
 
 ```text
-ubuntu@juju-b87344-2:~$ sudo -u snap_daemon patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml switchover postgresql --candidate postgresql-2 --force
+ubuntu@juju-b87344-2:~$ sudo -u _daemon_ patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml switchover postgresql --candidate postgresql-2 --force
 Current cluster topology
 + Cluster: postgresql (7496847632512033809) ----+-----------+----+-----------+
 | Member        | Host           | Role         | State     | TL | Lag in MB |
@@ -96,7 +96,7 @@ Current cluster topology
 | postgresql-3  | 10.189.210.26  | Replica | stopped   |    |   unknown |
 +---------------+----------------+---------+-----------+----+-----------+
 
-ubuntu@juju-b87344-2:~$ sudo -u snap_daemon patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml list
+ubuntu@juju-b87344-2:~$ sudo -u _daemon_ patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml list
 + Cluster: postgresql (7496847632512033809) ----+-----------+----+-----------+
 | Member        | Host           | Role         | State     | TL | Lag in MB |
 +---------------+----------------+--------------+-----------+----+-----------+
@@ -110,7 +110,7 @@ ubuntu@juju-b87344-2:~$ sudo -u snap_daemon patronictl -c /var/snap/charmed-post
 <details><summary>Example: failover</summary>
 
 ```text
-ubuntu@juju-b87344-2:~$ sudo -u snap_daemon patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml failover postgresql --candidate postgresql-3              
+ubuntu@juju-b87344-2:~$ sudo -u _daemon_ patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml failover postgresql --candidate postgresql-3              
 Current cluster list
 + Cluster: postgresql (7496847632512033809) ----+-----------+----+-----------+
 | Member        | Host           | Role         | State     | TL | Lag in MB |
@@ -129,14 +129,14 @@ Are you sure you want to failover cluster postgresql, demoting current leader po
 | postgresql-3  | 10.189.210.26  | Leader  | running |  1 |           |
 +---------------+----------------+---------+---------+----+-----------+
 
-ubuntu@juju-b87344-2:~$ sudo -u snap_daemon patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml history
+ubuntu@juju-b87344-2:~$ sudo -u _daemon_ patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml history
 +----+-----------+------------------------------+----------------------------------+--------------+
 | TL |       LSN | Reason                       | Timestamp                        | New Leader   |
 +----+-----------+------------------------------+----------------------------------+--------------+
 |  1 | 335544480 | no recovery target specified | 2025-04-25T04:44:53.137152+00:00 | postgresql-3 |
 +----+-----------+------------------------------+----------------------------------+--------------+
 
-ubuntu@juju-b87344-2:~$ sudo -u snap_daemon patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml list
+ubuntu@juju-b87344-2:~$ sudo -u _daemon_ patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml list
 + Cluster: postgresql (7496847632512033809) ----+-----------+----+-----------+
 | Member        | Host           | Role         | State     | TL | Lag in MB |
 +---------------+----------------+--------------+-----------+----+-----------+
@@ -154,7 +154,7 @@ Sometimes the cluster member might stuck in the middle of nowhere, the easiest w
 <details><summary>Example: cluster member re-initialization</summary>
 
 ```text
-ubuntu@juju-b87344-2:~$ sudo -u snap_daemon patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml reinit postgresql postgresql-1
+ubuntu@juju-b87344-2:~$ sudo -u _daemon_ patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml reinit postgresql postgresql-1
 + Cluster: postgresql (7496847632512033809) ----+-----------+----+-----------+
 | Member        | Host           | Role         | State     | TL | Lag in MB |
 +---------------+----------------+--------------+-----------+----+-----------+

--- a/docs/reference/troubleshooting/index.md
+++ b/docs/reference/troubleshooting/index.md
@@ -48,11 +48,11 @@ The Patroni/PostgreSQL logs are located inside the snap:
 > ls -la /var/snap/charmed-postgresql/common/var/log/*
 
 /var/snap/charmed-postgresql/common/var/log/patroni:
--rw-r--r-- 1 snap_daemon snap_daemon 292519 Sep 15 21:47 patroni.log
+-rw-r--r-- 1 _daemon_ _daemon_ 292519 Sep 15 21:47 patroni.log
 
 /var/snap/charmed-postgresql/common/var/log/pgbackrest:
--rw-r----- 1 snap_daemon snap_daemon 7337 Sep 15 21:46 all-server.log
--rw-r----- 1 snap_daemon snap_daemon 5858 Sep 15 10:41 testbet.postgresql-stanza-create.log
+-rw-r----- 1 _daemon_ _daemon_ 7337 Sep 15 21:46 all-server.log
+-rw-r----- 1 _daemon_ _daemon_ 5858 Sep 15 10:41 testbet.postgresql-stanza-create.log
 
 /var/snap/charmed-postgresql/common/var/log/pgbouncer:
 # The pgBouncer should be stopped on Charmed PostgreSQL deployments and produce no logs.

--- a/refresh_versions.toml
+++ b/refresh_versions.toml
@@ -6,6 +6,6 @@ name = "charmed-postgresql"
 
 [snap.revisions]
 # amd64
-x86_64 = "183"
+x86_64 = "197"
 # arm64
-aarch64 = "185"
+aarch64 = "198"

--- a/scripts/cluster_topology_observer.py
+++ b/scripts/cluster_topology_observer.py
@@ -102,7 +102,7 @@ def check_for_database_changes(run_cmd, unit, charm_dir, previous_databases):
         "-E",
         "-H",
         "-u",
-        "snap_daemon",
+        "_daemon_",
         "charmed-postgresql.patronictl",
         "-c",
         conf_file_path,

--- a/src/backups.py
+++ b/src/backups.py
@@ -344,7 +344,7 @@ class PostgreSQLBackups(Object):
         """Execute a command in the workload container."""
 
         def demote():
-            pw_record = pwd.getpwnam("snap_daemon")
+            pw_record = pwd.getpwnam("_daemon_")
 
             def result():
                 os.setgid(pw_record.pw_gid)

--- a/src/charm.py
+++ b/src/charm.py
@@ -1324,15 +1324,15 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         except snap.SnapError:
             logger.warning("Unable to create psql alias")
 
-        # Create the user home directory for the snap_daemon user.
+        # Create the user home directory for the _daemon_ user.
         # This is needed due to https://bugs.launchpad.net/snapd/+bug/2011581.
         try:
             # Input is hardcoded
-            subprocess.check_call(["mkdir", "-p", "/home/snap_daemon"])  # noqa: S607
-            subprocess.check_call(["chown", "snap_daemon:snap_daemon", "/home/snap_daemon"])  # noqa: S607
-            subprocess.check_call(["usermod", "-d", "/home/snap_daemon", "snap_daemon"])  # noqa: S607
+            subprocess.check_call(["mkdir", "-p", "/home/_daemon_"])  # noqa: S607
+            subprocess.check_call(["chown", "_daemon_:_daemon_", "/home/_daemon_"])  # noqa: S607
+            subprocess.check_call(["usermod", "-d", "/home/_daemon_", "_daemon_"])  # noqa: S607
         except subprocess.CalledProcessError:
-            logger.exception("Unable to create snap_daemon home dir")
+            logger.exception("Unable to create _daemon_ home dir")
 
         self.set_unit_status(WaitingStatus("waiting to start PostgreSQL"))
 

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -218,8 +218,8 @@ class Patroni:
         Args:
             path: path to a file or directory.
         """
-        # Get the uid/gid for the snap_daemon user.
-        user_database = pwd.getpwnam("snap_daemon")
+        # Get the uid/gid for the _daemon_ user.
+        user_database = pwd.getpwnam("_daemon_")
         # Set the correct ownership for the file or directory.
         os.chown(path, uid=user_database.pw_uid, gid=user_database.pw_gid)
 
@@ -590,7 +590,7 @@ class Patroni:
             mode: access permission mask applied to the
               file using chmod (e.g. 0o640).
             change_owner: whether to change the file owner
-              to the snap_daemon user.
+              to the _daemon_ user.
         """
         # TODO: keep this method to use it also for generating replication configuration files and
         # move it to an utils / helpers file.

--- a/src/relations/async_replication.py
+++ b/src/relations/async_replication.py
@@ -336,7 +336,7 @@ class PostgreSQLAsyncReplication(Object):
         """Returns the PostgreSQL system identifier from this instance."""
 
         def demote():
-            pw_record = pwd.getpwnam("snap_daemon")
+            pw_record = pwd.getpwnam("_daemon_")
 
             def result():
                 os.setgid(pw_record.pw_gid)

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -189,7 +189,7 @@ postgresql:
     - {{ 'hostssl' if enable_tls else 'host' }}     replication    replication    {{ peer_ip }}/0    md5
     {% endfor %}
   pg_ident:
-  - operator snap_daemon backup
+  - operator _daemon_ backup
   authentication:
     replication:
       username: replication

--- a/templates/pgbackrest.logrotate.j2
+++ b/templates/pgbackrest.logrotate.j2
@@ -4,7 +4,7 @@
     notifempty
     nocompress
     daily
-    create 0600 snap_daemon snap_daemon
+    create 0600 _daemon_ _daemon_
     dateext
     dateformat -%Y%m%d_%H%M
 }

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -113,7 +113,7 @@ async def test_tls_enabled(ops_test: OpsTest) -> None:
                 await run_command_on_unit(
                     ops_test,
                     replica,
-                    "sudo -u snap_daemon charmed-postgresql.pg-ctl -D /var/snap/charmed-postgresql/common/var/lib/postgresql/ promote",
+                    "sudo -u _daemon_ charmed-postgresql.pg-ctl -D /var/snap/charmed-postgresql/common/var/lib/postgresql/ promote",
                 )
 
                 # Check that the replica was promoted.

--- a/tests/spread/test_upgrade.py/task.yaml
+++ b/tests/spread/test_upgrade.py/task.yaml
@@ -5,3 +5,6 @@ execute: |
   tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - -ubuntu-24.04
+  - -ubuntu-24.04-arm

--- a/tests/spread/test_upgrade_from_stable.py/task.yaml
+++ b/tests/spread/test_upgrade_from_stable.py/task.yaml
@@ -5,3 +5,6 @@ execute: |
   tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - -ubuntu-24.04
+  - -ubuntu-24.04-arm

--- a/tests/unit/test_backups.py
+++ b/tests/unit/test_backups.py
@@ -492,7 +492,7 @@ def test_execute_command(harness):
         _run.assert_called_once_with(
             command, input=None, capture_output=True, preexec_fn=ANY, timeout=None
         )
-        _getpwnam.assert_called_once_with("snap_daemon")
+        _getpwnam.assert_called_once_with("_daemon_")
 
         # Test when the command runs successfully.
         _run.reset_mock()
@@ -505,7 +505,7 @@ def test_execute_command(harness):
         _run.assert_called_once_with(
             command, input=b"fake input", capture_output=True, preexec_fn=ANY, timeout=5
         )
-        _getpwnam.assert_called_once_with("snap_daemon")
+        _getpwnam.assert_called_once_with("_daemon_")
 
 
 def test_format_backup_list(harness):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -89,9 +89,9 @@ def test_on_install(harness):
         pg_snap.alias.assert_any_call("patronictl")
 
         assert _check_call.call_count == 3
-        _check_call.assert_any_call(["mkdir", "-p", "/home/snap_daemon"])
-        _check_call.assert_any_call(["chown", "snap_daemon:snap_daemon", "/home/snap_daemon"])
-        _check_call.assert_any_call(["usermod", "-d", "/home/snap_daemon", "snap_daemon"])
+        _check_call.assert_any_call(["mkdir", "-p", "/home/_daemon_"])
+        _check_call.assert_any_call(["chown", "_daemon_:_daemon_", "/home/_daemon_"])
+        _check_call.assert_any_call(["usermod", "-d", "/home/_daemon_", "_daemon_"])
 
         # Assert the status set by the event handler.
         assert isinstance(harness.model.unit.status, WaitingStatus)
@@ -125,7 +125,7 @@ def test_on_install_failed_to_create_home(harness):
         pg_snap.alias.assert_any_call("psql")
         pg_snap.alias.assert_any_call("patronictl")
 
-        _logger_exception.assert_called_once_with("Unable to create snap_daemon home dir")
+        _logger_exception.assert_called_once_with("Unable to create _daemon_ home dir")
 
         # Assert the status set by the event handler.
         assert isinstance(harness.model.unit.status, WaitingStatus)

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -274,7 +274,7 @@ def test_render_file(peers_ips, patroni):
         # Check the rendered file is opened with "w+" mode.
         assert mock.call_args_list[0][0] == (filename, "w+")
         # Ensure that the correct user is lookup up.
-        _pwnam.assert_called_with("snap_daemon")
+        _pwnam.assert_called_with("_daemon_")
         # Ensure the file is chmod'd correctly.
         _chmod.assert_called_with(filename, 0o640)
         # Ensure the file is chown'd correctly.
@@ -499,7 +499,7 @@ def test_configure_patroni_on_unit(peers_ips, patroni):
 
         patroni.configure_patroni_on_unit()
 
-        _getpwnam.assert_called_once_with("snap_daemon")
+        _getpwnam.assert_called_once_with("_daemon_")
 
         _chown.assert_any_call(
             "/var/snap/charmed-postgresql/common/var/lib/postgresql",


### PR DESCRIPTION
## Issue

The snap user `snap_daemon` has been deprecated by SNAP team,
see: https://forum.snapcraft.io/t/system-usernames/13386
Also the newer charmed-postgresql snap is available with new parts there.

## Solution

* Bump snap revision to 197/198.
* Use `_daemon_` (UID:584792) instead of `snap_daemon` (UID:584788)
* temporary disable upgrade tests due to snap user change.
  Tests will be re-enabled after releasing to edge, as we do not
  provide upgrade path for snap ownership changes.
  Upgrade path is unnecessary here, as it is a first stable release to PG16 charm.
* Stop creating $SNAP_COMMON/data/db (unnecessary) + polishing
* new snap adds postgresql-16-repack PG extention

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
