### PR TITLE
DPE-9158 Speedup action list-backups by list archive only

### DIFF
--- a/src/backups.py
+++ b/src/backups.py
@@ -553,6 +553,7 @@ class PostgreSQLBackups(Object):
             PGBACKREST_CONFIGURATION_FILE,
             PGBACKREST_LOG_LEVEL_STDERR,
             "repo-ls",
+            "archive",
             "--recurse",
             "--output=json",
         ])


### PR DESCRIPTION
Backport https://github.com/canonical/postgresql-operator/pull/1375 to PG16.

## Issue

At the moment charm action `list-backups` executes minutes on S3 buckets with hundreds backups,
while some common backups have thousand of backups causing action timeout.

The often config is hold backups for 30 days with nightly full backup and incremental backup each 15 minutes.

## Solution

List S3 content recursively for `archive` part only. It will be enough to generate Timelines list.
This will skip the biggest neighbor folder `backups`, which used to eat most of the time in _list_timelines().

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.