### PR TITLE
feat: implement reinit action and automatic lost+found cleanup

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -97,3 +97,5 @@ restore:
     restore-to-time:
       type: string
       description: Point-in-time-recovery target in PSQL format.
+reinit:
+  description: Reinitialize a replica. Must be run against the unit being reinitialized.

--- a/src/charm.py
+++ b/src/charm.py
@@ -329,6 +329,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         self.framework.observe(self.on.leader_elected, self._on_leader_elected)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
         self.framework.observe(self.on.get_primary_action, self._on_get_primary)
+        self.framework.observe(self.on.reinit_action, self._on_reinit_action)
         self.framework.observe(self.on[PEER].relation_changed, self._on_peer_relation_changed)
         self.framework.observe(self.on.secret_changed, self._on_peer_relation_changed)
         # add specific handler for updated system-user secrets
@@ -716,6 +717,24 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             event.set_results({"primary": primary})
         except RetryError as e:
             logger.error(f"failed to get primary with error {e}")
+
+    def _on_reinit_action(self, event: ActionEvent) -> None:
+        """Handle the reinit action."""
+        if self.is_primary:
+            event.fail("Cannot reinitialize the primary unit.")
+            return
+
+        self.unit_peer_data["nofailover"] = "True"
+        self.update_config()
+
+        try:
+            self._patroni.reinit_member(self._member_name)
+            event.set_results({"result": f"reinitialize started for member {self._member_name}"})
+        except Exception as e:
+            event.fail(f"Failed to reinitialize member: {e}")
+        finally:
+            self.unit_peer_data.pop("nofailover", None)
+            self.update_config()
 
     def updated_synchronous_node_count(self) -> bool:
         """Tries to update synchronous_node_count configuration and reports the result."""
@@ -2641,6 +2660,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             parameters=pg_parameters,
             no_peers=no_peers,
             user_databases_map=self.relations_user_databases_map,
+            nofailover="nofailover" in self.unit_peer_data,
             # slots=replication_slots,
         )
         if no_peers:

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -673,6 +673,7 @@ class Patroni:
         no_peers: bool = False,
         user_databases_map: dict[str, str] | None = None,
         slots: dict[str, str] | None = None,
+        nofailover: bool = False,
     ) -> None:
         """Render the Patroni configuration file.
 
@@ -692,6 +693,7 @@ class Patroni:
             no_peers: Don't include peers.
             user_databases_map: map of databases to be accessible by each user.
             slots: replication slots (keys) with assigned database name (values).
+            nofailover: whether to set the nofailover tag in the configuration.
         """
         slots = slots or {}
         if not self._are_passwords_set:
@@ -749,8 +751,25 @@ class Patroni:
             user_databases_map=user_databases_map,
             slots=slots,
             instance_password_encryption=self.charm.config.instance_password_encryption,
+            nofailover=nofailover,
         )
         self.render_file(f"{PATRONI_CONF_PATH}/patroni.yaml", rendered, 0o600)
+
+    def _remove_lost_and_found(self) -> None:
+        """Remove lost+found directories from storages if they exist."""
+        storages = [
+            "/var/snap/charmed-postgresql/common/data/archive",
+            POSTGRESQL_DATA_PATH,
+            "/var/snap/charmed-postgresql/common/data/logs",
+            "/var/snap/charmed-postgresql/common/data/temp",
+        ]
+        for storage in storages:
+            lost_and_found = f"{storage}/lost+found"
+            try:
+                if os.path.exists(lost_and_found):
+                    shutil.rmtree(lost_and_found)
+            except OSError as e:
+                logger.warning("Failed to remove %s: %s", lost_and_found, e)
 
     def start_patroni(self) -> bool:
         """Start Patroni service using snap.
@@ -758,6 +777,7 @@ class Patroni:
         Returns:
             Whether the service started successfully.
         """
+        self._remove_lost_and_found()
         try:
             logger.debug("Starting Patroni...")
             cache = snap.SnapCache()
@@ -768,6 +788,63 @@ class Patroni:
             error_message = "Failed to start patroni snap service"
             logger.exception(error_message, exc_info=e)
             return False
