### PR TITLE
Add `lxc image list` to integration tests

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -132,6 +132,11 @@ jobs:
       - timeout-minutes: 1
         if: ${{ success() || (failure() && steps.spread.outcome == 'failure') }}
         run: snap list
+      - name: lxc image list
+        timeout-minutes: 1
+        if: ${{ success() || (failure() && steps.spread.outcome == 'failure') }}
+        # sudo needed since spread runs scripts as root
+        run: sudo lxc image list
       - name: Select model
         timeout-minutes: 1
         # `!contains(matrix.job.spread_job, 'juju29')` workaround for juju 2 error:


### PR DESCRIPTION
Make it easier to track changes to LXC images downloaded by Juju to help troubleshoot issues such as https://chat.canonical.com/canonical/pl/spbm6i4hwprrbqb13e9tfuuuyc
