### PR TITLE
[MISC] Add back raft encryption check on upgrade

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -267,6 +267,11 @@ def test_is_replication_healthy(peers_ips, patroni):
         ]
         assert not patroni.is_replication_healthy()
 
+        # Test ignoring errors in case of raft encryption.
+        _get.side_effect = None
+        _get.return_value.status_code = 503
+        assert patroni.is_replication_healthy(True)
+
 
 def test_is_member_isolated(peers_ips, patroni):
     with (


### PR DESCRIPTION
Add back check for RAFT encryption when upgrading to prevent the upgrade getting stuck due to 503 errors from the Patroni API.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
