### PR TITLE
[MISC] Don't re-add databases owner and update snaps

### DIFF
--- a/refresh_versions.toml
+++ b/refresh_versions.toml
@@ -6,6 +6,6 @@ name = "charmed-postgresql"
 
 [snap.revisions]
 # amd64
-x86_64 = "203"
+x86_64 = "205"
 # arm64
-aarch64 = "204"
+aarch64 = "206"

--- a/src/charm.py
+++ b/src/charm.py
@@ -2505,6 +2505,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
                     "postgres",
                     "replication",
                     "rewind",
+                    "charmed_databases_owner",
                 ):
                     continue
                 if databases := ",".join(


### PR DESCRIPTION
* Don't add additional HBA access to charmed_databases_owner (allowed by default)
* Update snaps (`postgresql-ldap-sync` version bump)

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
