### PR TITLE
[DPE-7594] Add custom users to pg_hba filter

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -2162,9 +2162,16 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             return {USER: "all", REPLICATION_USER: "all", REWIND_USER: "all"}
         user_database_map = {}
         try:
-            for user in sorted(
-                self.postgresql.list_users_from_relation(current_host=self.is_connectivity_enabled)
-            ):
+            for user in self.postgresql.list_users(current_host=self.is_connectivity_enabled):
+                if user in (
+                    "backup",
+                    "monitoring",
+                    "operator",
+                    "postgres",
+                    "replication",
+                    "rewind",
+                ):
+                    continue
                 user_database_map[user] = ",".join(
                     sorted(
                         self.postgresql.list_accessible_databases_for_user(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -2958,7 +2958,7 @@ def test_relations_user_databases_map(harness):
         assert harness.charm.relations_user_databases_map == {}
 
         # Test when there are relation users in the database.
-        _postgresql.list_users_from_relation.return_value = {"user1", "user2"}
+        _postgresql.list_users.return_value = ["user1", "user2"]
         _postgresql.list_accessible_databases_for_user.side_effect = [{"db1", "db2"}, {"db3"}]
         assert harness.charm.relations_user_databases_map == {"user1": "db1,db2", "user2": "db3"}
 


### PR DESCRIPTION
Don't skip custom users when generating pg_hba configuration

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
