### PR TITLE
DPE-9050 Temporary pin Juju to 3.6.11

### DIFF
--- a/concierge.yaml
+++ b/concierge.yaml
@@ -1,6 +1,8 @@
 juju:
   model-defaults:
     logging-config: <root>=INFO; unit=DEBUG
+  # TODO: Remove once fixed https://github.com/juju/juju/issues/21409
+  agent-version: 3.6.11
 providers:
   lxd:
     enable: true


### PR DESCRIPTION
## Issue

Juju 3.6.12 has an issue https://github.com/juju/juju/issues/21409 which effects testing a lot.

## Solution

Temporary use Juju 3.6.11