### PR TITLE
[DPE-8932] Strict mode configuration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,7 +5,8 @@ options:
   synchronous_node_count:
     description: |
       Sets the number of synchronous nodes to be maintained in the cluster. Should be
-      either "all", "majority" or a positive integer value.
+      either "all", "majority" or an integer value.
+      Setting to 0 disables strict synchronous mode.
     type: string
     default: "all"
   connection_authentication_timeout:
@@ -69,6 +70,12 @@ options:
       Default is on (true).
     type: boolean
     default: true
+  durability_maximum_lag_on_failover:
+    description: |
+      The amount of transactions that can be lost in bytes to consider failover is safe.
+      Default is 1048576.
+    type: int
+    default: 1048576
   durability_synchronous_commit:
     description: |
       Sets the current transactions synchronization level. This charm allows only the
@@ -811,6 +818,14 @@ options:
       Allowed values are: from 64 to 2147483647.
     type: int
     default: 4096
+  storage_hot_standby_feedback:
+    description: |
+      Send feedback to the primary or upstream standby about queries currently executing on
+      the standby.
+      Warning: enabling can cause database bloat on the Primary for some workloads.
+      Default is off
+    type: string
+    default: "off"
   storage_old_snapshot_threshold:
     description: |
       Time before a snapshot is too old to read pages changed after the snapshot was taken.

--- a/config.yaml
+++ b/config.yaml
@@ -5,10 +5,15 @@ options:
   synchronous_node_count:
     description: |
       Sets the number of synchronous nodes to be maintained in the cluster. Should be
-      either "all", "majority" or an integer value.
-      Setting to 0 disables strict synchronous mode.
+      either "all", "majority" or a positive integer value.
     type: string
     default: "all"
+  synchronous_mode_strict:
+    description: |
+      Enforce transactions to be committed on Primary and at least one more synchronous node.
+      Default is true.
+    type: boolean
+    default: true
   connection_authentication_timeout:
     description: |
       Sets the maximum allowed time to complete client authentication.
@@ -823,9 +828,9 @@ options:
       Send feedback to the primary or upstream standby about queries currently executing on
       the standby.
       Warning: enabling can cause database bloat on the Primary for some workloads.
-      Default is off
-    type: string
-    default: "off"
+      Default is false.
+    type: boolean
+    default: false
   storage_old_snapshot_threshold:
     description: |
       Time before a snapshot is too old to read pages changed after the snapshot was taken.

--- a/src/charm.py
+++ b/src/charm.py
@@ -1190,11 +1190,6 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             logger.error("Invalid configuration: %s", str(e))
             return
 
-        if not self.updated_synchronous_node_count():
-            logger.debug("Defer on_config_changed: unable to set synchronous node count")
-            event.defer()
-            return
-
         if self.is_blocked and "Configuration Error" in self.unit.status.message:
             self.unit.status = ActiveStatus()
 
@@ -2017,10 +2012,6 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             return str(min(8, 2 * self.cpu_count))
         elif self.config.cpu_max_worker_processes is not None:
             value = self.config.cpu_max_worker_processes
