### PR TITLE
fix(cluster): move lost+found out of PGDATA during bootstrap

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -985,6 +985,8 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         # Start can be called here multiple times as it's idempotent.
         # At this moment, it starts Patroni at the first time the data is received
         # in the relation.
+        if not self._patroni.member_started:
+            self._patroni._hide_lost_found()
         self._patroni.start_patroni()
 
         # Assert the member is up and running before marking the unit as active.
@@ -994,6 +996,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             event.defer()
             return
 
+        self._patroni._restore_lost_found()
         self._start_stop_pgbackrest_service(event)
 
         # This is intended to be executed only when leader is reinitializing S3 connection due to the leader change.
@@ -1814,6 +1817,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         """Bootstrap the cluster."""
         # Set some information needed by Patroni to bootstrap the cluster.
         if not self._patroni.bootstrap_cluster():
+            self._patroni._restore_lost_found()
             self.set_unit_status(BlockedStatus("failed to start Patroni"))
             return
 
@@ -1823,6 +1827,8 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             self.set_unit_status(WaitingStatus("awaiting for member to start"))
             event.defer()
             return
+
+        self._patroni._restore_lost_found()
 
         if not self._can_connect_to_postgresql:
             logger.debug("Deferring on_start: awaiting for database to start")

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -57,6 +57,7 @@ from constants import (
     POSTGRESQL_CONF_PATH,
     POSTGRESQL_DATA_PATH,
     POSTGRESQL_LOGS_PATH,
+    SNAP_COMMON_PATH,
     TLS_CA_BUNDLE_FILE,
 )
 from utils import label2name
@@ -64,6 +65,8 @@ from utils import label2name
 logger = logging.getLogger(__name__)
 
 PG_BASE_CONF_PATH = f"{POSTGRESQL_CONF_PATH}/postgresql.conf"
+LOST_FOUND_STASH_DIRECTORY = f"{SNAP_COMMON_PATH}/data/.lost+found-stash"
+LOST_FOUND_STASH_PATH = f"{LOST_FOUND_STASH_DIRECTORY}/lost+found"
 
 STARTED_STATES = ["running", "streaming"]
 RUNNING_STATES = [*STARTED_STATES, "starting"]
@@ -219,6 +222,7 @@ class Patroni:
         """Bootstrap a PostgreSQL cluster using Patroni."""
         # Render the configuration files and start the cluster.
         self.configure_patroni_on_unit()
+        self._hide_lost_found()
         return self.start_patroni()
 
     def configure_patroni_on_unit(self):
@@ -231,6 +235,27 @@ class Patroni:
         # Expected permission
         # Replicas refuse to start with the default permissions
         os.chmod(POSTGRESQL_DATA_PATH, POSTGRESQL_STORAGE_PERMISSIONS)
