### PR TITLE
[MISC] Don't block if the snap cannot be installed

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -1070,11 +1070,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         self.unit.status = MaintenanceStatus("installing PostgreSQL")
 
         # Install the charmed PostgreSQL snap.
-        try:
-            self._install_snap_packages(packages=SNAP_PACKAGES)
-        except snap.SnapError:
-            self.unit.status = BlockedStatus("failed to install snap packages")
-            return
+        self._install_snap_packages(packages=SNAP_PACKAGES)
 
         cache = snap.SnapCache()
         postgres_snap = cache[POSTGRESQL_SNAP_NAME]

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -134,22 +134,6 @@ def test_on_install_failed_to_create_home(harness):
         assert isinstance(harness.model.unit.status, WaitingStatus)
 
 
-def test_on_install_snap_failure(harness):
-    with (
-        patch("charm.PostgresqlOperatorCharm._install_snap_packages") as _install_snap_packages,
-        patch(
-            "charm.PostgresqlOperatorCharm._is_storage_attached", return_value=True
-        ) as _is_storage_attached,
-    ):
-        # Mock the result of the call.
-        _install_snap_packages.side_effect = snap.SnapError
-        # Trigger the hook.
-        harness.charm.on.install.emit()
-        # Assert that the needed calls were made.
-        _install_snap_packages.assert_called_once()
-        assert isinstance(harness.model.unit.status, BlockedStatus)
-
-
 def test_patroni_scrape_config_no_tls(harness):
     result = harness.charm.patroni_scrape_config()
 


### PR DESCRIPTION
Port of https://github.com/canonical/postgresql-operator/pull/1135 to 14/edge

## Issue
If the snap fails to install the charm will attempt to block, but subsequent hooks will error out and there should be no way to automatically recover

## Solution
Don't handle the snap installation error so that the install hook can fail and can be retried with `juju resolve`

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.