+
+    def reinit_member(self, member: str) -> None:
+        """Reinitialize a database member.
+        
+        Args:
+            member: The member to reinitialize.
+        """
+        try:
+            logger.info("Reinitializing %s", member)
+
+            # Additional cleanup for reinit
+            pg_wal = f"{POSTGRESQL_DATA_PATH}/pg_wal"
+            if os.path.islink(pg_wal):
+                logger.info("Removing pg_wal symlink")
+                os.remove(pg_wal)
+
+            logs_path = "/var/snap/charmed-postgresql/common/data/logs"
+            if os.path.exists(logs_path):
+                logger.info("Cleaning logs storage content")
+                for item in os.listdir(logs_path):
+                    item_path = os.path.join(logs_path, item)
+                    try:
+                        if os.path.isfile(item_path) or os.path.islink(item_path):
+                            os.remove(item_path)
+                        elif os.path.isdir(item_path):
+                            shutil.rmtree(item_path)
+                    except Exception as e:
+                        logger.warning("Failed to remove %s: %s", item_path, e)
+
+            subprocess.run(
+                [
+                    "charmed-postgresql.patronictl",
+                    "-c",
+                    f"{PATRONI_CONF_PATH}/patroni.yaml",
+                    "reinit",
+                    self.cluster_name,
+                    member,
+                    "--force",
+                ],
+                check=True,
+            )
+            # Wait for Patroni to start the reinitialization process
+            try:
+                for attempt in Retrying(
+                    stop=stop_after_delay(60),
+                    wait=wait_fixed(3),
+                    retry=retry_if_result(lambda s: s == "running"),
+                    reraise=True,
+                ):
+                    with attempt:
+                        attempt.retry_state.set_result(self.get_member_status(member))
+            except RetryError:
+                logger.warning("Timed out waiting for member %s to start reinitializing", member)
+
+        except subprocess.CalledProcessError as e:
+            logger.error("Failed to reinitialize %s: %s", member, e)
+            raise
 
     def patroni_logs(self, num_lines: int | Literal["all"] = 10) -> str:
         """Get Patroni snap service logs. Executes only on current unit.

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -791,7 +791,7 @@ class Patroni:
 
     def reinit_member(self, member: str) -> None:
         """Reinitialize a database member.
