### PR TITLE
[DPE-7792] Update predefined roles docs

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -28,6 +28,7 @@ cjk
 codebase
 config
 configs
+CREATEDB
 cryptographically
 CSR
 CSRs

--- a/docs/explanation/roles.md
+++ b/docs/explanation/roles.md
@@ -44,6 +44,8 @@ Charmed PostgreSQL 16 introduces the following instance-level predefined roles:
 * `charmed_dba` (allowed to escalate to any other user, including the superuser `operator`)
 * `charmed_admin` (inherit from `charmed_dml` and allowed to escalate to the database-specific `charmed_<database-name>_owner` role, which is explained later in this document)
 * `charmed_databases_owner` (allowed to create databases; it can be requested through the CREATEDB extra user role)
+ 
+Currently, `charmed_backup` and `charmed_dba` cannot be requested through the relation as extra user roles.
 
 ```text
 test123=> SELECT * FROM pg_roles;

--- a/docs/explanation/roles.md
+++ b/docs/explanation/roles.md
@@ -60,11 +60,12 @@ test123=> SELECT * FROM pg_roles;
 Charmed PostgreSQL 16 also introduces catalogue/database level roles, with permissions tied to each database that's created. Example for a database named `test`:
 
 ```text
-test123=> SELECT * FROM pg_roles where rolname like 'test_%';;
-          rolname           | rolsuper | rolinherit | rolcreaterole | rolcreatedb | rolcanlogin | rolreplication | rolconnlimit | rolpassword | rolvaliduntil | rolbypassrls | rolconfig |  oid  
-----------------------------+----------+------------+---------------+-------------+-------------+----------------+--------------+-------------+---------------+--------------+-----------+-------
- test_owner                 | f        | t          | f             | f           | f           | f              |           -1 | ********    |               | f            |           | 16479
- test_admin                 | f        | f          | f             | f           | f           | f              |           -1 | ********    |               | f            |           | 16480
+test123=> SELECT * FROM pg_roles WHERE rolname LIKE 'charmed_test_%';
+      rolname       | rolsuper | rolinherit | rolcreaterole | rolcreatedb | rolcanlogin | rolreplication | rolconnlimit | rolpassword | rolvaliduntil | rolbypassrls | rolconfig |  oid  
+--------------------+----------+------------+---------------+-------------+-------------+----------------+--------------+-------------+---------------+--------------+-----------+-------
+ charmed_test_owner | f        | t          | f             | f           | f           | f              |           -1 | ********    |               | f            |           | 16393
+ charmed_test_admin | f        | f          | f             | f           | f           | f              |           -1 | ********    |               | f            |           | 16394
+ charmed_test_dml   | f        | t          | f             | f           | f           | f              |           -1 | ********    |               | f            |           | 16396
 ```
 
 The `charmed_<database-name>_admin` role is assigned to each relation user (explained in the next section) with access to the specific database. When that user connects to the database, it's auto-escalated to the `charmed_<database-name>_owner` user, which will own every object inside the database, simplifying the permissions to perform operations on those objects when a new user requests access to that same database.

--- a/docs/explanation/roles.md
+++ b/docs/explanation/roles.md
@@ -54,6 +54,9 @@ test123=> SELECT * FROM pg_roles;
  charmed_read                | f        | t          | f             | f           | f           | f              |           -1 | ********    |               | f            |           | 16388
  charmed_dml                 | f        | t          | f             | f           | f           | f              |           -1 | ********    |               | f            |           | 16390
  charmed_backup              | f        | t          | f             | f           | f           | f              |           -1 | ********    |               | f            |           | 16392
+ charmed_dba                 | f        | t          | f             | f           | f           | f              |           -1 | ********    |               | f            |           | 16393
+ charmed_admin               | f        | t          | f             | f           | f           | f              |           -1 | ********    |               | f            |           | 16394
+ charmed_databases_owner     | f        | t          | f             | t           | t           | f              |           -1 | ********    |               | f            |           | 16395
 ...
 ```
 
@@ -63,9 +66,9 @@ Charmed PostgreSQL 16 also introduces catalogue/database level roles, with permi
 test123=> SELECT * FROM pg_roles WHERE rolname LIKE 'charmed_test_%';
       rolname       | rolsuper | rolinherit | rolcreaterole | rolcreatedb | rolcanlogin | rolreplication | rolconnlimit | rolpassword | rolvaliduntil | rolbypassrls | rolconfig |  oid  
 --------------------+----------+------------+---------------+-------------+-------------+----------------+--------------+-------------+---------------+--------------+-----------+-------
- charmed_test_owner | f        | t          | f             | f           | f           | f              |           -1 | ********    |               | f            |           | 16393
- charmed_test_admin | f        | f          | f             | f           | f           | f              |           -1 | ********    |               | f            |           | 16394
- charmed_test_dml   | f        | t          | f             | f           | f           | f              |           -1 | ********    |               | f            |           | 16396
+ charmed_test_owner | f        | t          | f             | f           | f           | f              |           -1 | ********    |               | f            |           | 16396
+ charmed_test_admin | f        | f          | f             | f           | f           | f              |           -1 | ********    |               | f            |           | 16397
+ charmed_test_dml   | f        | t          | f             | f           | f           | f              |           -1 | ********    |               | f            |           | 16398
 ```
 
 The `charmed_<database-name>_admin` role is assigned to each relation user (explained in the next section) with access to the specific database. When that user connects to the database, it's auto-escalated to the `charmed_<database-name>_owner` user, which will own every object inside the database, simplifying the permissions to perform operations on those objects when a new user requests access to that same database.


### PR DESCRIPTION
## Issue
Not all the predefined roles are documented after the last refactoring in that list.

## Solution
Add the missing roles and update the SQL queries outputs.

Also, remove the mentions of relation users having the ownership of the objects created within the databases. The ownership of those objects now (in PG 16) belongs to the `charmed_<database-name>_owner` role.

## Checklist
- [x] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
