### PR TITLE
Update event security logs documentation regarding logging charm operations

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -87,6 +87,7 @@ Nextcloud
 otf
 Parca
 Parca's
+patroni
 Patroni
 patronictl
 performant

--- a/docs/explanation/security/index.md
+++ b/docs/explanation/security/index.md
@@ -100,6 +100,12 @@ The following information is configured to be logged:
 
 Other events, like connections and disconnections, are logged depending on the value of the charm configuration options related to them. For more information, check the configuration options with the `logging` prefix in the [configuration reference](https://charmhub.io/postgresql/configurations#logging_log_connections).
 
+Also, all operations performed by the charm as a result of user actions — such as enabling or disabling plugins, managing TLS, creating or restoring backups, and configuring replication between clusters (asynchronous or logical) — are executed through the underlying workload components (PostgreSQL, Patroni, or pgBackRest). Consequently, these operations are recorded in the respective workload log files, which are accessible in the directories below and also forwarded to COS:
+
+* /var/snap/charmed-postgresql/common/var/log/patroni
+* /var/snap/charmed-postgresql/common/var/log/pgbackrest
+* /var/snap/charmed-postgresql/common/var/log/postgresql
+
 No secrets are logged.
 
 ## Additional resources


### PR DESCRIPTION
## Issue
For the SSDLC requirements, the event security logging documentation should also inform whether the operations performed by the charm are also logged. 

## Solution
Port of https://github.com/canonical/postgresql-operator/pull/1253.

Document that the charm operations call the workload, which already logs the relevant underlying operations.

## Checklist
- [x] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
