### PR TITLE
[DPE-7584] Fix temp tablespace permissions

### DIFF
--- a/lib/charms/postgresql_k8s/v1/postgresql.py
+++ b/lib/charms/postgresql_k8s/v1/postgresql.py
@@ -1060,6 +1060,7 @@ class PostgreSQL:
             cursor = connection.cursor()
 
             if temp_location is not None:
+                # Fix permissions on the temporary tablespace location when a reboot happens and tmpfs is being used.
                 user = pwd.getpwnam("_daemon_")
                 os.chown(temp_location, uid=user.pw_uid, gid=user.pw_gid)
                 os.chmod(temp_location, 0o700)


### PR DESCRIPTION
## Issue
When using `tmpfs` for the `temp` storage, if we reboot the host machine, and later, after the charm starts again, it's not possible to create temporary objects, like temporary tables.

The reason is that after the reboot, the storage is mounted with wrong ownership and permissions (owned by `root` instead of `_daemon_` and with permissions set to `755` instead of `700`).

## Solution
Fix the permissions when the charm starts again.

I'll create a follow-up PR in the single kernel library repo to port those changes.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
