### PR TITLE
DPE-7968: Switch snap to rev 210 (test on GH CI)

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -35,7 +35,7 @@ POSTGRESQL_SNAP_NAME = "charmed-postgresql"
 SNAP_PACKAGES = [
     (
         POSTGRESQL_SNAP_NAME,
-        {"revision": {"aarch64": "186", "x86_64": "184"}},
+        {"revision": {"aarch64": "186", "x86_64": "210"}},
     )
 ]
 


### PR DESCRIPTION
## Issue

Charmed PostgreSQL shipped no-longer necessary python3-boto3 with dependency to python3-certifi.
The last one has list of open CVEs, e.g. CVE-2023-37920.

## Solution

Update snap without python3-boto3/python3-certifi.

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
