### PR TITLE
Re-enable subordinated landscape-client tests

### DIFF
--- a/tests/integration/test_subordinates.py
+++ b/tests/integration/test_subordinates.py
@@ -32,7 +32,6 @@ async def check_subordinate_env_vars(ops_test: OpsTest) -> None:
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.skip(reason="Unstable")
 async def test_deploy(ops_test: OpsTest, charm: str, check_subordinate_env_vars):
     await gather(
         ops_test.model.deploy(
@@ -73,7 +72,6 @@ async def test_deploy(ops_test: OpsTest, charm: str, check_subordinate_env_vars)
     )
 
 
-@pytest.mark.skip(reason="Unstable")
 async def test_scale_up(ops_test: OpsTest, check_subordinate_env_vars):
     await scale_application(ops_test, DATABASE_APP_NAME, 4)
 
@@ -82,7 +80,6 @@ async def test_scale_up(ops_test: OpsTest, check_subordinate_env_vars):
     )
 
 
-@pytest.mark.skip(reason="Unstable")
 async def test_scale_down(ops_test: OpsTest, check_subordinate_env_vars):
     await scale_application(ops_test, DATABASE_APP_NAME, 3)
 


### PR DESCRIPTION
## Issue

The landscape client subordinated tests have been fixed the last week due to the regression in landscape client PPA.

## Solution

The landscape team has fixed the client and tests can be re-enabled: https://github.com/canonical/landscape-client/pull/427