### PR TITLE
Fix linkcheck failures (14)

### DIFF
--- a/docs/reference/performance-and-resources.md
+++ b/docs/reference/performance-and-resources.md
@@ -12,7 +12,7 @@ Charmed PostgreSQL resource allocation can be controlled via the charm's `profil
 
 |Value|Description|Details|
 | --- | --- | ----- |
-|`production`<br>(default)|[Maximum performance](https://github.com/canonical/postgresql-operator/blob/main/lib/charms/postgresql_k8s/v0/postgresql.py#L437-L446)| 25% of the available memory for `shared_buffers` and the remain as cache memory (defaults mimic legacy charm behaviour).<br/>`max_connections = max(4 * os.cpu_count(), 100)`.<br/> Use [pgbouncer](https://charmhub.io/pgbouncer?channel=1/stable) if max_connections are not enough.|
+|`production`<br>(default)|[Maximum performance](https://github.com/canonical/postgresql-operator/blob/main/lib/charms/postgresql_k8s/v0/postgresql.py#L437-L446)| 25% of the available memory for `shared_buffers` and the remain as cache memory (defaults mimic legacy charm behaviour).<br/>`max_connections = max(4 * os.cpu_count(), 100)`.<br/> Use [pgbouncer](https://charmhub.io/pgbouncer?channel=1/stable) if max_connections are not enough ([reasoning](https://www.percona.com/blog/scaling-postgresql-with-pgbouncer-you-may-need-a-connection-pooler-sooner-than-you-expect/)).|
 |`testing`|[Minimal resource usage](https://github.com/canonical/postgresql-operator/blob/main/lib/charms/postgresql_k8s/v0/postgresql.py#L437-L446)|  PostgreSQL 14 defaults. |
 
 ```{caution}


### PR DESCRIPTION
## Issue
Link checker failed two Percona link checks

## Solution
One of them pointed to a page that no longer exists, so the link was removed.

The other failed page exists, but returns a `403` error, so I added `percona.com` subdomains to the exceptions list. 

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