-            # Pydantic already enforces minimum of 2 via conint(ge=2)
-            # This is an extra safeguard
-            if value < 2:
-                raise ValueError(f"max_worker_processes value {value} is below minimum of 2")
             cap = 10 * self.cpu_count
             if value > cap:
                 raise ValueError(
@@ -2043,8 +2034,6 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         Raises:
             ValueError: If value is less than 2 or exceeds 10 * vCores
         """
-        if value < 2:
-            raise ValueError(f"{param_name} value {value} is below minimum of 2")
         cap = 10 * self.cpu_count
         if value > cap:
             raise ValueError(
@@ -2143,6 +2132,39 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
 
         return result
 
+    def _api_update_config(self) -> None:
+        # Use config value if set, calculate otherwise
+        max_connections = (
+            self.config.experimental_max_connections
+            if self.config.experimental_max_connections
+            else max(4 * os.cpu_count(), 100)
+        )
+
+        # Build parameters for Patroni API update (restart-required parameters)
+        cfg_patch = {
+            "max_connections": max_connections,
+            "max_prepared_transactions": self.config.memory_max_prepared_transactions,
+            "shared_buffers": self.config.memory_shared_buffers,
+            "wal_keep_size": self.config.durability_wal_keep_size,
+        }
+
+        # Add restart-required worker process parameters via Patroni API
+        worker_configs = self._calculate_worker_process_config()
+        if "max_worker_processes" in worker_configs:
+            cfg_patch["max_worker_processes"] = worker_configs["max_worker_processes"]
+        if "max_logical_replication_workers" in worker_configs:
+            cfg_patch["max_logical_replication_workers"] = worker_configs[
+                "max_logical_replication_workers"
+            ]
+
+        base_patch = {
+            **self._patroni.synchronous_configuration,
+            "maximum_lag_on_failover": self.config.durability_maximum_lag_on_failover,
+        }
+        if primary_endpoint := self.async_replication.get_primary_cluster_endpoint():
+            base_patch["standby_cluster"] = {"host": primary_endpoint}
+        self._patroni.bulk_update_parameters_controller_by_patroni(cfg_patch, base_patch)
+
     def _build_postgresql_parameters(self) -> dict[str, str] | None:
         """Build PostgreSQL configuration parameters.
 
@@ -2172,6 +2194,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             if pg_parameters is None:
                 pg_parameters = {}
             pg_parameters["wal_compression"] = "on" if self.config.cpu_wal_compression else "off"
+        pg_parameters.pop("maximum_lag_on_failover", None)
 
         return pg_parameters
 
@@ -2220,31 +2243,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             logger.warning("Early exit update_config: Cannot connect to Postgresql")
             return False
 
-        # Use config value if set, calculate otherwise
-        max_connections = (
-            self.config.experimental_max_connections
-            if self.config.experimental_max_connections
-            else max(4 * os.cpu_count(), 100)
-        )
-
-        # Build parameters for Patroni API update (restart-required parameters)
-        cfg_patch = {
-            "max_connections": max_connections,
-            "max_prepared_transactions": self.config.memory_max_prepared_transactions,
-            "shared_buffers": self.config.memory_shared_buffers,
-            "wal_keep_size": self.config.durability_wal_keep_size,
-        }
-
-        # Add restart-required worker process parameters via Patroni API
-        worker_configs = self._calculate_worker_process_config()
-        if "max_worker_processes" in worker_configs:
-            cfg_patch["max_worker_processes"] = worker_configs["max_worker_processes"]
-        if "max_logical_replication_workers" in worker_configs:
-            cfg_patch["max_logical_replication_workers"] = worker_configs[
-                "max_logical_replication_workers"
-            ]
-
-        self._patroni.bulk_update_parameters_controller_by_patroni(cfg_patch)
+        self._api_update_config()
 
         self._handle_postgresql_restart_need(
             self.unit_peer_data.get("config_hash") != self.generate_config_hash

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -1065,8 +1065,7 @@ class Patroni:
         return {
             "synchronous_node_count": self._synchronous_node_count,
             "synchronous_mode_strict": len(member_units) > 1
-            # Explicitly setting 0 is to disable sync mode
-            and self.charm.config.synchronous_node_count != 0
+            and self.charm.config.synchronous_mode_strict
             and self._synchronous_node_count > 0,
         }
 

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -689,6 +689,7 @@ class Patroni:
             restore_stanza=restore_stanza,
             version=self.get_postgresql_version().split(".")[0],
             synchronous_node_count=self._synchronous_node_count,
+            maximum_lag_on_failover=self.charm.config.durability_maximum_lag_on_failover,
             pg_parameters=parameters,
             primary_cluster_endpoint=self.charm.async_replication.get_primary_cluster_endpoint(),
             extra_replication_endpoints=self.charm.async_replication.get_standby_endpoints(),
@@ -1000,12 +1001,16 @@ class Patroni:
         )
 
     @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=2, max=10))
