### PR TITLE
Fix CIDR mask for replication peer_ip - #1299

### DIFF
--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -180,7 +180,7 @@ postgresql:
     - {{ 'hostssl' if enable_tls else 'host' }} replication replication {{ endpoint }}/32 md5
     {%- endfor %}
     {%- for peer_ip in peers_ips %}
-    - {{ 'hostssl' if enable_tls else 'host' }}     replication    replication    {{ peer_ip }}/0    md5
+    - {{ 'hostssl' if enable_tls else 'host' }}     replication    replication    {{ peer_ip }}/32    md5
     {% endfor %}
   pg_ident:
   - operator snap_daemon backup


### PR DESCRIPTION
## Issue

The `replication` users' `peer_ip` CIDR mask is too open. A `/0` usually means `ALL`.

See https://github.com/canonical/postgresql-operator/issues/1299

## Solution

Reduce CIDR mask to a single IP, with `/32` which is safest. If not, we can go with something a little more relaxed such as a `/24`.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
