### PR TITLE
Revert "fix(monitoring): add _total suffix to PostgreSQL counter metrics in Grafana dashboard (#1485)"

### DIFF
--- a/src/grafana_dashboards/postgresql-metrics.json
+++ b/src/grafana_dashboards/postgresql-metrics.json
@@ -299,7 +299,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "SUM(pg_stat_database_tup_fetched_total{datname=~\"$datname\", instance=~\"$instance\"})",
+          "expr": "SUM(pg_stat_database_tup_fetched{datname=~\"$datname\", instance=~\"$instance\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -385,7 +385,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "SUM(pg_stat_database_tup_inserted_total{release=\"$release\", datname=~\"$datname\", instance=~\"$instance\"})",
+          "expr": "SUM(pg_stat_database_tup_inserted{release=\"$release\", datname=~\"$datname\", instance=~\"$instance\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -471,7 +471,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "SUM(pg_stat_database_tup_updated_total{datname=~\"$datname\", instance=~\"$instance\"})",
+          "expr": "SUM(pg_stat_database_tup_updated{datname=~\"$datname\", instance=~\"$instance\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -1805,14 +1805,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(pg_stat_database_xact_commit_total{instance=\"$instance\", datname=~\"$datname\"}[5m])",
+          "expr": "irate(pg_stat_database_xact_commit{instance=\"$instance\", datname=~\"$datname\"}[5m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{datname}} commits",
           "refId": "A"
         },
         {
-          "expr": "irate(pg_stat_database_xact_rollback_total{instance=\"$instance\", datname=~\"$datname\"}[5m])",
+          "expr": "irate(pg_stat_database_xact_rollback{instance=\"$instance\", datname=~\"$datname\"}[5m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{datname}} rollbacks",
@@ -1909,7 +1909,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "pg_stat_database_tup_updated_total{datname=~\"$datname\", instance=~\"$instance\"}",
+          "expr": "pg_stat_database_tup_updated{datname=~\"$datname\", instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{datname}}",
@@ -2006,7 +2006,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(pg_stat_database_tup_fetched_total{datname=~\"$datname\", instance=~\"$instance\"}[5m])",
+          "expr": "irate(pg_stat_database_tup_fetched{datname=~\"$datname\", instance=~\"$instance\"}[5m])",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{datname}}",
@@ -2103,7 +2103,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(pg_stat_database_tup_returned_total{datname=~\"$datname\", instance=~\"$instance\"}[5m])",
+          "expr": "irate(pg_stat_database_tup_returned{datname=~\"$datname\", instance=~\"$instance\"}[5m])",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{datname}}",
@@ -2200,7 +2200,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(pg_stat_database_tup_updated_total{datname=~\"$datname\", instance=~\"$instance\"}[5m])",
+          "expr": "irate(pg_stat_database_tup_updated{datname=~\"$datname\", instance=~\"$instance\"}[5m])",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{datname}}",
@@ -2297,7 +2297,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(pg_stat_database_tup_inserted_total{datname=~\"$datname\", instance=~\"$instance\"}[5m])",
+          "expr": "irate(pg_stat_database_tup_inserted{datname=~\"$datname\", instance=~\"$instance\"}[5m])",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{datname}}",
@@ -2394,7 +2394,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(pg_stat_database_tup_deleted_total{datname=~\"$datname\", instance=~\"$instance\"}[5m])",
+          "expr": "irate(pg_stat_database_tup_deleted{datname=~\"$datname\", instance=~\"$instance\"}[5m])",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{datname}}",
@@ -2491,7 +2491,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "pg_stat_database_tup_inserted_total{datname=~\"$datname\", instance=~\"$instance\"}",
+          "expr": "pg_stat_database_tup_inserted{datname=~\"$datname\", instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{datname}}",
@@ -2688,7 +2688,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "pg_stat_database_tup_fetched_total{datname=~\"$datname\", instance=~\"$instance\"}",
+          "expr": "pg_stat_database_tup_fetched{datname=~\"$datname\", instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{datname}}",
@@ -2785,7 +2785,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "pg_stat_database_tup_returned_total{datname=~\"$datname\", instance=~\"$instance\"}",
+          "expr": "pg_stat_database_tup_returned{datname=~\"$datname\", instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{datname}}",
@@ -2979,7 +2979,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "pg_stat_database_tup_deleted_total{datname=~\"$datname\", instance=~\"$instance\"}",
+          "expr": "pg_stat_database_tup_deleted{datname=~\"$datname\", instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{datname}}",
@@ -3072,7 +3072,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "pg_stat_database_blks_hit_total{instance=\"$instance\", datname=~\"$datname\"} / (pg_stat_database_blks_read_total{instance=\"$instance\", datname=~\"$datname\"} + pg_stat_database_blks_hit_total{instance=\"$instance\", datname=~\"$datname\"})",
+          "expr": "pg_stat_database_blks_hit{instance=\"$instance\", datname=~\"$datname\"} / (pg_stat_database_blks_read{instance=\"$instance\", datname=~\"$datname\"} + pg_stat_database_blks_hit{instance=\"$instance\", datname=~\"$datname\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ datname }}",
@@ -3282,14 +3282,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(pg_stat_database_conflicts_total{instance=\"$instance\", datname=~\"$datname\"}[5m])",
+          "expr": "irate(pg_stat_database_conflicts{instance=\"$instance\", datname=~\"$datname\"}[5m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{datname}} conflicts",
           "refId": "B"
         },
         {
-          "expr": "irate(pg_stat_database_deadlocks_total{instance=\"$instance\", datname=~\"$datname\"}[5m])",
+          "expr": "irate(pg_stat_database_deadlocks{instance=\"$instance\", datname=~\"$datname\"}[5m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{datname}} deadlocks",
@@ -3380,7 +3380,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(pg_stat_database_temp_bytes_total{instance=\"$instance\", datname=~\"$datname\"}[5m])",
+          "expr": "irate(pg_stat_database_temp_bytes{instance=\"$instance\", datname=~\"$datname\"}[5m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{datname}}",

--- a/tests/integration/test_subordinates.py
+++ b/tests/integration/test_subordinates.py
@@ -32,6 +32,7 @@ async def check_subordinate_env_vars(ops_test: OpsTest) -> None:
 
 
 @pytest.mark.abort_on_fail
+@pytest.mark.skip(reason="Unstable")
 async def test_deploy(ops_test: OpsTest, charm: str, check_subordinate_env_vars):
     await gather(
         ops_test.model.deploy(
@@ -72,6 +73,7 @@ async def test_deploy(ops_test: OpsTest, charm: str, check_subordinate_env_vars)
     )
 
 
+@pytest.mark.skip(reason="Unstable")
 async def test_scale_up(ops_test: OpsTest, check_subordinate_env_vars):
     await scale_application(ops_test, DATABASE_APP_NAME, 4)
 
@@ -80,6 +82,7 @@ async def test_scale_up(ops_test: OpsTest, check_subordinate_env_vars):
     )
 
 
+@pytest.mark.skip(reason="Unstable")
 async def test_scale_down(ops_test: OpsTest, check_subordinate_env_vars):
     await scale_application(ops_test, DATABASE_APP_NAME, 3)
 


### PR DESCRIPTION
## Issue

The reverted commit did fix COS Opentelemetry Collector compatibility for
the cost of braking compatibility with Grafana Agents.
To restore backward compatibility for already deployed COS productions with
 subordinated grafana-agent we have to revert this commit and re-apply better
 approach compatible with both otel collector AND grafana agent (WIP):
https://github.com/canonical/postgresql-k8s-operator/pull/1285#issuecomment-4221887305

## Solution

We are planning the next stable release, therefor have to revert it now.

This reverts commit 494fef648e4527bc12ae27cefb61b9b52f79ba97.