### PR TITLE
[DPE-8987] Juju Terraform Provider 1.0.0

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,6 +1,5 @@
 resource "juju_application" "machine_postgresql" {
-  name  = var.app_name
-  model = var.juju_model_name
+  name = var.app_name
 
   charm {
     name     = var.charm_name
@@ -14,6 +13,7 @@ resource "juju_application" "machine_postgresql" {
   config             = var.config
   constraints        = var.constraints
   storage_directives = var.storage
+  model_uuid         = var.juju_model
 
   dynamic "expose" {
     for_each = var.enable_expose ? [1] : []

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,5 +1,5 @@
-variable "juju_model_name" {
-  description = "Juju model name"
+variable "juju_model" {
+  description = "Juju model uuid"
   type        = string
   default     = null
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.14.0"
+      version = "~> 1.0.0"
     }
   }
 }


### PR DESCRIPTION
## Issue
We're not using Juju Terraform Provider 1.0.0.

## Solution
Port of https://github.com/canonical/postgresql-k8s-operator/pull/1157.

Update to 1.0.0 and change the model name to model uuid (a change in 1.0.0)

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
