### PR TITLE
Add comment about limitation of collect status event

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -327,6 +327,9 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         self.framework.observe(self.on.promote_to_primary_action, self._on_promote_to_primary)
         self.framework.observe(self.on.update_status, self._on_update_status)
         self.framework.observe(self.on.secret_remove, self._on_secret_remove)
+        # Do not use collect status events elsewhere—otherwise ops will prioritize statuses
+        # incorrectly
+        # https://canonical-charm-refresh.readthedocs-hosted.com/latest/add-to-charm/status/#implementation
         self.framework.observe(self.on.collect_unit_status, self._reconcile_refresh_status)
         self.cluster_name = self.app.name
         self._member_name = self.unit.name.replace("/", "-")


### PR DESCRIPTION
If multiple collect status events are used, ops will prioritize statuses incorrectly (since it assumes all blocked statuses have higher priority than all maintenance statuses, etc.)

Realized I forgot to add this in #866 while reviewing the k8s implementation (https://github.com/canonical/postgresql-k8s-operator/pull/1115#discussion_r2560113367)
