### PR TITLE
[DPE-9070] Handle pgBackRest archive timeout in check_stanza

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -26,6 +26,10 @@ PATRONI_SERVICE_DEFAULT_PATH = f"/etc/systemd/system/{PATRONI_SERVICE_NAME}"
 
 # Snap constants.
 PGBACKREST_EXECUTABLE = "charmed-postgresql.pgbackrest"
+# pgBackRest error codes
+PGBACKREST_ARCHIVE_TIMEOUT_ERROR_CODE = (
+    82  # Archive timeout - unable to archive WAL files within configured timeout period
+)
 
 SNAP_COMMON_PATH = "/var/snap/charmed-postgresql/common"
 SNAP_CURRENT_PATH = "/var/snap/charmed-postgresql/current"

--- a/tests/unit/test_backups.py
+++ b/tests/unit/test_backups.py
@@ -860,6 +860,14 @@ def test_check_stanza(harness):
             FAILED_TO_INITIALIZE_STANZA_ERROR_MESSAGE
         )
 
+        # Test when the failure in the stanza check is due to an archive timeout.
+        _execute_command.reset_mock()
+        _s3_initialization_set_failure.reset_mock()
+        _execute_command.return_value = (82, "", "fake stderr")
+        with pytest.raises(TimeoutError):
+            harness.charm.backup.check_stanza()
+        _s3_initialization_set_failure.assert_not_called()
+
         _execute_command.reset_mock()
         _s3_initialization_set_failure.reset_mock()
         _execute_command.return_value = (0, "fake stdout", "")


### PR DESCRIPTION
## Issue
The archive timeout error handling (error code 82) from PR #1328 to allow users to fix network issues and retry with `juju resolve` was not added to PG 16.

## Solution
When archive operations timeout, the charm enters error state instead of blocked state, enabling recovery via juju resolve. Fixes #1346

https://github.com/canonical/postgresql-operator/pull/1320 must be merged before this PR.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
