### PR TITLE
[DPE-9157] Patch shared buffers

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -2572,6 +2572,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             "max_prepared_transactions": self.config.memory_max_prepared_transactions,
             "max_replication_slots": 25,
             "max_wal_senders": 25,
+            "shared_buffers": self.config.memory_shared_buffers,
             "wal_keep_size": self.config.durability_wal_keep_size,
         }
 


### PR DESCRIPTION
Backport from PG14: https://github.com/canonical/postgresql-operator/pull/1373

## Issue

The test_charm often failing with error:
```
  File "/root/spread_project/tests/integration/test_charm.py", line 227, in test_postgresql_parameters_change
    assert settings["shared_buffers"] == "32768"
AssertionError: assert '16384' == '32768'
  
  - 32768
  + 16384
```

## Solution

Add shared_buffers to PATCH list (it was missing for VM, but available for K8s).