### PR TITLE
Fix CIDR mask for self_ip - #1232

### DIFF
--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -160,7 +160,7 @@ postgresql:
     - local all operator scram-sha-256
     - local all monitoring password
     {%- if not connectivity %}
-    - {{ 'hostssl' if enable_tls else 'host' }} all all {{ self_ip }} md5
+    - {{ 'hostssl' if enable_tls else 'host' }} all all {{ self_ip }}/32 md5
     - {{ 'hostssl' if enable_tls else 'host' }} all all 0.0.0.0/0 reject
     {%- elif enable_ldap %}
     - {{ 'hostssl' if enable_tls else 'host' }} all +identity_access 0.0.0.0/0 ldap {{ ldap_parameters }}


### PR DESCRIPTION
## Issue

https://github.com/canonical/postgresql-operator/issues/1232

When CIDR mask is missing for self-ip, `patroni` fails to start with:

```
2025-10-26 01:58:57 UTC [2315097]: user=,db=,app=,client=,line=9 LOCATION:  StreamServerPort, pqcomm.c:578
2025-10-26 01:58:57 UTC [2315097]: user=,db=,app=,client=,line=10 LOG:  00000: listening on Unix socket "/tmp/.s.PGSQL.5432"
2025-10-26 01:58:57 UTC [2315097]: user=,db=,app=,client=,line=11 LOCATION:  StreamServerPort, pqcomm.c:573
2025-10-26 01:58:57 UTC [2315097]: user=,db=,app=,client=,line=12 LOG:  F0000: invalid IP mask "md5": Name or service not known
2025-10-26 01:58:57 UTC [2315097]: user=,db=,app=,client=,line=13 CONTEXT:  line 7 of configuration file "/var/snap/charmed-postgresql/common/var/lib/postgresql/pg_hba.conf"
2025-10-26 01:58:57 UTC [2315097]: user=,db=,app=,client=,line=14 LOCATION:  parse_hba_line, hba.c:1279
2025-10-26 01:58:57 UTC [2315097]: user=,db=,app=,client=,line=15 FATAL:  XX000: could not load pg_hba.conf
2025-10-26 01:58:57 UTC [2315097]: user=,db=,app=,client=,line=16 LOCATION:  PostmasterMain, postmaster.c:1367
2025-10-26 01:58:57 UTC [2315097]: user=,db=,app=,client=,line=17 LOG:  00000: database system is shut down
2025-10-26 01:58:57 UTC [2315097]: user=,db=,app=,client=,line=18 LOCATION:  UnlinkLockFiles, miscinit.c:1017
```

Also, the mask of `/0` for replication peers is incorrect and a security concern.

## Solution

For self_ip, we want to add a missing CIDR mask, in this case, `/32` is the most exact match.

For replication peers, we want to also use `/32` for the most exact match.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
