### PR TITLE
Fix promote workflow

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -25,7 +25,7 @@ on:
 jobs:
   promote:
     name: Promote charm
-    uses: canonical/data-platform-workflows/.github/workflows/_promote_charm.yaml@v35.0.2
+    uses: canonical/data-platform-workflows/.github/workflows/_promote_charms.yaml@v35.0.2
     with:
       track: '16'
       from-risk: ${{ inputs.from-risk }}


### PR DESCRIPTION
v35.0.0 renamed `_promote_charm.yaml` to `_promote_charms.yaml`: https://github.com/canonical/data-platform-workflows/pull/305
