### PR TITLE
DPE-8296 Bump PostgreSQL to 14.19

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -35,7 +35,7 @@ POSTGRESQL_SNAP_NAME = "charmed-postgresql"
 SNAP_PACKAGES = [
     (
         POSTGRESQL_SNAP_NAME,
-        {"revision": {"aarch64": "221", "x86_64": "220"}},
+        {"revision": {"aarch64": "230", "x86_64": "229"}},
     )
 ]
 


### PR DESCRIPTION
## Issue

The charm ships non-latest PostgreSQL 14.18.

## Solution

Bump PostgreSQL to 14.19.

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
