### PR TITLE
Fix LDAP component to use dedicated user instead of operator user

### DIFF
--- a/docs/explanation/users.md
+++ b/docs/explanation/users.md
@@ -17,6 +17,7 @@ The operator uses the following internal DB users:
 * `rewind` - the internal user for synchronizing a PostgreSQL cluster with another copy of the same cluster.
 * `monitoring` - the user for [COS integration](/how-to/monitoring-cos/enable-monitoring).
 * `backups` - the user to [perform/list/restore backups](/how-to/back-up-and-restore/create-a-backup).
+* `ldap` - the user for [LDAP synchronization](/how-to/enable-ldap) when LDAP integration is enabled. This user has the `CREATEROLE` privilege to manage PostgreSQL roles synchronized from LDAP.
 
 The full list of internal users is available in charm [source code](https://github.com/canonical/postgresql-operator/blob/main/src/constants.py). The full dump of internal users (on the newly installed charm):
 
@@ -26,6 +27,7 @@ postgres=# \du
   Role name  |                         Attributes                         |  Member of   
 -------------+------------------------------------------------------------+--------------
  backup      | Superuser                                                  | {}
+ ldap        | Create role                                                | {}
  monitoring  |                                                            | {pg_monitor}
  operator    | Superuser, Create role, Create DB, Replication, Bypass RLS | {}
  postgres    | Superuser                                                  | {}
@@ -51,7 +53,7 @@ password:
   description: The password will be auto-generated if this option is not specified.
 username:
   type: string
-  description: The username, the default value 'operator'. Possible values - operator, replication, rewind.
+  description: The username, the default value 'operator'. Possible values - operator, replication, rewind, monitoring, backup, ldap.
 ```
 
 For example, to generate a new random password for *internal* user:

--- a/docs/how-to/manage-passwords.md
+++ b/docs/how-to/manage-passwords.md
@@ -30,3 +30,5 @@ To set a manual password for another user:
 juju run postgresql/leader set-password username=<username> password=<password>
 ```
 
+Where `<username>` can be any of the system users: `operator`, `replication`, `rewind`, `monitoring`, `backup`, or `ldap`.
+

--- a/src/constants.py
+++ b/src/constants.py
@@ -18,6 +18,7 @@ PATRONI_CLUSTER_STATUS_ENDPOINT = "cluster"
 BACKUP_USER = "backup"
 REPLICATION_USER = "replication"
 REWIND_USER = "rewind"
+LDAP_USER = "ldap"
 TLS_KEY_FILE = "key.pem"
 TLS_CA_FILE = "ca.pem"
 TLS_CERT_FILE = "cert.pem"
@@ -27,7 +28,7 @@ MONITORING_SNAP_SERVICE = "prometheus-postgres-exporter"
 PATRONI_SERVICE_NAME = "snap.charmed-postgresql.patroni.service"
 PATRONI_SERVICE_DEFAULT_PATH = f"/etc/systemd/system/{PATRONI_SERVICE_NAME}"
 # List of system usernames needed for correct work of the charm/workload.
-SYSTEM_USERS = [BACKUP_USER, REPLICATION_USER, REWIND_USER, USER, MONITORING_USER]
+SYSTEM_USERS = [BACKUP_USER, REPLICATION_USER, REWIND_USER, USER, MONITORING_USER, LDAP_USER]
 
 # Snap constants.
 PGBACKREST_EXECUTABLE = "charmed-postgresql.pgbackrest"
@@ -67,6 +68,7 @@ REPLICATION_PASSWORD_KEY = "replication-password"  # noqa: S105
 REWIND_PASSWORD_KEY = "rewind-password"  # noqa: S105
 USER_PASSWORD_KEY = "operator-password"  # noqa: S105
 MONITORING_PASSWORD_KEY = "monitoring-password"  # noqa: S105
+LDAP_PASSWORD_KEY = "ldap-password"  # noqa: S105
 RAFT_PASSWORD_KEY = "raft-password"  # noqa: S105
 PATRONI_PASSWORD_KEY = "patroni-password"  # noqa: S105
 SECRET_INTERNAL_LABEL = "internal-secret"  # noqa: S105

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -825,6 +825,7 @@ def test_on_get_password(harness):
             {
                 "operator-password": "test-password",
                 "replication-password": "replication-test-password",
+                "ldap-password": "ldap-test-password",
             },
         )
 
