### PR TITLE
[DPE-9150] Use socket for local connections

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -399,7 +399,8 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         """Returns an instance of the object used to interact with the database."""
         return PostgreSQL(
             primary_host=self.primary_endpoint,
-            current_host=self._unit_ip,
+            # Connecting to local Postgresql socket
+            current_host="/tmp/snap-private-tmp/snap.charmed-postgresql/tmp/",  # noqa: S108
             user=USER,
             password=self.get_secret(APP_SCOPE, f"{USER}-password"),
             database=DATABASE_DEFAULT_NAME,


### PR DESCRIPTION
Port of https://github.com/canonical/postgresql-operator/pull/1363

Use socket connection to check DB availability to prevent a race when setting up client TLS during charm initialisation.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
