### PR TITLE
[MISC] Remove bind mounts (16/edge)

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -83,8 +83,6 @@ backends:
 
       ADDRESS localhost
 
-      sudo mkdir -p /var/snap/lxd/common/lxd/storage-pools
-      sudo mount --bind /mnt /var/snap/lxd/common/lxd/storage-pools
     # HACK: spread does not pass environment variables set on runner
     # Manually pass specific environment variables
     environment:


### PR DESCRIPTION
Github amd64 runners no longer have most of the space in `/mnt` so there's no need to try to mount lxd storage there.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
