### PR TITLE
[DPE-9455] Bump PostgreSQL to 14.22

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -40,7 +40,7 @@ POSTGRESQL_SNAP_NAME = "charmed-postgresql"
 SNAP_PACKAGES = [
     (
         POSTGRESQL_SNAP_NAME,
-        {"revision": {"aarch64": "246", "x86_64": "247"}},
+        {"revision": {"aarch64": "250", "x86_64": "251"}},
     )
 ]
 

--- a/src/dependency.json
+++ b/src/dependency.json
@@ -9,6 +9,6 @@
     "dependencies": {},
     "name": "charmed-postgresql",
     "upgrade_supported": "^14",
-    "version": "14.20"
+    "version": "14.22"
   }
 }


### PR DESCRIPTION
# Issue:

We ship outdated PostgreSQL 14.20.

# Solution:

Update PostgreSQL to 14.22.