### PR TITLE
[DPE-8426] Fix refresh tests

### DIFF
--- a/tests/integration/high_availability/test_async_replication_upgrade.py
+++ b/tests/integration/high_availability/test_async_replication_upgrade.py
@@ -252,7 +252,7 @@ def run_upgrade_from_edge(juju: Juju, app_name: str, charm: str) -> None:
                 wait=5 * MINUTE_SECS,
             )
 
-            juju.wait(jubilant.all_agents_idle, timeout=5 * MINUTE_SECS)
+        juju.wait(jubilant.all_agents_idle, timeout=5 * MINUTE_SECS)
 
         logging.info("Run resume-refresh action")
         juju.run(unit=unit_names[1], action="resume-refresh", wait=5 * MINUTE_SECS)

--- a/tests/integration/high_availability/test_upgrade.py
+++ b/tests/integration/high_availability/test_upgrade.py
@@ -94,7 +94,7 @@ def test_upgrade_from_edge(juju: Juju, charm: str, continuous_writes) -> None:
                 wait=5 * MINUTE_SECS,
             )
 
-            juju.wait(jubilant.all_agents_idle, timeout=5 * MINUTE_SECS)
+        juju.wait(jubilant.all_agents_idle, timeout=5 * MINUTE_SECS)
 
         logging.info("Run resume-refresh action")
         juju.run(unit=unit_names[1], action="resume-refresh", wait=5 * MINUTE_SECS)

--- a/tests/integration/high_availability/test_upgrade_from_stable.py
+++ b/tests/integration/high_availability/test_upgrade_from_stable.py
@@ -89,10 +89,10 @@ def test_upgrade_from_stable(juju: Juju, charm: str, continuous_writes) -> None:
                 wait=5 * MINUTE_SECS,
             )
 
-            juju.wait(jubilant.all_agents_idle, timeout=5 * MINUTE_SECS)
+        juju.wait(jubilant.all_agents_idle, timeout=5 * MINUTE_SECS)
 
         logging.info("Run resume-refresh action")
-        juju.run(unit=unit_names[-1], action="resume-refresh", wait=5 * MINUTE_SECS)
+        juju.run(unit=unit_names[1], action="resume-refresh", wait=5 * MINUTE_SECS)
     except TimeoutError:
         logging.info("Upgrade completed without snap refresh (charm.py upgrade only)")
         assert juju.status().apps[DB_APP_NAME].is_active

--- a/tests/integration/high_availability/test_upgrade_skip_pre_upgrade_check.py
+++ b/tests/integration/high_availability/test_upgrade_skip_pre_upgrade_check.py
@@ -75,7 +75,7 @@ def test_refresh_without_pre_refresh_check(juju: Juju, charm: str, continuous_wr
                 wait=5 * MINUTE_SECS,
             )
 
-            juju.wait(jubilant.all_agents_idle, timeout=5 * MINUTE_SECS)
+        juju.wait(jubilant.all_agents_idle, timeout=5 * MINUTE_SECS)
 
         logging.info("Run resume-refresh action")
         juju.run(unit=unit_names[1], action="resume-refresh", wait=5 * MINUTE_SECS)
@@ -123,7 +123,7 @@ async def test_rollback_without_pre_refresh_check(
                 wait=5 * MINUTE_SECS,
             )
 
-            juju.wait(jubilant.all_agents_idle, timeout=5 * MINUTE_SECS)
+        juju.wait(jubilant.all_agents_idle, timeout=5 * MINUTE_SECS)
 
         logging.info("Run resume-refresh action")
         juju.run(unit=unit_names[1], action="resume-refresh", wait=5 * MINUTE_SECS)


### PR DESCRIPTION
Wait for idleness in all blocked cases. Seems to be a problem on 16/edge publish: https://github.com/canonical/postgresql-operator/actions/runs/18670358815/job/53266326487#step:10:16

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
