### PR TITLE
[DPE-8395] Remove secret's old revision

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -2761,3 +2761,15 @@ def test_relations_user_databases_map(harness):
             "replication": "all",
             "rewind": "all",
         }
+
+
+def test_on_secret_remove(harness):
+    event = Mock()
+    harness.charm._on_secret_remove(event)
+    event.remove_revision.assert_called_once_with()
+    event.reset_mock()
+
+    # No secret
+    event.secret.label = None
+    harness.charm._on_secret_remove(event)
+    assert not event.remove_revision.called


### PR DESCRIPTION
## Issue
The charm does not remove the old revisions of a secret after updating it.

## Solution
Port of https://github.com/canonical/postgresql-operator/pull/1195.

Implement the `secret-remove` event handler.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
