### PR TITLE
[DPE-9534] fix(monitoring): add _total suffix to PostgreSQL counter metrics in Grafana dashboard

### DIFF
--- a/src/grafana_dashboards/postgresql-metrics.json
+++ b/src/grafana_dashboards/postgresql-metrics.json
@@ -299,7 +299,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "SUM(pg_stat_database_tup_fetched{datname=~\"$datname\", instance=~\"$instance\"})",
+          "expr": "SUM(pg_stat_database_tup_fetched_total{datname=~\"$datname\", instance=~\"$instance\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -385,7 +385,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "SUM(pg_stat_database_tup_inserted{release=\"$release\", datname=~\"$datname\", instance=~\"$instance\"})",
+          "expr": "SUM(pg_stat_database_tup_inserted_total{release=\"$release\", datname=~\"$datname\", instance=~\"$instance\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -471,7 +471,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "SUM(pg_stat_database_tup_updated{datname=~\"$datname\", instance=~\"$instance\"})",
+          "expr": "SUM(pg_stat_database_tup_updated_total{datname=~\"$datname\", instance=~\"$instance\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -1805,14 +1805,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(pg_stat_database_xact_commit{instance=\"$instance\", datname=~\"$datname\"}[5m])",
+          "expr": "irate(pg_stat_database_xact_commit_total{instance=\"$instance\", datname=~\"$datname\"}[5m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{datname}} commits",
           "refId": "A"
         },
         {
-          "expr": "irate(pg_stat_database_xact_rollback{instance=\"$instance\", datname=~\"$datname\"}[5m])",
+          "expr": "irate(pg_stat_database_xact_rollback_total{instance=\"$instance\", datname=~\"$datname\"}[5m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{datname}} rollbacks",
@@ -1909,7 +1909,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "pg_stat_database_tup_updated{datname=~\"$datname\", instance=~\"$instance\"}",
+          "expr": "pg_stat_database_tup_updated_total{datname=~\"$datname\", instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{datname}}",
@@ -2006,7 +2006,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(pg_stat_database_tup_fetched{datname=~\"$datname\", instance=~\"$instance\"}[5m])",
+          "expr": "irate(pg_stat_database_tup_fetched_total{datname=~\"$datname\", instance=~\"$instance\"}[5m])",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{datname}}",
@@ -2103,7 +2103,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(pg_stat_database_tup_returned{datname=~\"$datname\", instance=~\"$instance\"}[5m])",
+          "expr": "irate(pg_stat_database_tup_returned_total{datname=~\"$datname\", instance=~\"$instance\"}[5m])",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{datname}}",
@@ -2200,7 +2200,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(pg_stat_database_tup_updated{datname=~\"$datname\", instance=~\"$instance\"}[5m])",
+          "expr": "irate(pg_stat_database_tup_updated_total{datname=~\"$datname\", instance=~\"$instance\"}[5m])",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{datname}}",
@@ -2297,7 +2297,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(pg_stat_database_tup_inserted{datname=~\"$datname\", instance=~\"$instance\"}[5m])",
+          "expr": "irate(pg_stat_database_tup_inserted_total{datname=~\"$datname\", instance=~\"$instance\"}[5m])",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{datname}}",
@@ -2394,7 +2394,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(pg_stat_database_tup_deleted{datname=~\"$datname\", instance=~\"$instance\"}[5m])",
+          "expr": "irate(pg_stat_database_tup_deleted_total{datname=~\"$datname\", instance=~\"$instance\"}[5m])",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{datname}}",
@@ -2491,7 +2491,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "pg_stat_database_tup_inserted{datname=~\"$datname\", instance=~\"$instance\"}",
+          "expr": "pg_stat_database_tup_inserted_total{datname=~\"$datname\", instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{datname}}",
@@ -2688,7 +2688,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "pg_stat_database_tup_fetched{datname=~\"$datname\", instance=~\"$instance\"}",
+          "expr": "pg_stat_database_tup_fetched_total{datname=~\"$datname\", instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{datname}}",
@@ -2785,7 +2785,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "pg_stat_database_tup_returned{datname=~\"$datname\", instance=~\"$instance\"}",
+          "expr": "pg_stat_database_tup_returned_total{datname=~\"$datname\", instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{datname}}",
@@ -2979,7 +2979,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "pg_stat_database_tup_deleted{datname=~\"$datname\", instance=~\"$instance\"}",
+          "expr": "pg_stat_database_tup_deleted_total{datname=~\"$datname\", instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{datname}}",
@@ -3072,7 +3072,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "pg_stat_database_blks_hit{instance=\"$instance\", datname=~\"$datname\"} / (pg_stat_database_blks_read{instance=\"$instance\", datname=~\"$datname\"} + pg_stat_database_blks_hit{instance=\"$instance\", datname=~\"$datname\"})",
+          "expr": "pg_stat_database_blks_hit_total{instance=\"$instance\", datname=~\"$datname\"} / (pg_stat_database_blks_read_total{instance=\"$instance\", datname=~\"$datname\"} + pg_stat_database_blks_hit_total{instance=\"$instance\", datname=~\"$datname\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ datname }}",
@@ -3282,14 +3282,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(pg_stat_database_conflicts{instance=\"$instance\", datname=~\"$datname\"}[5m])",
+          "expr": "irate(pg_stat_database_conflicts_total{instance=\"$instance\", datname=~\"$datname\"}[5m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{datname}} conflicts",
           "refId": "B"
         },
         {
-          "expr": "irate(pg_stat_database_deadlocks{instance=\"$instance\", datname=~\"$datname\"}[5m])",
+          "expr": "irate(pg_stat_database_deadlocks_total{instance=\"$instance\", datname=~\"$datname\"}[5m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{datname}} deadlocks",
@@ -3380,7 +3380,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(pg_stat_database_temp_bytes{instance=\"$instance\", datname=~\"$datname\"}[5m])",
+          "expr": "irate(pg_stat_database_temp_bytes_total{instance=\"$instance\", datname=~\"$datname\"}[5m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{datname}}",


### PR DESCRIPTION
## Issue
Grafana metrics were missing the `_total` suffix for read/write/update/delete counts and rates, cache hit rate, conflicts/deadlocks, transaction number, and temp file size queries. As a consequence, the default grafana dashboard for the charm was not showing data.

## Solution
Port of https://github.com/canonical/postgresql-k8s-operator/pull/1285.

Align metric names with Prometheus naming conventions by appending `_total` suffix to pg_stat_database counter metrics (tup_inserted, tup_updated, tup_deleted, tup_fetched, tup_returned, blks_hit, blks_read, conflicts, deadlocks, temp_bytes).

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
