### PR TITLE
[DPE-8556] Defer peer relation changed event while upgrading

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -651,6 +651,11 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             event.defer()
             return False
 
+        if not self.upgrade.idle:
+            logger.debug("Defer on_peer_relation_changed: upgrade in progress")
+            event.defer()
+            return False
+
         # Check whether raft is stuck.
         if self.has_raft_keys():
             self._raft_reinitialisation()


### PR DESCRIPTION
## Issue
While upgrading from old revisions of the charm that don't contain the pgAudit plugin, the charm updates its config to consider that plugin in the list of those that should be preloaded, making the workload fail on not finding the plugin before the snap is refreshed.

## Solution
Defer the peer relation changed event when the upgrade is in progress. That event's handler is being called while the upgrade is in progress and updates the config before the snap can be refreshed, causing the error.

As future work, we'll need to identify why that event is triggered during the upgrade.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
