### PR TITLE
[DPE-6965] Re-enable charm upgrade tests (new snap _daemon_ user)

### DIFF
--- a/tests/spread/test_upgrade_from_stable.py/task.yaml
+++ b/tests/spread/test_upgrade_from_stable.py/task.yaml
@@ -5,6 +5,3 @@ execute: |
   tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
-systems:
-  - -ubuntu-24.04
-  - -ubuntu-24.04-arm


### PR DESCRIPTION
## Issue

The upgrade test was temporary disabled in commit 94f31bdec0213655c81fdd379b18a846eacbae2e 
to migrate on new snap user. The migration has been completed.

## Solution

The new charm has been merged and released, we should re-enable test.

## Checklist
- [x] I have added or updated any relevant documentation.
- [X] I have cleaned any remaining cloud resources from my accounts.
