### PR TITLE
DPE-8980 Support Juju 4: use 'ip' instead of 'private-address' (if available)

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -1898,7 +1898,8 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
                 alternative_endpoints=other_cluster_endpoints
             )
             other_cluster_primary_ip = next(
-                replication_offer_relation.data[unit].get("private-address")
+                replication_offer_relation.data[unit].get("ip")
+                or replication_offer_relation.data[unit].get("private-address")
                 for unit in replication_offer_relation.units
                 if unit.name.replace("/", "-") == other_cluster_primary
             )

--- a/src/relations/tls.py
+++ b/src/relations/tls.py
@@ -67,7 +67,9 @@ class TLS(Object):
             peer_addrs.add(addr)
         if addr := self.charm.unit_peer_data.get("replication-offer-address"):
             peer_addrs.add(addr)
-        if addr := self.charm.unit_peer_data.get("private-address"):
+        if addr := self.charm.unit_peer_data.get("ip") or self.charm.unit_peer_data.get(
+            "private-address"
+        ):
             peer_addrs.add(addr)
         return peer_addrs
 

--- a/src/relations/tls.py
+++ b/src/relations/tls.py
@@ -67,8 +67,8 @@ class TLS(Object):
             peer_addrs.add(addr)
         if addr := self.charm.unit_peer_data.get("replication-offer-address"):
             peer_addrs.add(addr)
-        if addr := self.charm.unit_peer_data.get("ip") or self.charm.unit_peer_data.get(
-            "private-address"
+        if addr := self.charm.unit_peer_data.get(
+            "ip", self.charm.unit_peer_data.get("private-address")
         ):
             peer_addrs.add(addr)
         return peer_addrs


### PR DESCRIPTION
## Issue

No Juju 4 support by the charm.

## Solution

The Juju 4 has removed support databag fiesl `private-address`, `ingress-address` and more. The field we should use is `ip` now. The PG16 charm still have to support Juju 3.6 LTS, so adding support of the ip field with backward compatibility.

We are not going to allow Juju 4 deployments (assume in metadata.yaml), 
however users can use the following command to test Juju 4:
> juju deploy postgresql --channel 16/edge --force