### PR TITLE
Refresh v3 documentation

### DIFF
--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -45,6 +45,8 @@ Other deployment scenarios and configurations:
 
 ## Upgrades
 * [How to upgrade]
+    * [Perform a minor upgrade]
+    * [Perform a minor rollback]
 
 ## Cross-regional (cluster-cluster) async replication
 
@@ -95,6 +97,8 @@ This section is for charm developers looking to support PostgreSQL integrations 
 [Enable profiling]: /how-to/monitoring-cos/enable-profiling
 
 [How to upgrade]: /how-to/upgrade/index
+[Perform a minor upgrade]: /how-to/upgrade/minor-upgrade
+[Perform a minor rollback]: /how-to/upgrade/minor-rollback
 
 [Cross-regional async replication]: /how-to/cross-regional-async-replication/index
 [Set up clusters]: /how-to/cross-regional-async-replication/set-up-clusters

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -114,7 +114,6 @@ This section is for charm developers looking to support PostgreSQL integrations 
 ```{toctree}
 :titlesonly:
 :maxdepth: 2
-:glob:
 :hidden:
 
 Deploy <deploy/index>
@@ -128,7 +127,8 @@ Enable LDAP <enable-ldap>
 Enable plugins/extensions <enable-plugins-extensions/index>
 Back up and restore <back-up-and-restore/index>
 Monitoring (COS) <monitoring-cos/index>
-Upgrade <upgrade/index>
+Upgrade (refresh) <upgrade/index>
 Cross-regional async replication <cross-regional-async-replication/index>
 Development <development/index>
+```
 

--- a/docs/how-to/upgrade/index.md
+++ b/docs/how-to/upgrade/index.md
@@ -1,9 +1,45 @@
-# Upgrade
+# Upgrade (refresh)
 
