### PR TITLE
[DPE-9455] Bump PostgreSQL to 16.13

### DIFF
--- a/refresh_versions.toml
+++ b/refresh_versions.toml
@@ -1,11 +1,11 @@
 charm_major = 1
-workload = "16.11"
+workload = "16.13"
 
 [snap]
 name = "charmed-postgresql"
 
 [snap.revisions]
 # amd64
-x86_64 = "244"
+x86_64 = "253"
 # arm64
-aarch64 = "242"
+aarch64 = "252"

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -139,7 +139,7 @@ def test_get_patroni_health(peers_ips, patroni):
 
 
 def test_get_postgresql_version(peers_ips, patroni):
-    assert patroni.get_postgresql_version() == "16.11"
+    assert patroni.get_postgresql_version() == "16.13"
 
 
 def test_dict_to_hba_string(harness, patroni):


### PR DESCRIPTION
# Issue:

We ship outdated PostgreSQL 16.11.

# Solution:

Update PostgreSQL to 16.13.