### PR TITLE
Add optional flags to provides endpoints for PG14 VM

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -40,11 +40,14 @@ provides:
     interface: postgresql_client
   db:
     interface: pgsql
+    optional: true
   db-admin:
     interface: pgsql
+    optional: true
   cos-agent:
     interface: cos_agent
     limit: 1
+    optional: true
 
 requires:
   replication:


### PR DESCRIPTION
## Issue

SolQA is experiencing troubles with automated testing due lack of optional flag for PG interfaces.

## Solution

Let's add this flag for cos-agent, as PG can work without COS.
Also, we can consider to add them for legacy interface.... as PG will work (not going to blocked state) when postgresql_client interface is related only. So, legacy interfaces are optionally in fact... Thoughts?!?

## Checklist
- [X] I have added or updated any relevant documentation.
- [X] I have cleaned any remaining cloud resources from my accounts.