-    def bulk_update_parameters_controller_by_patroni(self, parameters: dict[str, Any]) -> None:
+    def bulk_update_parameters_controller_by_patroni(
+        self, parameters: dict[str, Any], base_parameters: dict[str, Any] | None
+    ) -> None:
         """Update the value of a parameter controller by Patroni.
 
         For more information, check https://patroni.readthedocs.io/en/latest/patroni_configuration.html#postgresql-parameters-controlled-by-patroni.
         """
-        requests.patch(
+        if not base_parameters:
+            base_parameters = {}
+        r = requests.patch(
             f"{self._patroni_url}/config",
             verify=self.verify,
             json={
@@ -1013,10 +1018,16 @@ class Patroni:
                     "remove_data_directory_on_rewind_failure": False,
                     "remove_data_directory_on_diverged_timelines": False,
                     "parameters": parameters,
-                }
+                },
+                **base_parameters,
             },
             auth=self._patroni_auth,
             timeout=PATRONI_TIMEOUT,
+        )
+        logger.debug(
+            "API bulk_update_parameters_controller_by_patroni: %s (%s)",
+            r,
+            r.elapsed.total_seconds(),
         )
 
     @cached_property
@@ -1033,19 +1044,26 @@ class Patroni:
             else planned_units - 1
         )
 
-    def update_synchronous_node_count(self) -> None:
-        """Update synchronous_node_count to the minority of the planned cluster."""
+    @cached_property
+    def synchronous_configuration(self) -> dict[str, Any]:
+        """Synchronous mode configuration."""
         # Try to update synchronous_node_count.
         member_units = json.loads(self.charm.app_peer_data.get("members_ips", "[]"))