@@ -840,11 +841,17 @@ def test_on_get_password(harness):
         harness.charm._on_get_password(mock_event)
         mock_event.set_results.assert_called_once_with({"password": "test-password"})
 
-        # Also test providing the username option.
+        # Test providing the replication username option.
         mock_event.reset_mock()
         mock_event.params["username"] = "replication"
         harness.charm._on_get_password(mock_event)
         mock_event.set_results.assert_called_once_with({"password": "replication-test-password"})
+
+        # Test providing the ldap username option.
+        mock_event.reset_mock()
+        mock_event.params["username"] = "ldap"
+        harness.charm._on_get_password(mock_event)
+        mock_event.set_results.assert_called_once_with({"password": "ldap-test-password"})
 
 
 def test_on_set_password(harness):
@@ -900,14 +907,21 @@ def test_on_set_password(harness):
         mock_event.fail.assert_called_once()
         _set_secret.assert_not_called()
 
-        # Also test providing the username option.
+        # Test providing the replication username option.
         _set_secret.reset_mock()
         mock_event.params["username"] = "replication"
         harness.charm._on_set_password(mock_event)
         _set_secret.assert_called_once_with("app", "replication-password", "newpass")
 
+        # Test providing the ldap username option.
+        _set_secret.reset_mock()
+        mock_event.params["username"] = "ldap"
+        harness.charm._on_set_password(mock_event)
+        _set_secret.assert_called_once_with("app", "ldap-password", "newpass")
+
         # And test providing both the username and password options.
         _set_secret.reset_mock()
+        mock_event.params["username"] = "replication"
         mock_event.params["password"] = "replication-test-password"
         harness.charm._on_set_password(mock_event)
         _set_secret.assert_called_once_with(


### PR DESCRIPTION
## Issue

Fixes #966

The LDAP component currently uses the operator user to connect to PostgreSQL, which violates the principle of least privilege. Each component should have its own dedicated user with minimal necessary permissions.

## Solution

This PR implements a dedicated LDAP user for PostgreSQL connections used by the LDAP synchronization service:

### Key Changes:

1. **Add LDAP user constants and system configuration**:
   - Added `LDAP_USER = "ldap"` and `LDAP_PASSWORD_KEY = "ldap-password"` constants
   - Added LDAP_USER to SYSTEM_USERS list for proper management
   - Imported new constants in charm.py

2. **Implement LDAP user creation with minimal privileges**:
   - Generate LDAP password during leader election alongside other system passwords
   - Create LDAP user in `_start_primary` method with `CREATEROLE` privilege only
   - Ensures minimal necessary permissions for LDAP sync operations

3. **Update LDAP sync to use dedicated user**:
   - Modified `_setup_ldap_sync` to use LDAP_USER and LDAP_PASSWORD_KEY
   - Replaced operator user credentials with dedicated LDAP user credentials
   - Maintains security isolation between components

4. **Comprehensive test coverage**:
   - Added LDAP user to integration password rotation tests
   - Extended unit tests for get-password and set-password actions
   - Ensures LDAP user is properly tested in all password management scenarios

5. **Complete documentation updates**:
   - Added LDAP user to internal users documentation with privilege explanation
   - Updated PostgreSQL roles dump example to include ldap user
   - Extended password management documentation to include all system users

### Security Benefits:

- **Principle of least privilege**: LDAP user has only `CREATEROLE` privilege needed for LDAP sync
- **Component isolation**: LDAP service no longer uses operator user credentials  
- **Audit clarity**: LDAP operations are clearly identifiable in logs and monitoring

### Backward Compatibility:

- Existing deployments will automatically create the LDAP user during next restart
- No manual intervention required for existing LDAP integrations
- Password management actions now support the new LDAP user

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.