### PR TITLE
DPE-8470 Bump snap for Patroni to 3.3.8

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -35,7 +35,7 @@ POSTGRESQL_SNAP_NAME = "charmed-postgresql"
 SNAP_PACKAGES = [
     (
         POSTGRESQL_SNAP_NAME,
-        {"revision": {"aarch64": "230", "x86_64": "229"}},
+        {"revision": {"aarch64": "237", "x86_64": "238"}},
     )
 ]
 


### PR DESCRIPTION
## Issue

PostgreSQL cluster is not solid with flickering IO environment.
See https://warthogs.atlassian.net/browse/DPE-8470

## Solution
Updating snap to deliver the latest Patroni 3.3.8 and enabling strict mode (followup commits).

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