+        return {
+            "synchronous_node_count": self._synchronous_node_count,
+            "synchronous_mode_strict": len(member_units) > 1
+            # Explicitly setting 0 is to disable sync mode
+            and self.charm.config.synchronous_node_count != 0
+            and self._synchronous_node_count > 0,
+        }
+
+    def update_synchronous_node_count(self) -> None:
+        """Update synchronous_node_count to the minority of the planned cluster."""
         for attempt in Retrying(stop=stop_after_delay(60), wait=wait_fixed(3)):
             with attempt:
                 r = requests.patch(
                     f"{self._patroni_url}/config",
-                    json={
-                        "synchronous_node_count": self._synchronous_node_count,
-                        "synchronous_mode_strict": len(member_units) > 1
-                        and self._synchronous_node_count > 0,
-                    },
+                    json=self.synchronous_configuration,
                     verify=self.verify,
                     auth=self._patroni_auth,
                     timeout=PATRONI_TIMEOUT,

--- a/src/config.py
+++ b/src/config.py
@@ -21,7 +21,8 @@ WorkerProcessInt = Annotated[int, Field(ge=2)]
 class CharmConfig(BaseConfigModel):
     """Manager for the structured configuration."""
 
-    synchronous_node_count: Literal["all", "majority"] | NonNegativeInt
+    synchronous_node_count: Literal["all", "majority"] | PositiveInt
+    synchronous_mode_strict: bool = Field(default=True)
     connection_authentication_timeout: int | None
     connection_statement_timeout: int | None
     cpu_max_logical_replication_workers: Literal["auto"] | WorkerProcessInt | None
@@ -31,7 +32,7 @@ class CharmConfig(BaseConfigModel):
     cpu_max_worker_processes: Literal["auto"] | WorkerProcessInt | None
     cpu_parallel_leader_participation: bool | None
     cpu_wal_compression: bool | None
-    durability_maximum_lag_on_failover: PositiveInt | None
+    durability_maximum_lag_on_failover: NonNegativeInt | None
     durability_synchronous_commit: str | None
     durability_wal_keep_size: int | None
     experimental_max_connections: int | None
@@ -176,7 +177,7 @@ class CharmConfig(BaseConfigModel):
     storage_bgwriter_lru_multiplier: float | None
     storage_default_table_access_method: str | None
     storage_gin_pending_list_limit: int | None
-    storage_hot_standby_feedback: Literal["on", "off"] | None
+    storage_hot_standby_feedback: bool | None
     storage_old_snapshot_threshold: int | None
     vacuum_autovacuum_analyze_scale_factor: float | None
     vacuum_autovacuum_analyze_threshold: int | None

--- a/src/config.py
+++ b/src/config.py
@@ -8,20 +8,20 @@ import logging
 from typing import Annotated, Literal
 
 from charms.data_platform_libs.v0.data_models import BaseConfigModel
-from pydantic import PositiveInt, conint, validator
+from pydantic import Field, NonNegativeInt, PositiveInt, validator
 
 from locales import SNAP_LOCALES
 
 logger = logging.getLogger(__name__)
 
 # Type for worker process parameters that must be >= 2
-WorkerProcessInt = Annotated[int, conint(ge=2)]
+WorkerProcessInt = Annotated[int, Field(ge=2)]
 
 
 class CharmConfig(BaseConfigModel):
     """Manager for the structured configuration."""
 
-    synchronous_node_count: Literal["all", "majority"] | PositiveInt
+    synchronous_node_count: Literal["all", "majority"] | NonNegativeInt
     connection_authentication_timeout: int | None
     connection_statement_timeout: int | None
     cpu_max_logical_replication_workers: Literal["auto"] | WorkerProcessInt | None
@@ -31,6 +31,7 @@ class CharmConfig(BaseConfigModel):
     cpu_max_worker_processes: Literal["auto"] | WorkerProcessInt | None
     cpu_parallel_leader_participation: bool | None
     cpu_wal_compression: bool | None
+    durability_maximum_lag_on_failover: PositiveInt | None
     durability_synchronous_commit: str | None
     durability_wal_keep_size: int | None
     experimental_max_connections: int | None
@@ -175,6 +176,7 @@ class CharmConfig(BaseConfigModel):
     storage_bgwriter_lru_multiplier: float | None
     storage_default_table_access_method: str | None
     storage_gin_pending_list_limit: int | None
+    storage_hot_standby_feedback: Literal["on", "off"] | None
     storage_old_snapshot_threshold: int | None
     vacuum_autovacuum_analyze_scale_factor: float | None
     vacuum_autovacuum_analyze_threshold: int | None

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -57,7 +57,7 @@ bootstrap:
     ttl: 30
     loop_wait: 10
     retry_timeout: 10
-    maximum_lag_on_failover: 1048576
+    maximum_lag_on_failover: {{ maximum_lag_on_failover }}
     synchronous_mode: true
     synchronous_mode_strict: false
     synchronous_node_count: {{ synchronous_node_count }}

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -75,7 +75,7 @@ async def test_config_parameters(ops_test: OpsTest, charm) -> None:
         {
             "durability_synchronous_commit": [test_string, "on"]
         },  # config option is one of `on`, `remote_apply` or `remote_write`
-        {"durability-maximum-lag-on-failover": ["-1", "1024"]},  # config option is integer
+        {"durability_maximum_lag_on_failover": ["-1", "1024"]},  # config option is integer
         {
             "instance_default_text_search_config": [test_string, "pg_catalog.simple"]
         },  # config option is validated against the db
@@ -195,7 +195,7 @@ async def test_config_parameters(ops_test: OpsTest, charm) -> None:
             "storage_gin_pending_list_limit": ["-1", "4096"]
         },  # config option is between 64 and 2147483647
         {
-            "storage-hot-standby-feedback": [test_string, "on"]
+            "storage_hot_standby_feedback": [test_string, "on"]
         },  # config option is one of on and off
         {"storage_old_snapshot_threshold": ["-2", "-1"]},  # config option is between -1 and 86400
         {

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -35,7 +35,7 @@ async def test_config_parameters(ops_test: OpsTest, charm) -> None:
     test_string = "abcXYZ123"
 
     configs = [
-        {"synchronous_node_count": ["0", "1"]},  # config option is greater than 0
+        {"synchronous_node_count": ["-1", "1"]},  # config option is greater than -1
         {
             "synchronous_node_count": [test_string, "all"]
         },  # config option is one of `all`, `minority` or `majority`
@@ -75,6 +75,7 @@ async def test_config_parameters(ops_test: OpsTest, charm) -> None:
         {
             "durability_synchronous_commit": [test_string, "on"]
         },  # config option is one of `on`, `remote_apply` or `remote_write`
+        {"durability-maximum-lag-on-failover": ["-1", "1024"]},  # config option is integer
         {
             "instance_default_text_search_config": [test_string, "pg_catalog.simple"]
         },  # config option is validated against the db
@@ -193,6 +194,9 @@ async def test_config_parameters(ops_test: OpsTest, charm) -> None:
         {
             "storage_gin_pending_list_limit": ["-1", "4096"]
         },  # config option is between 64 and 2147483647
+        {
+            "storage-hot-standby-feedback": [test_string, "on"]
+        },  # config option is one of on and off
         {"storage_old_snapshot_threshold": ["-2", "-1"]},  # config option is between -1 and 86400
         {
             "vacuum_autovacuum_analyze_scale_factor": ["-1", "0.1"]

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -35,7 +35,7 @@ async def test_config_parameters(ops_test: OpsTest, charm) -> None:
     test_string = "abcXYZ123"
 
     configs = [
-        {"synchronous_node_count": ["-1", "1"]},  # config option is greater than -1
+        {"synchronous_node_count": ["0", "1"]},  # config option is greater than 0
         {
             "synchronous_node_count": [test_string, "all"]
         },  # config option is one of `all`, `minority` or `majority`
@@ -194,9 +194,6 @@ async def test_config_parameters(ops_test: OpsTest, charm) -> None:
         {
             "storage_gin_pending_list_limit": ["-1", "4096"]
         },  # config option is between 64 and 2147483647
-        {
-            "storage_hot_standby_feedback": [test_string, "on"]
-        },  # config option is one of on and off
         {"storage_old_snapshot_threshold": ["-2", "-1"]},  # config option is between -1 and 86400
         {
             "vacuum_autovacuum_analyze_scale_factor": ["-1", "0.1"]

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -251,9 +251,6 @@ def test_on_config_changed(harness):
             "charm.PostgresqlOperatorCharm._validate_config_options"
         ) as _validate_config_options,
         patch("charm.PostgresqlOperatorCharm.update_config") as _update_config,
-        patch(
-            "charm.PostgresqlOperatorCharm.updated_synchronous_node_count", return_value=True
-        ) as _updated_synchronous_node_count,
         patch("relations.db.DbProvides.set_up_relation") as _set_up_relation,
         patch(
             "charm.PostgresqlOperatorCharm.enable_disable_extensions"
@@ -281,7 +278,6 @@ def test_on_config_changed(harness):
         harness.charm.on.config_changed.emit()
         assert not _update_config.called
         _validate_config_options.side_effect = None
-        _updated_synchronous_node_count.assert_called_once_with()
 
         # Test after the cluster was initialised.
         with harness.hooks_disabled():

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -298,7 +298,7 @@ def test_render_patroni_yml_file(peers_ips, patroni):
         patch(
             "relations.async_replication.PostgreSQLAsyncReplication.get_partner_addresses",
             return_value=["2.2.2.2", "3.3.3.3"],
-        ) as _get_partner_addresses,
+        ),
         patch("charm.Patroni.get_postgresql_version") as _get_postgresql_version,
         patch("charm.Patroni.render_file") as _render_file,
         patch("charm.Patroni._create_directory"),
@@ -335,6 +335,7 @@ def test_render_patroni_yml_file(peers_ips, patroni):
             rewind_password=rewind_password,
             version=postgresql_version,
             synchronous_node_count=0,
+            maximum_lag_on_failover=1048576,
             raft_password=raft_password,
             patroni_password=patroni_password,
         )


### PR DESCRIPTION
Port of https://github.com/canonical/postgresql-operator/pull/1389

Adds `synchronous_mode_strict`, `storage_hot_standby_feedback` and `durability_maximum_lag_on_failover` config options.

Spec is DA237.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.