-        
+
         Args:
             member: The member to reinitialize.
         """
@@ -814,12 +814,12 @@ class Patroni:
                             os.remove(item_path)
                         elif os.path.isdir(item_path):
                             shutil.rmtree(item_path)
-                    except Exception as e:
+                    except OSError as e:
                         logger.warning("Failed to remove %s: %s", item_path, e)
 
-            subprocess.run(
+            subprocess.run(  # noqa: S603
                 [
-                    "charmed-postgresql.patronictl",
+                    "/snap/bin/charmed-postgresql.patronictl",
                     "-c",
                     f"{PATRONI_CONF_PATH}/patroni.yaml",
                     "reinit",

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -236,7 +236,12 @@ postgresql:
       sslcert: {{ conf_path }}/nonexistent_cert.pem
       sslkey: {{ conf_path }}/nonexistent_key.pem
 use_unix_socket: true
-{%- if is_creating_backup %}
+{%- if is_creating_backup or nofailover %}
 tags:
+  {%- if is_creating_backup %}
   is_creating_backup: {{ is_creating_backup }}
+  {%- endif %}
+  {%- if nofailover %}
+  nofailover: true
+  {%- endif %}
 {%- endif %}

--- a/tests/integration/test_reinit_missing_pg_control.py
+++ b/tests/integration/test_reinit_missing_pg_control.py
@@ -20,9 +20,7 @@ REINIT_TIMEOUT = 20 * MINUTE
 
 PATRONI_CONFIGURATION_FILE = "/var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml"
 # Without 16/main because we are not on the multiple clusters branch
-PG_CONTROL_FILE = (
-    "/var/snap/charmed-postgresql/common/var/lib/postgresql/global/pg_control"
-)
+PG_CONTROL_FILE = "/var/snap/charmed-postgresql/common/var/lib/postgresql/global/pg_control"
 
 LAYOUT_DIRECTORIES = (
     "/var/snap/charmed-postgresql/common/var/lib/postgresql",
@@ -125,11 +123,10 @@ def test_reinit_after_pg_control_removal(juju: jubilant.Juju) -> None:
     for attempt in Retrying(stop=stop_after_delay(5 * MINUTE), wait=wait_fixed(10), reraise=True):
         with attempt:
             result = subprocess.run(
-                [
-                    "juju", "run", "-m", juju.model, replica_unit,
-                    "reinit"
-                ],
-                text=True, capture_output=True, check=True
+                ["juju", "run", "-m", juju.model, replica_unit, "reinit"],
+                text=True,
+                capture_output=True,
+                check=True,
             )
             reinit_output = result.stdout
 

--- a/tests/integration/test_reinit_missing_pg_control.py
+++ b/tests/integration/test_reinit_missing_pg_control.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+import subprocess
+
+import jubilant
+import pytest
+from tenacity import Retrying, stop_after_delay, wait_fixed
+
+from .helpers import DATABASE_APP_NAME
+from .jubilant_helpers import get_primary
+
+logger = logging.getLogger(__name__)
+
+MINUTE = 60
+TIMEOUT = 20 * MINUTE
+REINIT_TIMEOUT = 20 * MINUTE
+
+PATRONI_CONFIGURATION_FILE = "/var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml"
+# Without 16/main because we are not on the multiple clusters branch
+PG_CONTROL_FILE = (
+    "/var/snap/charmed-postgresql/common/var/lib/postgresql/global/pg_control"
+)
+
+LAYOUT_DIRECTORIES = (
+    "/var/snap/charmed-postgresql/common/var/lib/postgresql",
+    "/var/snap/charmed-postgresql/common/data/logs",
+    "/var/snap/charmed-postgresql/common/data/temp",
+    "/var/snap/charmed-postgresql/common/data/archive",
+)
+
+
+def _run_juju_ssh(juju: jubilant.Juju, unit_name: str, remote_command: str) -> str:
+    """Run a command over `juju ssh` and return stdout."""
+    result = subprocess.run(
+        ["juju", "ssh", "-m", juju.model, unit_name, remote_command],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Command failed ({result.returncode}): juju ssh -m {juju.model} {unit_name}"
+            f" {remote_command}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result.stdout
+
+
+def _patronictl_list(juju: jubilant.Juju, unit_name: str) -> str:
+    """Return the Patroni cluster table from a unit."""
+    return _run_juju_ssh(
+        juju,
+        unit_name,
+        f"sudo charmed-postgresql.patronictl -c {PATRONI_CONFIGURATION_FILE} list",
+    )
+
+
+def _member_role_state(patronictl_output: str, member_name: str) -> tuple[str | None, str | None]:
+    """Return role and state for a member in `patronictl list` output."""
+    for raw_line in patronictl_output.splitlines():
+        line = raw_line.strip()
+        if not line.startswith("|") or member_name not in line:
+            continue
+
+        columns = [column.strip() for column in raw_line.split("|")[1:-1]]
+        if len(columns) < 4:
+            continue
+
+        role = columns[2]
+        state = columns[3].lower()
+        return role, state
+
+    return None, None
+
+
+@pytest.mark.abort_on_fail
+def test_deploy_three_units(juju: jubilant.Juju, charm) -> None:
+    """Deploy a three-unit PostgreSQL cluster."""
+    if DATABASE_APP_NAME not in juju.status().apps:
+        juju.deploy(
+            charm,
+            app=DATABASE_APP_NAME,
+            num_units=3,
+            config={"profile": "testing"},
+        )
+
+    juju.wait(jubilant.all_agents_idle, timeout=5 * MINUTE)
+
+    unit_names = sorted(juju.status().get_units(DATABASE_APP_NAME))
+    assert len(unit_names) == 3, f"Expected 3 units, got {len(unit_names)}: {unit_names}"
+
+
+def test_reinit_after_pg_control_removal(juju: jubilant.Juju) -> None:
+    """Remove pg_control on a replica and verify `reinit` action recovers it."""
+    unit_names = sorted(juju.status().get_units(DATABASE_APP_NAME))
+    assert len(unit_names) == 3, f"Expected 3 units, got {len(unit_names)}: {unit_names}"
+
+    primary_unit = get_primary(juju, unit_names[0])
+    replica_unit = next(unit for unit in unit_names if unit != primary_unit)
+    replica_member = replica_unit.replace("/", "-")
+
+    logger.info("Primary: %s, replica under test: %s", primary_unit, replica_unit)
+
+    for layout_path in LAYOUT_DIRECTORIES:
+        _run_juju_ssh(juju, primary_unit, f"sudo test -d {layout_path}")
+
+    _run_juju_ssh(
+        juju,
+        replica_unit,
+        f"sudo rm -f {PG_CONTROL_FILE} && sudo test ! -f {PG_CONTROL_FILE}",
+    )
+    _run_juju_ssh(juju, replica_unit, "sudo snap restart charmed-postgresql.patroni")
+
+    for attempt in Retrying(stop=stop_after_delay(5 * MINUTE), wait=wait_fixed(10), reraise=True):
+        with attempt:
+            cluster_table = _patronictl_list(juju, primary_unit)
+            _, state = _member_role_state(cluster_table, replica_member)
+            assert state == "stopped", (
+                f"Expected {replica_member} to be stopped after pg_control removal.\n{cluster_table}"
+            )
+
+    reinit_output = ""
+    for attempt in Retrying(stop=stop_after_delay(5 * MINUTE), wait=wait_fixed(10), reraise=True):
+        with attempt:
+            result = subprocess.run(
+                [
+                    "juju", "run", "-m", juju.model, replica_unit,
+                    "reinit"
+                ],
+                text=True, capture_output=True, check=True
+            )
+            reinit_output = result.stdout
+
+    assert "reinitialize started for member" in reinit_output
+
+    for attempt in Retrying(
+        stop=stop_after_delay(REINIT_TIMEOUT),
+        wait=wait_fixed(10),
+        reraise=True,
+    ):
+        with attempt:
+            _run_juju_ssh(juju, replica_unit, f"sudo test -f {PG_CONTROL_FILE}")
+            cluster_table = _patronictl_list(juju, primary_unit)
+            role, state = _member_role_state(cluster_table, replica_member)
+            assert role in {"Replica", "Sync Standby"}, (
+                f"Unexpected role for {replica_member}: {role}\n{cluster_table}"
+            )
+            assert state in {"running", "streaming"}, (
+                f"Unexpected state for {replica_member}: {state}\n{cluster_table}"
+            )
+
+    juju.wait(lambda status: jubilant.all_active(status, DATABASE_APP_NAME), timeout=TIMEOUT)

--- a/tests/spread/test_reinit_missing_pg_control.py/task.yaml
+++ b/tests/spread/test_reinit_missing_pg_control.py/task.yaml
@@ -1,0 +1,7 @@
+summary: test_reinit_missing_pg_control.py
+environment:
+  TEST_MODULE: test_reinit_missing_pg_control.py
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1019,6 +1019,7 @@ def test_update_config(harness):
             no_peers=False,
             user_databases_map={"operator": "all", "replication": "all", "rewind": "all"},
             # slots={},
+            nofailover=False,
         )
         _handle_postgresql_restart_need.assert_called_once_with(True)
         _restart_ldap_sync_service.assert_called_once()
@@ -1059,6 +1060,7 @@ def test_update_config(harness):
             no_peers=False,
             user_databases_map={"operator": "all", "replication": "all", "rewind": "all"},
             # slots={},
+            nofailover=False,
         )
         _handle_postgresql_restart_need.assert_called_once()
         _restart_ldap_sync_service.assert_called_once()


### PR DESCRIPTION
## Issue

## Solution

- Add `reinit` Juju action for safe replica recovery.
- Implement failover protection during reinit using Patroni `nofailover` tags.
- Add automatic removal of `lost+found` directories before Patroni startup.
- Add comprehensive integration test for `pg_control` corruption recovery.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
