### PR TITLE
[MISC] Switch back to Noble runners for arm64

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -98,7 +98,7 @@ backends:
     systems:
       - ubuntu-24.04:
           username: runner
-      - ubuntu-22.04-arm:
+      - ubuntu-24.04-arm:
           username: runner
           variants:
             - -juju29

--- a/tests/spread/test_new_relations_2.py/task.yaml
+++ b/tests/spread/test_new_relations_2.py/task.yaml
@@ -6,4 +6,4 @@ execute: |
 artifacts:
   - allure-results
 systems:
-  - -ubuntu-22.04-arm
+  - -ubuntu-24.04-arm


### PR DESCRIPTION
Jammy containers on Noble with kernel 6.14 seem to work now.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