-This charm does not support in-place upgrades for major version changes, and there are currently no minor versions of Charmed PostgreSQL 16 to upgrade or rollback.
+Charmed PostgreSQL supports minor in-place {term}`upgrades <upgrade>` via the [`juju refresh`](https://documentation.ubuntu.com/juju/3.6/reference/juju-cli/list-of-juju-cli-commands/refresh/#details) command:
 
-For minor version upgrades on Charmed PostgreSQL 14, see the [version 14 upgrades documentation](https://canonical-charmed-postgresql.readthedocs-hosted.com/en/14/how-to/upgrade/).
+```{admonition} Please keep in mind: 
+:class: caution
 
-```{note}
-We will soon publish a migration guide with instructions on how to change from PostgreSQL 14 to 16.
+* This charm **can only be upgraded to a higher version**. It cannot be {term}`downgraded <downgrade>` to a lower version.
+* This charm **only supports minor version upgrades**, e.g. 16.9 --> 16.10.
+* If anything goes wrong during the refresh process, the best option is usually to perorm a {term}`rollback`.
+```
+
+Guides:
+
+```{toctree}
+:titlesonly:
+
+Perform a minor upgrade <minor-upgrade>
+Perform a minor rollback <minor-rollback>
+```
+
+## Glossary
+
+This is a simplified summary of refresh terminology. 
+
+For a more detailed glossary, see the [charm refresh  developer documentation](https://canonical-charm-refresh.readthedocs-hosted.com/latest/glossary/). 
+
+```{glossary}
+refresh
+    `juju refresh` to a different workload and/or charm version.
+
+    Note: *rollback*, *upgrade*, and *downgrade* are specific types of refresh.
+
+upgrade
+    `juju refresh` to a higher workload and/or charm version.
+
+downgrade
+    `juju refresh` to a lower workload and/or charm version.
+
+rollback
+    `juju refresh` to the original workload and charm version while a refresh is in progress.
+
+workload
+    A software component that the charm operates. E.g. PostgreSQL.
 ```

--- a/docs/how-to/upgrade/index.md
+++ b/docs/how-to/upgrade/index.md
@@ -1,45 +1,34 @@
 # Upgrade (refresh)
 
-Charmed PostgreSQL supports minor in-place {term}`upgrades <upgrade>` via the [`juju refresh`](https://documentation.ubuntu.com/juju/3.6/reference/juju-cli/list-of-juju-cli-commands/refresh/#details) command:
+A charm **refresh** is any change to the version of a charm, and/or its {term}`workload`. 
 
-```{admonition} Please keep in mind: 
-:class: caution
+Charmed PostgreSQL supports minor in-place {term}`upgrades <upgrade>` via the [`juju refresh`](https://documentation.ubuntu.com/juju/3.6/reference/juju-cli/list-of-juju-cli-commands/refresh/#details) command.
 
-* This charm **can only be upgraded to a higher version**. It cannot be {term}`downgraded <downgrade>` to a lower version.
-* This charm **only supports minor version upgrades**, e.g. 16.9 --> 16.10.
-* If anything goes wrong during the refresh process, the best option is usually to perorm a {term}`rollback`.
+## Supported refresh types
+
+This charm **can only be upgraded to a higher version**. It cannot be {term}`downgraded <downgrade>` to a lower version.
+
+The charm version can only be lowered in the case of an ongoing refresh that needs to {term}`roll back <rollback>` to its {term}`original version` due to a failure.
+
+```{seealso}
+* [How to perform a minor upgrade](/how-to/upgrade/minor-upgrade)
+* [How to perform a minor rollback](/how-to/upgrade/minor-rollback)
 ```
 
-Guides:
+## Supported versions
+
+This charm **only supports minor version upgrades**, e.g. 16.9 --> 16.10.
+
+[Contact us](/reference/contacts) if you want to migrate from Charmed PostgreSQL 14 to 16
+
+```{seealso}
+* [Charmed PostgreSQL 16 versions](/reference/releases)
+```
 
 ```{toctree}
 :titlesonly:
+:hidden:
 
 Perform a minor upgrade <minor-upgrade>
 Perform a minor rollback <minor-rollback>
-```
-
-## Glossary
-
-This is a simplified summary of refresh terminology. 
-
-For a more detailed glossary, see the [charm refresh  developer documentation](https://canonical-charm-refresh.readthedocs-hosted.com/latest/glossary/). 
-
-```{glossary}
-refresh
-    `juju refresh` to a different workload and/or charm version.
-
-    Note: *rollback*, *upgrade*, and *downgrade* are specific types of refresh.
-
-upgrade
-    `juju refresh` to a higher workload and/or charm version.
-
-downgrade
-    `juju refresh` to a lower workload and/or charm version.
-
-rollback
-    `juju refresh` to the original workload and charm version while a refresh is in progress.
-
-workload
-    A software component that the charm operates. E.g. PostgreSQL.
 ```

--- a/docs/how-to/upgrade/minor-rollback.md
+++ b/docs/how-to/upgrade/minor-rollback.md
@@ -1,1 +1,29 @@
 # Perform a minor rollback
+
+After running `juju refresh`, if there are any version incompatibilities in charm revisions, its dependencies, or any other unexpected failure in the upgrade process, the process will be halted and enter a failure state.
+
+Even if the underlying PostgreSQL cluster continues to work, it’s important to roll back the charm to the {term}`original version` so that an update can be attempted after further inspection of the failure.
+
+```{attention}
+Only trigger a rollback if the refresh has expicitly failed and cannot continue. Do not initiate a rollback while the refresh process is still running.
+
+<!--TODO: examples-->
+```
+
+---
+
+## Initiate rollback
+
+Perform a rollback with the command obtained from the [pre-refresh check](pre-refresh check) that was performed before initiating the refresh process.
+
+<!--TODO: example-->
+
+## Resume rollback
+
+If the [`pause_after_unit_refresh`](https://charmhub.io/postgresql/configurations?channel=16/edge#pause_after_unit_refresh) config option on your PostgreSQL application is set to `first` (default) or `all`, you'll need to monitor and manually resume the refresh when one or more units have finished refreshing individually.
+
+When the refresh pauses and all units are in an idle state, check that they are healthy. <!-- TODO: how? -->
+
+Then, to resume the rollback, run the `resume-refresh` action on the unit shown by the app status.
+
+<!-->

--- a/docs/how-to/upgrade/minor-rollback.md
+++ b/docs/how-to/upgrade/minor-rollback.md
@@ -1,0 +1,1 @@
+# Perform a minor rollback

--- a/docs/how-to/upgrade/minor-upgrade.md
+++ b/docs/how-to/upgrade/minor-upgrade.md
@@ -1,6 +1,6 @@
 # Perform a minor upgrade
 
-A minor upgrade is a {term}`refresh` from one workload version to a higher one within the same major version. E.g. PostgreSQL 14.12 --> PostgreSQL 14.15.
+A minor upgrade is a {term}`refresh` from one workload version to a higher one within the same major version (e.g. PostgreSQL 14.12 --> PostgreSQL 14.15)
 
 The refresh process boils down to:
 * Running a pre-refresh check to ensure your deployment can undergo a safe upgrade process
@@ -10,14 +10,13 @@ The refresh process boils down to:
 Once in the refresh is in progress, the UI will clearly indicate what is happening to each unit, and what actions are required from the user to continue the process or roll back in case of a problem.
 
 ```{seealso}
-* [All Charmed PostgreSQL minor versions](/reference/releases)
 * [How to perform a minor rollback](/how-to/upgrade/minor-rollback)
+* [All Charmed PostgreSQL minor versions](/reference/releases)
 * [](/how-to/back-up-and-restore/create-a-backup)
 * [Developer docs for charm-refresh](https://canonical-charm-refresh.readthedocs-hosted.com/latest/)
     * [`pause_after_unit_refresh` documentation](https://canonical-charm-refresh.readthedocs-hosted.com/latest/user-experience/config/#pause-after-unit-refresh)
 ```
 
----
 
 ## Precautions
 
@@ -38,11 +37,11 @@ Avoid operations such as (but not limited to) the following:
 * Upgrading other connected/related/integrated applications simultaneously
 ```
 
-**Integrate Charmed PostgreSQL with the [Charmed PgBouncer](https://charmhub.io/pgbouncer) operator.** 
+**Integrate with [Charmed PgBouncer](https://charmhub.io/pgbouncer).** 
 
 This will ensure minimal service disruption, if any.
 
-
+(pre-refresh-check)=
 ## Pre-refresh check
 
 The `pre-refresh-check` action will check that a refresh is possible and will switch the primary, if necessary, for a safe upgrade process. 
@@ -59,7 +58,7 @@ Do not refresh if there are errors in the output.
 Copy down the rollback command from the action output in case a rollback is needed later.
 ```
 
-## Start refresh
+## Initiate refresh
 
 The following command will refresh the charm to the latest version in the channel you originally deployed your application from, e.g. `16/stable`:
 
@@ -78,15 +77,15 @@ Units will be refreshed one by one based on role: first the `replica` units, the
 If there are any version incompatibilities in charm revisions, dependencies, or any other unexpected failure in the upgrade process, the process will halt and enter a failure state.
 
 ```{attention}
-Only trigger a rollback if the refresh has expicitly failed and cannot continue. <!--TODO: examples-->
+Only trigger a rollback if the refresh has expicitly failed and cannot continue. <!--TODO: examples + clarify if you can rollback when refresh is healthy but paused waiting for resume-refresh -->
 ```
 
-## Resume refresh 
+## Resume refresh
 
 If the [`pause_after_unit_refresh`](https://charmhub.io/postgresql/configurations?channel=16/edge#pause_after_unit_refresh) config option on your PostgreSQL application is set to `first` (default) or `all`, you'll need to monitor and manually resume the refresh when one or more units have finished refreshing individually.
 
 When the refresh pauses and all units are in an idle state, check that they are healthy. <!-- TODO: how? -->
 
-Then, run the `resume-refresh` action on the unit shown by the app status.
+Then, to resume the upgrade, run the `resume-refresh` action on the unit shown by the app status.
 
 <!--TODO: example -->

--- a/docs/how-to/upgrade/minor-upgrade.md
+++ b/docs/how-to/upgrade/minor-upgrade.md
@@ -1,0 +1,92 @@
+# Perform a minor upgrade
+
+A minor upgrade is a {term}`refresh` from one workload version to a higher one within the same major version. E.g. PostgreSQL 14.12 --> PostgreSQL 14.15.
+
+The refresh process boils down to:
+* Running a pre-refresh check to ensure your deployment can undergo a safe upgrade process
+* Running the refresh command to initiate the process
+* Monitoring and following UI instructions
+
+Once in the refresh is in progress, the UI will clearly indicate what is happening to each unit, and what actions are required from the user to continue the process or roll back in case of a problem.
+
+```{seealso}
+* [All Charmed PostgreSQL minor versions](/reference/releases)
+* [How to perform a minor rollback](/how-to/upgrade/minor-rollback)
+* [](/how-to/back-up-and-restore/create-a-backup)
+* [Developer docs for charm-refresh](https://canonical-charm-refresh.readthedocs-hosted.com/latest/)
+    * [`pause_after_unit_refresh` documentation](https://canonical-charm-refresh.readthedocs-hosted.com/latest/user-experience/config/#pause-after-unit-refresh)
+```
+
+---
+
+## Precautions
+
+Below are some strongly recommended precautions before refreshing to ensure minimal service disruption:
+
+**Make sure to have a [backup](/how-to/back-up-and-restore/create-a-backup) of your data.**
+
+**Do not perform operations that modify your cluster while refreshing.**
+
+Concurrency with other operations is not supported, and it can lead the cluster to inconsistent states.
+
+```{dropdown} Examples
+Avoid operations such as (but not limited to) the following:
+
+* Adding or removing units
+* Creating or destroying new relations
+* Changes in workload configuration
+* Upgrading other connected/related/integrated applications simultaneously
+```
+
+**Integrate Charmed PostgreSQL with the [Charmed PgBouncer](https://charmhub.io/pgbouncer) operator.** 
+
+This will ensure minimal service disruption, if any.
+
+
+## Pre-refresh check
+
+The `pre-refresh-check` action will check that a refresh is possible and will switch the primary, if necessary, for a safe upgrade process. 
+
+Run a pre-refresh check against the leader unit:
+
+```shell
+juju run postgresql/leader pre-refresh-check
+```
+
+Do not refresh if there are errors in the output.
+
+```{tip}
+Copy down the rollback command from the action output in case a rollback is needed later.
+```
+
+## Start refresh
+
+The following command will refresh the charm to the latest version in the channel you originally deployed your application from, e.g. `16/stable`:
+
+```shell
+juju refresh postgresql
+```
+
+To refresh your charm to the latest version of a specific channel or track, use the `--channel` flag. For example:
+
+```shell
+juju refresh postgresql --channel 16/edge
+```
+
+Units will be refreshed one by one based on role: first the `replica` units, then `sync-standby`, and lastly the `leader` unit. 
+
+If there are any version incompatibilities in charm revisions, dependencies, or any other unexpected failure in the upgrade process, the process will halt and enter a failure state.
+
+```{attention}
+Only trigger a rollback if the refresh has expicitly failed and cannot continue. <!--TODO: examples-->
+```
+
+## Resume refresh 
+
+If the [`pause_after_unit_refresh`](https://charmhub.io/postgresql/configurations?channel=16/edge#pause_after_unit_refresh) config option on your PostgreSQL application is set to `first` (default) or `all`, you'll need to monitor and manually resume the refresh when one or more units have finished refreshing individually.
+
+When the refresh pauses and all units are in an idle state, check that they are healthy. <!-- TODO: how? -->
+
+Then, run the `resume-refresh` action on the unit shown by the app status.
+
+<!--TODO: example -->

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -1,0 +1,31 @@
+## Glossary
+
+Common terminology in the context of Charmed PostgreSQL.
+
+### Refresh
+
+This is a simplified summary of refresh terminology. 
+
+For a more detailed glossary, see the [charm refresh  developer documentation](https://canonical-charm-refresh.readthedocs-hosted.com/latest/glossary/). 
+
+```{glossary}
+refresh
+    `juju refresh` to a different workload and/or charm version.
+
+    Note: *rollback*, *upgrade*, and *downgrade* are specific types of refresh.
+
+upgrade
+    `juju refresh` to a higher workload and/or charm version.
+
+downgrade
+    `juju refresh` to a lower workload and/or charm version.
+
+rollback
+    `juju refresh` to the original workload and charm version while a refresh is in progress.
+
+workload
+    A software component that the charm operates. E.g. PostgreSQL.
+
+original version
+    Workload and/or charm version of all units before initiating a refresh process
+```

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -52,4 +52,5 @@ Troubleshooting <troubleshooting/index>
 Plugins/extensions <plugins-extensions>
 Alert rules <alert-rules>
 Statuses <statuses>
+Glossary <glossary>
 Contacts <contacts>


### PR DESCRIPTION
## Issue
There is no documentation about how to perform minor upgrades and rollbacks on PostgreSQL 16. 

## Solution
* Update "Upgrades" landing page with some context around refresh
* Create new "How to perform a minor upgrade" guide
* Create new "How to perform a minor rollback" guide
* Create a "Glossary" page for all docs, which for now only contains some simplified refresh terminology for users 
* Update releases page

I tried to make it easy to skim through, but still emphasizing critical points. I avoided large blocks of text in favor of referencing other documentation and resources.

It does not cover every single nuance, but my intention is to merge a first iteration of refresh documentation as soon as possible so that users have something to part from. I expect it to grow and evolve in future PRs.

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
