### PR TITLE
DPE-8296 Bump PostgreSQL to 16.10

### DIFF
--- a/refresh_versions.toml
+++ b/refresh_versions.toml
@@ -1,11 +1,11 @@
 charm_major = 1
-workload = "16.9"
+workload = "16.10"
 
 [snap]
 name = "charmed-postgresql"
 
 [snap.revisions]
 # amd64
-x86_64 = "218"
+x86_64 = "232"
 # arm64
-aarch64 = "219"
+aarch64 = "231"

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -139,7 +139,7 @@ def test_get_patroni_health(peers_ips, patroni):
 
 
 def test_get_postgresql_version(peers_ips, patroni):
-    assert patroni.get_postgresql_version() == "16.9"
+    assert patroni.get_postgresql_version() == "16.10"
 
 
 def test_dict_to_hba_string(harness, patroni):


### PR DESCRIPTION
## Issue

The charm ships non-latest PostgreSQL 16.9.

## Solution

Bump PostgreSQL to 16.10.

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
