### PR TITLE
DPE-8470 Bump patroni from 3.2.2 to 3.3.8

### DIFF
--- a/refresh_versions.toml
+++ b/refresh_versions.toml
@@ -6,6 +6,6 @@ name = "charmed-postgresql"
 
 [snap.revisions]
 # amd64
-x86_64 = "232"
+x86_64 = "239"
 # arm64
-aarch64 = "231"
+aarch64 = "240"


### PR DESCRIPTION
## Issue

PostgreSQL cluster is not solid with flickering IO environment.
See https://warthogs.atlassian.net/browse/DPE-8470

## Solution
Updating snap to deliver the latest Patroni 3.3.8 and enabling strict mode (followup commits).

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
