### PR TITLE
DPE-8299 Bump disk cleanup timeout 1=>10

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -84,10 +84,10 @@ jobs:
     needs:
       - collect-integration-tests
     runs-on: ${{ matrix.job.runner }}
-    timeout-minutes: 217  # Sum of steps `timeout-minutes` + 5
+    timeout-minutes: 226  # Sum of steps `timeout-minutes` + 5
     steps:
       - name: Free up disk space
-        timeout-minutes: 1
+        timeout-minutes: 10
         run: |
           printf '\nDisk usage before cleanup\n'
           df --human-readable


### PR DESCRIPTION
## Issue

GH CI often fails due to timeout on the disk cleanup.
Bump 1->3 didn't help.

## Solution

Bumping to 10 mins and reporting to GH as the issue.