### PR TITLE
Fix MicroStack links

### DIFF
--- a/docs/how-to/deploy/sunbeam.md
+++ b/docs/how-to/deploy/sunbeam.md
@@ -18,7 +18,7 @@ This guide assumes you have:
 
 ## Install and bootstrap Sunbeam
 
-Follow the official OpenStack guide: [Single-node deployment][Single-node guided]. 
+Follow the [official OpenStack installation guide][Single-node guided].
 
 Pay attention to the `Caution` and `Note` sections - the `/etc/hosts` will require a [manual {spellexception}`fqdn` fix](https://github.com/canonical/multipass/issues/3277#issuecomment-2471434029).
 
@@ -28,7 +28,7 @@ Follow the official [Images Sync] guide to enable auto-sync and wait for the ima
 
 ## Set up Juju inside an OpenStack bastion
 
-Follow the MicroStack guide [Manage workloads with Juju] from the beginning, and stop after the section "Create a Juju controller". 
+Follow the OpenStack guide [Manage workloads with Juju] from the beginning, and stop after the section "Create a Juju controller". 
 
 To summarise, the relevant sections are:
 * Set up the bastion
@@ -82,8 +82,8 @@ The image below is an example of the OpenStack dashboard view (bastion + juju co
 
 <!-- LABELS-->
 [Tutorial]: /tutorial/index
-[Single-node guided]: https://microstack.run/docs/single-node-guided
-[Accessing the OpenStack dashboard]: https://microstack.run/docs/dashboard
-[Images Sync]: https://microstack.run/docs/images
-[Manage workloads with Juju]: https://microstack.run/docs/juju-workloads
+[Single-node guided]: https://canonical-openstack.readthedocs-hosted.com/en/latest/how-to/install/install-canonical-openstack-using-the-manual-bare-metal-provider/
+[Accessing the OpenStack dashboard]: https://canonical-openstack.readthedocs-hosted.com/en/latest/how-to/misc/using-the-openstack-dashboard/
+[Images Sync]: https://canonical-openstack.readthedocs-hosted.com/en/latest/how-to/features/images-sync/
+[Manage workloads with Juju]: https://canonical-openstack.readthedocs-hosted.com/en/latest/how-to/misc/manage-workloads-with-juju/
 


### PR DESCRIPTION
## Issue
MicroStack docs migration led to some broken links in the Sunbeam guide.

## Solution
Replaced MicroStack links with their equivalents in the [new OpenStack docs](https://canonical-openstack.readthedocs-hosted.com/en/latest/).

PR on 16: https://github.com/canonical/postgresql-operator/pull/1062

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
