### PR TITLE
Add SNAP revisions to Releases page

### DIFF
--- a/docs/how-to/deploy/tls-vip-access.md
+++ b/docs/how-to/deploy/tls-vip-access.md
@@ -14,7 +14,7 @@ The basic requirements to follow along with this example setup are the following
 
 * A fully deployed and running Juju machine environment
   * See the [PostgreSQL Tutorial](/tutorial/index) for a quick setup with Multipass
-  * See the official [Juju deployment guide](https://juju.is/docs/juju/tutorial#deploy) for more details
+  * See the official [Juju deployment guide](https://juju.is/docs/juju/tutorial) for more details
 * A spare virtual IP address for [`hacluster`](https://discourse.charmhub.io/t/pgbouncer-how-to-externally-access/15741)
   * See the PgBouncer guide: [How to use a VIP to connect to PgBouncer](https://charmhub.io/pgbouncer/docs/h-external-access?channel=1/stable)
 * DNS record pointing to VIP above (`my-tls-example-db.local` is used as an example here)

--- a/docs/reference/releases.md
+++ b/docs/reference/releases.md
@@ -40,24 +40,24 @@ Check the tables below, or use [`juju info`](https://juju.is/docs/juju/juju-info
 
 ### Release 552-553
 
-| Revision | amd64 | arm64 | Ubuntu 22.04 LTS
-|:--------:|:-----:|:-----:|:-----:|
-|[553] | ![check] |          |  ![check]  |
-|[552] |          | ![check] |  ![check]  |
+| Revision | amd64 | arm64 | Ubuntu 22.04 LTS | Snap revision |
+|:--------:|:-----:|:-----:|:-----:|:-----:|
+|[553] | ![check] |          |  ![check]  | 143 |
+|[552] |          | ![check] |  ![check]  | 142 |
 
 <details>
 <summary>Older releases</summary>
 
-| Revision | amd64 | arm64 | Ubuntu 22.04 LTS
-|:--------:|:-----:|:-----:|:-----:|
-|[468] |![check]  |          | ![check] |
-|[467] |          | ![check] | ![check] |
-|[430] |          | ![check] | ![check] |
-|[429] |![check]  |          | ![check] |
-|[363] |![check]  |          | ![check] |          
-|[351] |![check]  |          | ![check] |         
-|[336] |![check]  |          | ![check] |       
-|[288] |![check]  |          | ![check] |       
+| Revision | amd64 | arm64 | Ubuntu 22.04 LTS | Snap revision |
+|:--------:|:-----:|:-----:|:-----:|:-----:|
+|[468] |![check]  |          | ![check] | 120 |
+|[467] |          | ![check] | ![check] | 121 |
+|[430] |          | ![check] | ![check] | 114 |
+|[429] |![check]  |          | ![check] | 115 |
+|[363] |![check]  |          | ![check] | 96 |      
+|[351] |![check]  |          | ![check] | 89 |      
+|[336] |![check]  |          | ![check] | 85 |    
+|[288] |![check]  |          | ![check] | 31 |    
 
 </details>
 

--- a/docs/reference/versions.md
+++ b/docs/reference/versions.md
@@ -28,7 +28,7 @@ PostgreSQL 16 is shipped in track `16` and is available for testing in the chann
   * All replicas are now [synchronous units]
   * Switchover the primary unit via `promote-to-primary scope=unit`
   * Raft re-init helper: `promote-to-primary scope=unit force=yes`
-* [Juju user secrets](https://documentation.ubuntu.com/juju/latest/reference/secret/index.html#user) for charm [internal passwords](/how-to/manage-passwords)
+* [Juju user secrets](https://documentation.ubuntu.com/juju/latest/reference/secret/index.html#user-secret) for charm [internal passwords](/how-to/manage-passwords)
 * [Timescale Community Edition]
 * [Extended COS integration]
   * [Profiling via Parca]


### PR DESCRIPTION

## Issue
The end-users have troubles to find the proper/expected SNAP revisions for the specific Charm revision in Git.

## Solution
List them on release notes.

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.