### PR TITLE
[MISC] Don't block if the snap cannot be installed

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -1337,11 +1337,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         self.set_unit_status(MaintenanceStatus("installing PostgreSQL"))
 
         # Install the charmed PostgreSQL snap.
-        try:
-            self._install_snap_package(revision=None)
-        except snap.SnapError:
-            self.set_unit_status(BlockedStatus("failed to install snap packages"))
-            return
+        self._install_snap_package(revision=None)
 
         cache = snap.SnapCache()
         postgres_snap = cache[charm_refresh.snap_name()]

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -119,22 +119,6 @@ def test_on_install(harness):
         assert isinstance(harness.model.unit.status, WaitingStatus)
 
 
-def test_on_install_snap_failure(harness):
-    with (
-        patch("charm.PostgresqlOperatorCharm._install_snap_package") as _install_snap_package,
-        patch(
-            "charm.PostgresqlOperatorCharm._is_storage_attached", return_value=True
-        ) as _is_storage_attached,
-    ):
-        # Mock the result of the call.
-        _install_snap_package.side_effect = snap.SnapError
-        # Trigger the hook.
-        harness.charm.on.install.emit()
-        # Assert that the needed calls were made.
-        _install_snap_package.assert_called_once()
-        assert isinstance(harness.model.unit.status, BlockedStatus)
-
-
 def test_patroni_scrape_config(harness):
     result = harness.charm.patroni_scrape_config()
 


### PR DESCRIPTION
## Issue
If the snap fails to install the charm will attempt to block, but subsequent hooks will error out and there should be no way to automatically recover

## Solution
Don't handle the snap installation error so that the install hook can fail and can be retried with `juju resolve`

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
