### PR TITLE
DPE-8900 Fix CIDR mask for self_ip (peer_ip in pg_hba)

### DIFF
--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -180,7 +180,7 @@ postgresql:
     - {{ 'hostssl' if enable_tls else 'host' }} all +charmed_admin 0.0.0.0/0 scram-sha-256
     - {{ 'hostssl' if enable_tls else 'host' }} all +charmed_databases_owner 0.0.0.0/0 scram-sha-256
     {%- if not connectivity %}
-    - {{ 'hostssl' if enable_tls else 'host' }} all all {{ self_ip }} {{ instance_password_encryption }}
+    - {{ 'hostssl' if enable_tls else 'host' }} all all {{ self_ip }}/32 {{ instance_password_encryption }}
     - {{ 'hostssl' if enable_tls else 'host' }} all all 0.0.0.0/0 reject
     {%- elif enable_ldap %}
     - {{ 'hostssl' if enable_tls else 'host' }} all +identity_access 0.0.0.0/0 ldap {{ ldap_parameters }}


### PR DESCRIPTION
## Issue

Post PG14 fix https://github.com/canonical/postgresql-operator/pull/1272 to PG16

## Solution

Use the same fix on PG14 and PG16

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
