### PR TITLE
Reuse class PostgreSQL on each self.postgresql.* call

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -607,7 +607,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
     def postgresql(self) -> PostgreSQL:
         """Returns an instance of the object used to interact with the database."""
         password = str(self.get_secret(APP_SCOPE, f"{USER}-password"))
-        if self._postgresql is None:
+        if self._postgresql is None or self._postgresql.primary_host is None:
             logger.debug("Init class PostgreSQL")
             self._postgresql = PostgreSQL(
                 primary_host=self.primary_endpoint,

--- a/src/charm.py
+++ b/src/charm.py
@@ -251,6 +251,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
 
     config_type = CharmConfig
     on = ClusterTopologyChangeCharmEvents()
+    _postgresql: PostgreSQL | None = None
 
     def __init__(self, *args):
         super().__init__(*args)
@@ -605,14 +606,20 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
     @property
     def postgresql(self) -> PostgreSQL:
         """Returns an instance of the object used to interact with the database."""
-        return PostgreSQL(
-            primary_host=self.primary_endpoint,
-            current_host=self._unit_ip,
-            user=USER,
-            password=self.get_secret(APP_SCOPE, f"{USER}-password"),
-            database=DATABASE_DEFAULT_NAME,
-            system_users=SYSTEM_USERS,
-        )
+        password = str(self.get_secret(APP_SCOPE, f"{USER}-password"))
+        if self._postgresql is None:
+            logger.debug("Init class PostgreSQL")
+            self._postgresql = PostgreSQL(
+                primary_host=self.primary_endpoint,
+                current_host=self._unit_ip,
+                user=USER,
+                password=password,
+                database=DATABASE_DEFAULT_NAME,
+                system_users=SYSTEM_USERS,
+            )
+        else:
+            self._postgresql.password = password
+        return self._postgresql
 
     @property
     def primary_endpoint(self) -> str | None:

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -260,6 +260,7 @@ class Patroni:
         if response := self.parallel_patroni_get_request(
             f"/{PATRONI_CLUSTER_STATUS_ENDPOINT}", alternative_endpoints
         ):
+            logger.debug("Patroni cluster members: %s", response["members"])
             return response["members"]
         raise RetryError(last_attempt=Exception("Unable to reach any units"))
 


### PR DESCRIPTION
## Issue
The charm inits class PostgreSQL on each `self.postgresql.*` call (which we have many).
Visualizing each Patroni API /cluster request:
```
@ src/cluster.py:263 @ class Patroni:
         if response := self.parallel_patroni_get_request(
             f"/{PATRONI_CLUSTER_STATUS_ENDPOINT}", alternative_endpoints
         ):
+            logger.debug(f"Patroni cluster members: %s", response["members"])
             return response["members"]
         raise RetryError(last_attempt=Exception("Unable to reach any units"))
```
Results:
```
> juju deploy ./postgresql_ubuntu@24.04-amd64.charm

# Amount of requests to Patroni API `/cluster` endpoint:
> juju debug-log --replay | grep -c "Patroni cluster members"  # default 16/edge r836
113
> juju debug-log --replay | grep -c "Patroni cluster members"  # this PR
22

# Amount of PostgreSQL class initializations (for entire charm deployment):
> juju debug-log --replay | grep -c "Init class PostgreSQL"  # this PR on powerful HW
3
> juju debug-log --replay | grep -c "Init class PostgreSQL"  # this PR on GH CI (defers events and primary_endpoint=None)
6 # up to 9 in rare cases
```
The [primary_endpoint=None](https://github.com/canonical/postgresql-operator/blob/fe2c9fbe64307a6391db0432e41a7e28fe801a62/src/charm.py#L425) might also be fixed separately.

The current result saves ~5% on CI deployment time (~10 seconds for 1 unit deployment).

## Solution

Inits class PostgreSQL once and reuse for each Juju event (Ops init).
Due to magic logic with secrets, we are avoiding caching them on this stage,
while it is space to improve it further.

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
