### PR TITLE
Remove `set-tls-private-key` action in docs (16)

### DIFF
--- a/docs/how-to/enable-tls.md
+++ b/docs/how-to/enable-tls.md
@@ -35,42 +35,6 @@ To check the certificates in use by PostgreSQL, run
 openssl s_client -starttls postgres -connect <leader_unit_IP>:<port> | grep issuer
 ```
 
-## Update keys
-
-Updates to private keys for certificate signing requests (CSR) can be made via the `set-tls-private-key` action. Note that passing keys to external/internal keys should *only be done with* `base64 -w0`, *not* `cat`. 
-
-With three replicas, this schema should be followed:
-
-Generate a shared internal key:
-
-```text
-openssl genrsa -out internal-key.pem 3072
-```
-
-Generate external keys for each unit:
-
-```text
-openssl genrsa -out external-key-0.pem 3072
-openssl genrsa -out external-key-1.pem 3072
-openssl genrsa -out external-key-2.pem 3072
-```
-
-Apply both private keys to each unit. The shared internal key will be applied only to the juju leader.
-
-```text
-juju run postgresql/0 set-tls-private-key "external-key=$(base64 -w0 external-key-0.pem)"  "internal-key=$(base64 -w0 internal-key.pem)"  --wait
-juju run postgresql/1 set-tls-private-key "external-key=$(base64 -w0 external-key-1.pem)"  "internal-key=$(base64 -w0 internal-key.pem)"  --wait
-juju run postgresql/2 set-tls-private-key "external-key=$(base64 -w0 external-key-2.pem)"  "internal-key=$(base64 -w0 internal-key.pem)"  --wait
-```
-
-Updates can also be done with auto-generated keys:
-
-```text
-juju run postgresql/0 set-tls-private-key
-juju run postgresql/1 set-tls-private-key
-juju run postgresql/2 set-tls-private-key
-```
-
 ## Disable TLS
 
 Disable TLS by removing the integration.


### PR DESCRIPTION
Addresses https://github.com/canonical/postgresql-operator/issues/1262

An alternative implementation for updating private keys on PostgreSQL 16 is pending, so for now I have removed this section entirely to avoid confusion.

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
