### PR TITLE
DPE-7968 Bump snap revision (remove python3-boto3 for CVE-2023-37920)

### DIFF
--- a/refresh_versions.toml
+++ b/refresh_versions.toml
@@ -6,6 +6,6 @@ name = "charmed-postgresql"
 
 [snap.revisions]
 # amd64
-x86_64 = "205"
+x86_64 = "218"
 # arm64
-aarch64 = "206"
+aarch64 = "219"


### PR DESCRIPTION
## Issue

Charmed PostgreSQL shipped no-longer necessary python3-boto3 with dependency to python3-certifi.
The last one has list of open CVEs, e.g. https://github.com/advisories/GHSA-xqr8-7jwr-rhp7.

## Solution

Update snap without python3-boto3/python3-certifi.

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
