### PR TITLE
DPE-7723: Update releases.md: fix arch for revs 429/430

### DIFF
--- a/docs/reference/releases.md
+++ b/docs/reference/releases.md
@@ -42,7 +42,7 @@ Check the tables below, or use [`juju info`](https://juju.is/docs/juju/juju-info
 
 | Revision | amd64 | arm64 | Ubuntu 22.04 LTS
 |:--------:|:-----:|:-----:|:-----:|
-|[553]  | ![check] |        |  ![check]  |
+|[553] | ![check] |          |  ![check]  |
 |[552] |          | ![check] |  ![check]  |
 
 <details>
@@ -52,8 +52,8 @@ Check the tables below, or use [`juju info`](https://juju.is/docs/juju/juju-info
 |:--------:|:-----:|:-----:|:-----:|
 |[468] |![check]  |          | ![check] |
 |[467] |          | ![check] | ![check] |
-|[430] |![check]  |          | ![check] |
-|[429] |          | ![check] | ![check] |
+|[430] |          | ![check] | ![check] |
+|[429] |![check]  |          | ![check] |
 |[363] |![check]  |          | ![check] |          
 |[351] |![check]  |          | ![check] |         
 |[336] |![check]  |          | ![check] |       


### PR DESCRIPTION
## Issue

https://canonical-charmed-postgresql.readthedocs-hosted.com/14/reference/releases/ says
rev 430 is amd64
rev 429 is arm64

This is wrong:
```
juju download postgresql --revision 429
mv ./postgresql_r429.charm ./postgresql_r429.zip
unp ./postgresql_r429.zip
grep amd manifest.yaml 
  - amd64
```
 
## Solution

Update docs with proper pinning.
Fixes: https://github.com/canonical/postgresql-operator/issues/1045

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
