### PR TITLE
[DPE-8062] Enable microceph test for arm64

### DIFF
--- a/tests/integration/test_backups_ceph.py
+++ b/tests/integration/test_backups_ceph.py
@@ -14,7 +14,6 @@ import botocore.exceptions
 import pytest
 from pytest_operator.plugin import OpsTest
 
-from . import markers
 from .helpers import (
     backup_operations,
 )
@@ -184,7 +183,6 @@ def cloud_configs(microceph: ConnectionInformation):
     }
 
 
-@markers.amd64_only
 async def test_backup_ceph(ops_test: OpsTest, cloud_configs, cloud_credentials, charm) -> None:
     """Build and deploy two units of PostgreSQL in microceph, test backup and restore actions."""
     await backup_operations(

--- a/tests/integration/test_backups_ceph.py
+++ b/tests/integration/test_backups_ceph.py
@@ -105,7 +105,9 @@ def microceph():
     )
 
     logger.info("Setting up microceph")
-    subprocess.run(["sudo", "snap", "install", "microceph", "--channel", "squid/stable"], check=True)
+    subprocess.run(
+        ["sudo", "snap", "install", "microceph", "--channel", "squid/stable"], check=True
+    )
     subprocess.run(["sudo", "microceph", "cluster", "bootstrap"], check=True)
     subprocess.run(["sudo", "microceph", "disk", "add", "loop,1G,3"], check=True)
     subprocess.run(

--- a/tests/integration/test_backups_ceph.py
+++ b/tests/integration/test_backups_ceph.py
@@ -105,7 +105,7 @@ def microceph():
     )
 
     logger.info("Setting up microceph")
-    subprocess.run(["sudo", "snap", "install", "microceph", "--revision", "1169"], check=True)
+    subprocess.run(["sudo", "snap", "install", "microceph", "--channel", "squid/stable"], check=True)
     subprocess.run(["sudo", "microceph", "cluster", "bootstrap"], check=True)
     subprocess.run(["sudo", "microceph", "disk", "add", "loop,1G,3"], check=True)
     subprocess.run(

--- a/tests/spread/test_backups_ceph.py/task.yaml
+++ b/tests/spread/test_backups_ceph.py/task.yaml
@@ -5,5 +5,3 @@ execute: |
   tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
-systems:
-  - -ubuntu-24.04-arm


### PR DESCRIPTION
## Issue
The test that checks the backup on microceph runs only for AMD64.

## Solution
Change the pinned revision to a channel and enable the test for ARM64.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
