### PR TITLE
Bump PG slots max_replication_slots / max_wal_senders = 25

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -2344,6 +2344,8 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         self._patroni.bulk_update_parameters_controller_by_patroni({
             "max_connections": max_connections,
             "max_prepared_transactions": self.config.memory_max_prepared_transactions,
+            "max_replication_slots": 25,
+            "max_wal_senders": 25
             "wal_keep_size": self.config.durability_wal_keep_size,
         })
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -2345,7 +2345,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             "max_connections": max_connections,
             "max_prepared_transactions": self.config.memory_max_prepared_transactions,
             "max_replication_slots": 25,
-            "max_wal_senders": 25
+            "max_wal_senders": 25,
             "wal_keep_size": self.config.durability_wal_keep_size,
         })
 


### PR DESCRIPTION
## Issue

To support logical replications and keep 9 units installation possible
+ async replication, we should bump slots count.

## Solution

Bump slots to support all features simultaneously.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
