### PR TITLE
DPE-9018 Bump PostgreSQL 14.20

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -36,7 +36,7 @@ POSTGRESQL_SNAP_NAME = "charmed-postgresql"
 SNAP_PACKAGES = [
     (
         POSTGRESQL_SNAP_NAME,
-        {"revision": {"aarch64": "237", "x86_64": "238"}},
+        {"revision": {"aarch64": "243", "x86_64": "245"}},
     )
 ]
 

--- a/src/dependency.json
+++ b/src/dependency.json
@@ -9,6 +9,6 @@
     "dependencies": {},
     "name": "charmed-postgresql",
     "upgrade_supported": "^14",
-    "version": "14.12"
+    "version": "14.20"
   }
 }


### PR DESCRIPTION
## Issue

Charm ships outdated PostgreSQL 14.19

## Solution

Update PostgreSQL to 14.20
