### PR TITLE
Bump snap to the latest security fixes (PG16)

### DIFF
--- a/refresh_versions.toml
+++ b/refresh_versions.toml
@@ -6,6 +6,6 @@ name = "charmed-postgresql"
 
 [snap.revisions]
 # amd64
-x86_64 = "268"
+x86_64 = "283"
 # arm64
-aarch64 = "267"
+aarch64 = "282"


### PR DESCRIPTION
## Issue

Snap has several security fixes

## Solution

Bump snap to the latest version. PG version is the same.