### PR TITLE
[DPE-5263] chore: bump charmed-postgresql snap revisions

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -40,7 +40,7 @@ POSTGRESQL_SNAP_NAME = "charmed-postgresql"
 SNAP_PACKAGES = [
     (
         POSTGRESQL_SNAP_NAME,
-        {"revision": {"aarch64": "243", "x86_64": "245"}},
+        {"revision": {"aarch64": "246", "x86_64": "247"}},
     )
 ]
 


### PR DESCRIPTION
## Issue
When a user runs `juju ssh <postgres machine>` and uses `psql`, the command history cannot be saved:
```sh
could not save history to file "/home/ubuntu/.psql_history": Permission denied
```

## Solution
Update snap revisions to 246 (aarch64) and 247 (x86_64) to allow writes to .psql_history.

With these snap revisions, psql correctly writes history to `~/snap/charmed-postgresql/common/.psql_history`, which persists across sessions.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.

Fixes https://github.com/canonical/postgresql-operator/issues/595.