### PR TITLE
[DPE-9150] Use socket for local connections

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -645,7 +645,8 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         return PostgreSQL(
             substrate=Substrates.VM,
             primary_host=self.primary_endpoint,
-            current_host="/tmp/snap-private-tmp/snap.charmed-postgresql/tmp/",
+            # Connecting to local Postgresql socket
+            current_host="/tmp/snap-private-tmp/snap.charmed-postgresql/tmp/",  # noqa: S108
             user=USER,
             password=str(self.get_secret(APP_SCOPE, f"{USER}-password")),
             database=DATABASE_DEFAULT_NAME,

--- a/src/charm.py
+++ b/src/charm.py
@@ -645,7 +645,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         return PostgreSQL(
             substrate=Substrates.VM,
             primary_host=self.primary_endpoint,
-            current_host=self._unit_ip,
+            current_host="/tmp/snap-private-tmp/snap.charmed-postgresql/tmp/",
             user=USER,
             password=str(self.get_secret(APP_SCOPE, f"{USER}-password")),
             database=DATABASE_DEFAULT_NAME,


### PR DESCRIPTION
Use socket connection to check DB availability to prevent a race when setting up client TLS during charm initialisation.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
