### PR TITLE
Update Charmhub home page (16) 

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -3,11 +3,11 @@
 
 name: postgresql
 display-name: Charmed PostgreSQL VM
-summary: Charmed PostgreSQL 16 for machines
+summary: Charmed PostgreSQL 16 for VMs
 description: |
    PostgreSQL is an open-source relational database management system
    built to handle a wide range of workloads. This charmed operator deploys 
-   and operates PostgreSQL on virtual machines.
+   and operates PostgreSQL on virtual machines and bare metal.
 
    For deployment on Kubernetes, see [Charmed PostgreSQL K8s](https://charmhub.io/postgresql-k8s).
 


### PR DESCRIPTION
This PR updates the `metadata.yaml` for PostgreSQL 16 releases on Charmhub in order to version the home page with the docs.

It addresses issue https://github.com/canonical/postgresql-operator/issues/1082

## Changes
* Replaced `docs:` link with new RTD docs - this [new Charmhub feature](https://github.com/canonical/charmhub.io/pull/2159) will create a dedicated button in the sidebar.
* Updated `summary:` and `description:` keys, since they will be the new title and content of the Charmhub home page.
* Removed old broken link to `chat.charmhub.io`

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
