### PR TITLE
DPE-9158 Speedup action list-backups (from minutes to seconds)

### DIFF
--- a/src/backups.py
+++ b/src/backups.py
@@ -560,6 +560,8 @@ class PostgreSQLBackups(Object):
             PGBACKREST_EXECUTABLE,
             PGBACKREST_CONFIGURATION_FILE,
             "repo-ls",
+            "archive",
+            "--recurse",
             "--output=json",
         ])
         if return_code != 0:

--- a/src/backups.py
+++ b/src/backups.py
@@ -560,7 +560,6 @@ class PostgreSQLBackups(Object):
             PGBACKREST_EXECUTABLE,
             PGBACKREST_CONFIGURATION_FILE,
             "repo-ls",
-            "--recurse",
             "--output=json",
         ])
         if return_code != 0:


### PR DESCRIPTION
## Issue

At the moment charm action `list-backups` executes minutes on S3 buckets with hundreds backups,
while some common backups have thousand of backups causing action timeout.

The often config is hold backups for 30 days with nightly full backup and incremental backup each 15 minutes.

## Solution

List S3 content recursively for `archive` part only. It will be enough to generate Timelines list.
This will skip the biggest neighbor folder `backups`, which used to eat most of the time in _list_timelines().

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
