### PR TITLE
[DPE-8573] Cache _patroni property

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -905,7 +905,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         ]
         return set(hosts)
 
-    @property
+    @cached_property
     def _patroni(self) -> Patroni:
         """Returns an instance of the Patroni object."""
         return Patroni(


### PR DESCRIPTION
Related to https://github.com/canonical/postgresql-operator/issues/1231

Cache the `_patroni` property to reduce the amount of controller checks.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
