### PR TITLE
Add optional flags to provides endpoints for PG16 VM

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -44,6 +44,7 @@ provides:
   cos-agent:
     interface: cos_agent
     limit: 1
+    optional: true
 
 requires:
   replication:


### PR DESCRIPTION
## Issue

SolQA is experiencing troubles with automated testing due lack of optional flag for PG interfaces.

## Solution

Let's add this flag for cos-agent, as PG can work without COS.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
