### PR TITLE
[MISC] Add permissions to workflows

### DIFF
--- a/.github/workflows/check_pr.yaml
+++ b/.github/workflows/check_pr.yaml
@@ -13,6 +13,7 @@ on:
       - main
       - '*/edge'
 
+permissions: {}
 jobs:
   check-pr:
     name: Check pull request

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,7 @@ jobs:
   lint:
     name: Lint
     uses: canonical/data-platform-workflows/.github/workflows/lint.yaml@v41.0.0
+    permissions: {}
 
   unit-test:
     name: Unit test charm
@@ -47,6 +48,7 @@ jobs:
         uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    permissions: {}
 
   alert-test:
     name: Test Prometheus Alert Rules
@@ -61,10 +63,12 @@ jobs:
         run: promtool check rules src/prometheus_alert_rules/*
       - name: Run unit tests for prometheus alert rules
         run: promtool test rules tests/alerts/*.yaml
+    permissions: {}
 
   build:
     name: Build charm
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v41.0.0
+    permissions: {}
 
   integration-test:
     name: Integration test charm

--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches: [main]
 
+permissions: {}
 jobs:
   cla-check:
     runs-on: ubuntu-24.04

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -14,8 +14,7 @@ jobs:
     name: Collect integration test spread jobs
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    permissions:
-      contents: write  # Needed for Allure Report
+    permissions: {}
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -14,6 +14,8 @@ jobs:
     name: Collect integration test spread jobs
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: write  # Needed for Allure Report
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -90,6 +92,7 @@ jobs:
       - collect-integration-tests
     runs-on: ${{ matrix.job.runner }}
     timeout-minutes: 216  # Sum of steps `timeout-minutes` + 5
+    permissions: {}
     steps:
       - name: Checkout
         timeout-minutes: 3
@@ -196,6 +199,8 @@ jobs:
       - integration-test
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: write  # Needed for Allure Report
     steps:
       - name: Parse branch name
         id: branch

--- a/.github/workflows/lib-check.yaml
+++ b/.github/workflows/lib-check.yaml
@@ -32,4 +32,6 @@ jobs:
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-
+    permissions:
+      # Add label to prs
+      pull-requests: write

--- a/.github/workflows/tiobe_scan.yaml
+++ b/.github/workflows/tiobe_scan.yaml
@@ -8,6 +8,7 @@ on:
     - cron: "0 2 * * 6" # Every Saturday 2:00 AM UTC
   workflow_dispatch:
 
+permissions: {}
 jobs:
   TICS:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Port of https://github.com/canonical/postgresql-operator/pull/1388

Keep workflows in sync. There's no security notices opened for the `16/edge` branch.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
