### PR TITLE
[DPE-9157] Patch shared buffers

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -2224,6 +2224,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         cfg_patch = {
             "max_connections": max_connections,
             "max_prepared_transactions": self.config.memory_max_prepared_transactions,
+            "shared_buffers": self.config.memory_shared_buffers,
             "wal_keep_size": self.config.durability_wal_keep_size,
         }
 


### PR DESCRIPTION
Shared buffers config was not being patched in Patroni's REST API, like other configuration needing restart.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
