### PR TITLE
Revert "DPE-8395 Remove old revision of Juju

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -50,7 +50,6 @@ from ops import (
     RelationEvent,
     SecretChangedEvent,
     SecretNotFoundError,
-    SecretRemoveEvent,
     StartEvent,
     Unit,
     WaitingStatus,
@@ -323,7 +322,6 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         self.framework.observe(self.on.start, self._on_start)
         self.framework.observe(self.on.promote_to_primary_action, self._on_promote_to_primary)
         self.framework.observe(self.on.update_status, self._on_update_status)
-        self.framework.observe(self.on.secret_remove, self._on_secret_remove)
         self.framework.observe(self.on.collect_unit_status, self._reconcile_refresh_status)
         self.cluster_name = self.app.name
         self._member_name = self.unit.name.replace("/", "-")
@@ -674,17 +672,6 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             return None
         else:
             return primary_endpoint
-
-    def _on_secret_remove(self, event: SecretRemoveEvent) -> None:
-        # A secret removal (entire removal, not just a revision removal) causes
-        # https://github.com/juju/juju/issues/20794. This check is to avoid the
-        # errors that would happen if we tried to remove the revision in that case
-        # (in the revision removal, the label is present).
-        if event.secret.label is None:
-            logger.debug("Secret with no label cannot be removed")
-            return
-        logger.debug(f"Removing secret with label {event.secret.label} revision {event.revision}")
-        event.remove_revision()
 
     def _on_get_primary(self, event: ActionEvent) -> None:
         """Get primary instance."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -2761,15 +2761,3 @@ def test_relations_user_databases_map(harness):
             "replication": "all",
             "rewind": "all",
         }
-
-
-def test_on_secret_remove(harness):
-    event = Mock()
-    harness.charm._on_secret_remove(event)
-    event.remove_revision.assert_called_once_with()
-    event.reset_mock()
-
-    # No secret
-    event.secret.label = None
-    harness.charm._on_secret_remove(event)
-    assert not event.remove_revision.called


### PR DESCRIPTION
Port of https://github.com/canonical/postgresql-operator/pull/1216 for 16/edge

Reverts secret revision removal until it is properly tested.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
