### PR TITLE
[MISC] Conditional pin for pydantic1

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,6 +15,7 @@
       matchPackageNames: [
         'pydantic',
       ],
+      "matchBaseBranches": ["main"],
       allowedVersions: '<2.0.0',
     },
   ],


### PR DESCRIPTION
## Issue
Pydantic pin is applied on both `16/edge` and `main`

## Solution
Match base branch to allow for pydantic2 to update in `16/edge`

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
