### PR TITLE
[DPE-8974] Handle certificate expiration

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -2212,6 +2212,8 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             return True
 
         if not self._patroni.member_started:
+            # Potentially expired cert reloading and deferring
+            self._patroni.reload_patroni_configuration()
             logger.debug("Early exit update_config: Patroni not started yet")
             return False
 

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -947,8 +947,8 @@ class Patroni:
     def reload_patroni_configuration(self):
         """Reload Patroni configuration after it was changed."""
         pid = None
-        module_patern = re.compile("/snap/charmed-postgresql/[0-9]+/usr/bin/patroni")
-        conf_pattern = re.compile("/var/snap/charmed-postgresql/[0-9]+/etc/patroni/patroni.yaml")
+        module_patern = re.compile("/snap/charmed-postgresql/x?[0-9]+/usr/bin/patroni")
+        conf_pattern = re.compile("/var/snap/charmed-postgresql/x?[0-9]+/etc/patroni/patroni.yaml")
         for proc in psutil.process_iter():
             cmdline = proc.cmdline()
             if (

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1233,6 +1233,7 @@ def test_update_config(harness):
             "charm.PostgresqlOperatorCharm._restart_ldap_sync_service"
         ) as _restart_ldap_sync_service,
         patch("charm.Patroni.bulk_update_parameters_controller_by_patroni"),
+        patch("charm.Patroni.reload_patroni_configuration"),
         patch("charm.Patroni.member_started", new_callable=PropertyMock) as _member_started,
         patch(
             "charm.PostgresqlOperatorCharm._is_workload_running", new_callable=PropertyMock

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -875,3 +875,16 @@ def test_reload_patroni_configuration(patroni):
         patroni.reload_patroni_configuration()
 
         assert not _kill.called
+
+        # Manually installed snap
+        patroni_proc.cmdline.return_value = [
+            "python3",
+            "/snap/charmed-postgresql/x1/usr/bin/patroni",
+            "/var/snap/charmed-postgresql/x1/etc/patroni/patroni.yaml",
+        ]
+        _process_iter.return_value = [proc1, proc2, patroni_proc]
+
+        patroni.reload_patroni_configuration()
+
+        _kill.assert_called_once_with(sentinel.patroni_pid, SIGHUP)
+        _kill.reset_mock()

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -2,6 +2,7 @@
 # See LICENSE file for licensing details.
 
 from pathlib import Path
+from signal import SIGHUP
 from unittest.mock import MagicMock, Mock, PropertyMock, mock_open, patch, sentinel
 
 import pytest
@@ -846,3 +847,31 @@ def test_are_replicas_up(patroni):
         # Return None on error
         _cluster_status.side_effect = Exception
         assert patroni.are_replicas_up() is None
+
+
+def test_reload_patroni_configuration(patroni):
+    with patch("cluster.psutil.process_iter") as _process_iter, patch("cluster.os.kill") as _kill:
+        proc1 = Mock()
+        proc2 = Mock()
+        patroni_proc = Mock()
+        proc1.cmdline.return_value = ["python3", "first", "second"]
+        proc2.cmdline.return_value = ["other"]
+        patroni_proc.cmdline.return_value = [
+            "python3",
+            "/snap/charmed-postgresql/1/usr/bin/patroni",
+            "/var/snap/charmed-postgresql/1/etc/patroni/patroni.yaml",
+        ]
+        patroni_proc.pid = sentinel.patroni_pid
+        _process_iter.return_value = [proc1, proc2, patroni_proc]
+
+        patroni.reload_patroni_configuration()
+
+        _kill.assert_called_once_with(sentinel.patroni_pid, SIGHUP)
+        _kill.reset_mock()
+
+        # No patroni process found
+        _process_iter.return_value = [proc1, proc2]
+
+        patroni.reload_patroni_configuration()
+
+        assert not _kill.called

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -124,8 +124,8 @@ def test_get_patroni_health(peers_ips, patroni):
         health = patroni.get_patroni_health()
 
         # Check needed to ensure a fast charm deployment.
-        _stop_after_delay.assert_called_once_with(60)
-        _wait_fixed.assert_called_once_with(7)
+        _stop_after_delay.assert_called_once_with(15)
+        _wait_fixed.assert_called_once_with(3)
 
         assert health == {"state": "running"}
 


### PR DESCRIPTION
## Issue
The charm doesn't handle ceritficate invalidated events

## Solution
Enable certificate invalidated hook and tweak so that the charm will recover if the certificate expires

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
