### PR TITLE
Revert "DPE-8395 Remove old revision of Juju Secret (#1195)"

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -46,7 +46,6 @@ from ops.charm import (
     InstallEvent,
     LeaderElectedEvent,
     RelationDepartedEvent,
-    SecretRemoveEvent,
     StartEvent,
 )
 from ops.framework import EventBase
@@ -202,7 +201,6 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         self.framework.observe(self.on.set_password_action, self._on_set_password)
         self.framework.observe(self.on.promote_to_primary_action, self._on_promote_to_primary)
         self.framework.observe(self.on.update_status, self._on_update_status)
-        self.framework.observe(self.on.secret_remove, self._on_secret_remove)
         self.cluster_name = self.app.name
         self._member_name = self.unit.name.replace("/", "-")
 
@@ -436,17 +434,6 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         # For now, as there is no DNS hostnames on VMs, and it would also depend on
         # the underlying provider (LXD, MAAS, etc.), the unit IP is returned.
         return self._unit_ip
-
-    def _on_secret_remove(self, event: SecretRemoveEvent) -> None:
-        # A secret removal (entire removal, not just a revision removal) causes
-        # https://github.com/juju/juju/issues/20794. This check is to avoid the
-        # errors that would happen if we tried to remove the revision in that case
-        # (in the revision removal, the label is present).
-        if event.secret.label is None:
-            logger.debug("Secret with no label cannot be removed")
-            return
-        logger.debug(f"Removing secret with label {event.secret.label} revision {event.revision}")
-        event.remove_revision()
 
     def _on_get_primary(self, event: ActionEvent) -> None:
         """Get primary instance."""


### PR DESCRIPTION
This reverts commit 27c5225f2f2e70616abe5d005603d502500f5da6 to avoid issues until we can properly test the charm on Juju 3.6.11.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
