### PR TITLE
[DPE-7594] Add custom users to pg_hba filter

### DIFF
--- a/lib/charms/postgresql_k8s/v1/postgresql.py
+++ b/lib/charms/postgresql_k8s/v1/postgresql.py
@@ -282,7 +282,8 @@ class PostgreSQL:
             raise PostgreSQLCreateDatabaseError() from e
 
         # Enable preset extensions
-        self.enable_disable_extensions(dict.fromkeys(plugins, True), database)
+        if plugins:
+            self.enable_disable_extensions(dict.fromkeys(plugins, True), database)
 
     def create_user(
         self,

--- a/src/charm.py
+++ b/src/charm.py
@@ -2458,9 +2458,16 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             return {USER: "all", REPLICATION_USER: "all", REWIND_USER: "all"}
         user_database_map = {}
         try:
-            for user in self.postgresql.list_users_from_relation(
-                current_host=self.is_connectivity_enabled
-            ):
+            for user in self.postgresql.list_users(current_host=self.is_connectivity_enabled):
+                if user in (
+                    "backup",
+                    "monitoring",
+                    "operator",
+                    "postgres",
+                    "replication",
+                    "rewind",
+                ):
+                    continue
                 user_database_map[user] = ",".join(
                     self.postgresql.list_accessible_databases_for_user(
                         user, current_host=self.is_connectivity_enabled

--- a/src/charm.py
+++ b/src/charm.py
@@ -2512,9 +2512,6 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
                         user, current_host=self.is_connectivity_enabled
                     )
                 )
-                # Add "landscape" superuser by default to the list when the "db-admin" relation is present.
-                if any(True for relation in self.client_relations if relation.name == "db-admin"):
-                    user_database_map["landscape"] = "all"
             if self.postgresql.list_access_groups(
                 current_host=self.is_connectivity_enabled
             ) != set(ACCESS_GROUPS):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -2678,3 +2678,59 @@ def test_generate_user_hash(harness):
         assert harness.charm.generate_user_hash == sentinel.hash
 
         _shake_128.assert_called_once_with(b"{'relation_id_2': 'test_db'}")
+
+
+def test_relations_user_databases_map(harness):
+    with (
+        patch("charm.PostgresqlOperatorCharm.postgresql") as _postgresql,
+        patch("charm.Patroni.member_started", new_callable=PropertyMock) as _member_started,
+        patch(
+            "charm.PostgresqlOperatorCharm.is_cluster_initialised", new_callable=PropertyMock
+        ) as _is_cluster_initialised,
+    ):
+        # Initial empty results from the functions used in the property that's being tested.
+        _postgresql.list_users_from_relation.return_value = set()
+        _postgresql.list_accessible_databases_for_user.return_value = set()
+        _postgresql.list_access_groups.return_value = {
+            "identity_access",
+            "internal_access",
+            "relation_access",
+        }
+
+        # Test when the cluster isn't initialised yet.
+        _is_cluster_initialised.return_value = False
+        _member_started.return_value = True
+        assert harness.charm.relations_user_databases_map == {
+            "operator": "all",
+            "replication": "all",
+            "rewind": "all",
+        }
+
+        # Test when the cluster is initialised but the cluster member hasn't started yet.
+        _is_cluster_initialised.return_value = True
+        _member_started.return_value = False
+        assert harness.charm.relations_user_databases_map == {
+            "operator": "all",
+            "replication": "all",
+            "rewind": "all",
+        }
+
+        # Test when there are no relation users in the database.
+        _member_started.return_value = True
+        assert harness.charm.relations_user_databases_map == {}
+
+        # Test when there are relation users in the database.
+        _postgresql.list_users.return_value = ["user1", "user2"]
+        _postgresql.list_accessible_databases_for_user.side_effect = [{"db1", "db2"}, {"db3"}]
+        assert harness.charm.relations_user_databases_map == {"user1": "db1,db2", "user2": "db3"}
+
+        # Test when the access groups where not created yet.
+        _postgresql.list_accessible_databases_for_user.side_effect = [{"db1", "db2"}, {"db3"}]
+        _postgresql.list_access_groups.return_value = set()
+        assert harness.charm.relations_user_databases_map == {
+            "user1": "db1,db2",
+            "user2": "db3",
+            "operator": "all",
+            "replication": "all",
+            "rewind": "all",
+        }

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -2721,11 +2721,11 @@ def test_relations_user_databases_map(harness):
 
         # Test when there are relation users in the database.
         _postgresql.list_users.return_value = ["user1", "user2"]
-        _postgresql.list_accessible_databases_for_user.side_effect = [{"db1", "db2"}, {"db3"}]
+        _postgresql.list_accessible_databases_for_user.side_effect = [["db1", "db2"], ["db3"]]
         assert harness.charm.relations_user_databases_map == {"user1": "db1,db2", "user2": "db3"}
 
         # Test when the access groups where not created yet.
-        _postgresql.list_accessible_databases_for_user.side_effect = [{"db1", "db2"}, {"db3"}]
+        _postgresql.list_accessible_databases_for_user.side_effect = [["db1", "db2"], ["db3"]]
         _postgresql.list_access_groups.return_value = set()
         assert harness.charm.relations_user_databases_map == {
             "user1": "db1,db2",


### PR DESCRIPTION
Don't skip custom users when generating pg_hba configuration

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