+
+    def _hide_lost_found(self) -> None:
+        """Move lost+found out of the data directory so initdb can bootstrap."""
+        lost_found_path = os.path.join(POSTGRESQL_DATA_PATH, "lost+found")
+        if os.path.isdir(LOST_FOUND_STASH_PATH) or not os.path.isdir(lost_found_path):
+            return
+
+        with suppress(FileNotFoundError):
+            os.makedirs(LOST_FOUND_STASH_DIRECTORY, exist_ok=True)
+            shutil.move(lost_found_path, LOST_FOUND_STASH_PATH)
+            logger.info("Temporarily moved lost+found out of the data directory")
+
+    def _restore_lost_found(self) -> None:
+        """Move lost+found back to the data directory after a bootstrap attempt."""
+        lost_found_path = os.path.join(POSTGRESQL_DATA_PATH, "lost+found")
+        if os.path.isdir(lost_found_path) or not os.path.isdir(LOST_FOUND_STASH_PATH):
+            return
+
+        with suppress(FileNotFoundError):
+            shutil.move(LOST_FOUND_STASH_PATH, lost_found_path)
+            logger.info("Restored lost+found into the data directory")
 
     def _change_owner(self, path: str) -> None:
         """Change the ownership of a file or a directory to the postgres user.

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -10,7 +10,7 @@ import platform
 import subprocess
 from datetime import UTC, datetime
 from typing import ClassVar
-from unittest.mock import MagicMock, Mock, PropertyMock, call, mock_open, patch, sentinel
+from unittest.mock import DEFAULT, MagicMock, Mock, PropertyMock, call, mock_open, patch, sentinel
 
 import charm_refresh
 import psycopg2
@@ -396,8 +396,12 @@ def test_on_start(harness):
             new_callable=PropertyMock,
         ) as _member_started,
         patch("charm.Patroni.bootstrap_cluster") as _bootstrap_cluster,
-        patch("charm.PostgresqlOperatorCharm._replication_password") as _replication_password,
-        patch("charm.PostgresqlOperatorCharm._get_password") as _get_password,
+        patch("charm.Patroni._restore_lost_found") as _restore_lost_found,
+        patch.multiple(
+            "charm.PostgresqlOperatorCharm",
+            _replication_password=DEFAULT,
+            _get_password=DEFAULT,
+        ) as _password_mocks,
         patch("charm.PostgresqlOperatorCharm._check_detached_storage"),
         patch(
             "charm.PostgresqlOperatorCharm._is_storage_attached",
@@ -416,6 +420,8 @@ def test_on_start(harness):
         patch("charm.PostgresqlOperatorCharm.get_secret"),
         patch("charm.TLS.generate_internal_peer_cert"),
     ):
+        _replication_password = _password_mocks["_replication_password"]
+        _get_password = _password_mocks["_get_password"]
         _get_postgresql_version.return_value = "16.6"
 
         # Test before the passwords are generated.
@@ -448,17 +454,20 @@ def test_on_start(harness):
         _bootstrap_cluster.assert_called_once()
         _oversee_users.assert_not_called()
         _restart_services_after_reboot.assert_called_once()
+        _restore_lost_found.assert_called_once()
         assert isinstance(harness.model.unit.status, BlockedStatus)
         # Set an initial waiting status (like after the install hook was triggered).
         harness.model.unit.status = WaitingStatus("fake message")
 
         # Test the event of an error happening when trying to create the default postgres user.
         _restart_services_after_reboot.reset_mock()
+        _restore_lost_found.reset_mock()
         _member_started.return_value = True
         harness.charm.on.start.emit()
         _postgresql.create_user.assert_called_once()
         _oversee_users.assert_not_called()
         _restart_services_after_reboot.assert_called_once()
+        _restore_lost_found.assert_called_once()
         assert isinstance(harness.model.unit.status, BlockedStatus)
 
         # Set an initial waiting status again (like after the install hook was triggered).
@@ -466,12 +475,14 @@ def test_on_start(harness):
 
         # Then test the event of a correct cluster bootstrapping.
         _restart_services_after_reboot.reset_mock()
+        _restore_lost_found.reset_mock()
         harness.charm.on.start.emit()
         assert _postgresql.create_user.call_count == 3  # Considering the previous failed call.
         _oversee_users.assert_called_once()
         _enable_disable_extensions.assert_called_once()
         _set_primary_status_message.assert_called_once()
         _restart_services_after_reboot.assert_called_once()
+        _restore_lost_found.assert_called_once()
 
 
 def test_on_start_replica(harness):
@@ -1778,6 +1789,8 @@ def test_on_peer_relation_changed(harness):
         patch("charm.PostgresqlOperatorCharm.is_standby_leader") as _is_standby_leader,
         patch("charm.PostgresqlOperatorCharm.is_primary") as _is_primary,
         patch("charm.Patroni.member_started", new_callable=PropertyMock) as _member_started,
+        patch("charm.Patroni._hide_lost_found") as _hide_lost_found,
+        patch("charm.Patroni._restore_lost_found") as _restore_lost_found,
         patch("charm.Patroni.start_patroni") as _start_patroni,
         patch("charm.PostgresqlOperatorCharm.update_config") as _update_config,
         patch("charm.PostgresqlOperatorCharm._update_member_ip") as _update_member_ip,
@@ -1810,6 +1823,8 @@ def test_on_peer_relation_changed(harness):
         harness.charm._on_peer_relation_changed(mock_event)
         _reconfigure_cluster.assert_called_once_with(mock_event)
         mock_event.defer.assert_called_once()
+        _hide_lost_found.assert_not_called()
+        _restore_lost_found.assert_not_called()
 
         # Test when the leader can reconfigure the cluster.
         mock_event.defer.reset_mock()
@@ -1823,31 +1838,45 @@ def test_on_peer_relation_changed(harness):
         _reconfigure_cluster.assert_called_once_with(mock_event)
         _update_config.assert_called_once()
         _start_patroni.assert_called_once()
+        _hide_lost_found.assert_not_called()
+        _restore_lost_found.assert_called_once()
         _update_new_unit_status.assert_called_once()
 
         # Test when the unit fails to update the Patroni configuration.
         _update_config.reset_mock()
         _start_patroni.reset_mock()
+        _hide_lost_found.reset_mock()
+        _restore_lost_found.reset_mock()
         _update_new_unit_status.reset_mock()
         _update_config.side_effect = RetryError(last_attempt=1)
         harness.charm._on_peer_relation_changed(mock_event)
         _update_config.assert_called_once()
         _start_patroni.assert_not_called()
+        _hide_lost_found.assert_not_called()
+        _restore_lost_found.assert_not_called()
         _update_new_unit_status.assert_not_called()
         assert isinstance(harness.model.unit.status, BlockedStatus)
 
         # Test event is early exiting when in blocked status.
         _update_config.side_effect = None
         _member_started.return_value = False
+        _hide_lost_found.reset_mock()
+        _restore_lost_found.reset_mock()
         harness.charm._on_peer_relation_changed(mock_event)
         _start_patroni.assert_not_called()
+        _hide_lost_found.assert_not_called()
+        _restore_lost_found.assert_not_called()
 
         # Test when Patroni hasn't started yet in the unit.
         harness.model.unit.status = ActiveStatus()
         _update_config.side_effect = None
         _member_started.return_value = False
+        _hide_lost_found.reset_mock()
+        _restore_lost_found.reset_mock()
         harness.charm._on_peer_relation_changed(mock_event)
         _start_patroni.assert_called_once()
+        _hide_lost_found.assert_called_once()
+        _restore_lost_found.assert_not_called()
         _update_new_unit_status.assert_not_called()
         assert isinstance(harness.model.unit.status, WaitingStatus)
 

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -19,6 +19,8 @@ from tenacity import (
 
 from charm import PostgresqlOperatorCharm
 from cluster import (
+    LOST_FOUND_STASH_DIRECTORY,
+    LOST_FOUND_STASH_PATH,
     PATRONI_TIMEOUT,
     Patroni,
     RemoveRaftMemberFailedError,
@@ -518,6 +520,104 @@ def test_configure_patroni_on_unit(peers_ips, patroni):
         _chmod.assert_called_once_with(
             "/var/snap/charmed-postgresql/common/var/lib/postgresql", 448
         )
+
+
+def test_hide_lost_found(peers_ips, patroni):
+    lost_found_path = f"{POSTGRESQL_DATA_PATH}/lost+found"
+
+    with (
+        patch(
+            "cluster.os.path.isdir",
+            side_effect=lambda path: path == lost_found_path,
+        ),
+        patch("cluster.os.makedirs") as _makedirs,
+        patch("cluster.shutil.move") as _move,
+    ):
+        patroni._hide_lost_found()
+
+        _makedirs.assert_called_once_with(LOST_FOUND_STASH_DIRECTORY, exist_ok=True)
+        _move.assert_called_once_with(lost_found_path, LOST_FOUND_STASH_PATH)
+
+
+def test_hide_lost_found_noop_when_already_moved(peers_ips, patroni):
+    lost_found_path = f"{POSTGRESQL_DATA_PATH}/lost+found"
+
+    with (
+        patch(
+            "cluster.os.path.isdir",
+            side_effect=lambda path: path in {lost_found_path, LOST_FOUND_STASH_PATH},
+        ),
+        patch("cluster.os.makedirs") as _makedirs,
+        patch("cluster.shutil.move") as _move,
+    ):
+        patroni._hide_lost_found()
+
+        _makedirs.assert_not_called()
+        _move.assert_not_called()
+
+
+def test_hide_lost_found_handles_file_not_found(peers_ips, patroni):
+    lost_found_path = f"{POSTGRESQL_DATA_PATH}/lost+found"
+
+    with (
+        patch(
+            "cluster.os.path.isdir",
+            side_effect=lambda path: path == lost_found_path,
+        ),
+        patch("cluster.os.makedirs"),
+        patch("cluster.shutil.move", side_effect=FileNotFoundError) as _move,
+    ):
+        patroni._hide_lost_found()
+
+        _move.assert_called_once_with(lost_found_path, LOST_FOUND_STASH_PATH)
+
+
+def test_restore_lost_found(peers_ips, patroni):
+    lost_found_path = f"{POSTGRESQL_DATA_PATH}/lost+found"
+
+    with (
+        patch(
+            "cluster.os.path.isdir",
+            side_effect=lambda path: path == LOST_FOUND_STASH_PATH,
+        ),
+        patch("cluster.shutil.move") as _move,
+    ):
+        patroni._restore_lost_found()
+
+        _move.assert_called_once_with(LOST_FOUND_STASH_PATH, lost_found_path)
+
+
+def test_restore_lost_found_handles_file_not_found(peers_ips, patroni):
+    lost_found_path = f"{POSTGRESQL_DATA_PATH}/lost+found"
+
+    with (
+        patch(
+            "cluster.os.path.isdir",
+            side_effect=lambda path: path == LOST_FOUND_STASH_PATH,
+        ),
+        patch("cluster.shutil.move", side_effect=FileNotFoundError) as _move,
+    ):
+        patroni._restore_lost_found()
+
+        _move.assert_called_once_with(LOST_FOUND_STASH_PATH, lost_found_path)
+
+
+def test_bootstrap_cluster(peers_ips, patroni):
+    call_order = []
+
+    with (
+        patch(
+            "cluster.Patroni.configure_patroni_on_unit",
+            side_effect=lambda: call_order.append("configure"),
+        ),
+        patch("cluster.Patroni._hide_lost_found", side_effect=lambda: call_order.append("hide")),
+        patch(
+            "cluster.Patroni.start_patroni",
+            side_effect=lambda: call_order.append("start") or True,
+        ),
+    ):
+        assert patroni.bootstrap_cluster()
+        assert call_order == ["configure", "hide", "start"]
 
 
 def test_member_started_true(peers_ips, patroni):


### PR DESCRIPTION
## Issue

## Solution
Work around initdb bootstrap failures on mounted storage by moving lost+found to a stash path outside POSTGRESQL_DATA_PATH before Patroni startup, then restoring it after member start (or bootstrap failure).

Wire the same hide/restore flow into peer-relation startup, add unit coverage for move/restore and bootstrap call order, and refactor test_on_start mock patching to avoid Python 3.12 nested-block limits.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
