### PR TITLE
[DPE-9001] Dynamic tls flag in the Patroni helper

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -940,7 +940,6 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             self._get_password(),
             self._replication_password,
             self.get_secret(APP_SCOPE, REWIND_PASSWORD_KEY),
-            bool(self.unit_peer_data.get("tls")),
             self.get_secret(APP_SCOPE, RAFT_PASSWORD_KEY),
             self.get_secret(APP_SCOPE, PATRONI_PASSWORD_KEY),
         )
@@ -974,6 +973,11 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
     def is_tls_enabled(self) -> bool:
         """Return whether TLS is enabled."""
         return all(self.tls.get_tls_files())
+
+    @property
+    def is_peer_data_tls_set(self) -> bool:
+        """Return whether the TLS flag is raised in the peer data."""
+        return bool(self.unit_peer_data.get("tls"))
 
     @property
     def _peer_members_ips(self) -> set[str]:

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -87,7 +87,6 @@ def patroni(harness, peers_ips):
         "fake-superuser-password",
         "fake-replication-password",
         "fake-rewind-password",
-        False,
         "fake-raft-password",
         "fake-patroni-password",
     )


### PR DESCRIPTION
Port of https://github.com/canonical/postgresql-k8s-operator/pull/1187

To keep logic consistent between k8s and VM.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
