### PR TITLE
Revert fbfd2e8dc: DPE-9050 Give a try for Juju to 3.6.13

### DIFF
--- a/concierge.yaml
+++ b/concierge.yaml
@@ -1,8 +1,6 @@
 juju:
   model-defaults:
     logging-config: <root>=INFO; unit=DEBUG
-  # TODO: Remove once fixed https://github.com/juju/juju/issues/21409
-  agent-version: 3.6.11
 providers:
   lxd:
     enable: true


### PR DESCRIPTION
## Issue

The Juju 3.6.12 has an issue with TCP timeouts, so 3.6.11 was pinned.

## Solution

Give a try for new Juju 3.6.13.