### PR TITLE
docs: Remove unclear blocked state (14)

### DIFF
--- a/docs/reference/statuses.md
+++ b/docs/reference/statuses.md
@@ -1,7 +1,7 @@
 # Charm statuses
 
 ```{caution}
-This reference is a work in progress and not fit for production. [Contact us](/reference/contacts) if you are interested in the topic.
+This reference is a work in progress and may not reflect the latest statuses. [Contact us] for status troubleshooting help.
 ```
 
 The charm follows [standard Juju applications statuses](https://documentation.ubuntu.com/juju/3.6/reference/status/#application-status). Here you can find the expected end-users reaction on different statuses:
@@ -12,7 +12,6 @@ The charm follows [standard Juju applications statuses](https://documentation.ub
 | **waiting** | any | Charm is waiting for relations to be finished | No actions required |
 | **maintenance** | any | Charm is performing the internal maintenance (e.g. cluster re-configuration, upgrade, ...) | No actions required |
 | **blocked** | the S3 repository has backups from another cluster | The bucket contains foreign backup. To avoid accident DB corruption, use clean bucket. The cluster identified by Juju app name + DB UUID. | Choose/change the new S3 [bucket](https://charmhub.io/s3-integrator/configuration#bucket)/[path](https://charmhub.io/s3-integrator/configuration#path) OR clean the current one. |
-| **blocked** | failed to update cluster members on member | TODO: error/retry? | |
 | **blocked** | failed to install snap packages | There are issues with the network connection and/or the Snap Store | Check your internet connection and https://status.snapcraft.io/. Remove the application and when everything is OK, deploy the charm again |
 | **blocked** | failed to patch snap `seccomp` profile | The charm failed to patch one issue that happens when pgBackRest restores a backup (this blocked status should be removed when https://github.com/pgbackrest/pgbackrest/releases/tag/release%2F2.46 is added to the snap) | Remove the unit and add it back again |
 | **blocked** | failed to set up postgresql_exporter options | The charm failed to set up the metrics exporter | Remove the unit and add it back again |
@@ -20,7 +19,9 @@ The charm follows [standard Juju applications statuses](https://documentation.ub
 | **blocked** | Failed to create postgres user | The charm couldn't create the default `postgres` database user due to connection problems | Connect to the database using the `operator` user and the password from the `get-password` action, then run `CREATE ROLE postgres WITH LOGIN SUPERUSER;` |
 | **blocked** | Failed to restore backup | The database couldn't start after the restore | The charm needs fix in the code to recover from this status and enable a new restore to be requested |
 | **blocked** | Please choose one endpoint to use. No need to relate all of them simultaneously! | [The modern and legacy interfaces](/explanation/charm-versions/index) should not be used simultaneously. | Remove modern or legacy relation. Choose one to use at a time. |
-| **error** | any | An unhanded internal error happened | Read the message hint. Execute `juju resolve <error_unit/0>` after addressing the root of the error state |
+| **error** | any | An unhanded internal error happened | Read the message hint. Execute `juju resolve <error_unit/0>` after addressing the root of the error state. [Contact us] for more help. |
 | **terminated** | any | The unit is gone and will be cleaned by Juju soon | No actions possible |
 | **unknown** | any | Juju doesn't know the charm app/unit status. Possible reason: K8s charm termination in progress. | Manual investigation required if status is permanent |
 
+<!-- Links -->
+[Contact us]: /reference/contacts


### PR DESCRIPTION
## Issue

An entry in `reference/statuses.md` has a TODO comment, as reported by https://github.com/canonical/postgresql-operator/issues/1213

## Solution

This `blocked` status entry was removed in favor of the more suitable `error` entry further down, which advises running `juju resolve`.

Lightly reworded the warning, and added another contact link to the `error` entry. 

This change will be ported to VM 16, K8s 14, and K8s 16 once approved.

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
