### PR TITLE
Re-enable subordinated landscape-client tests on PG14

### DIFF
--- a/tests/integration/test_subordinates.py
+++ b/tests/integration/test_subordinates.py
@@ -64,11 +64,12 @@ async def test_deploy(ops_test: OpsTest, charm: str, check_subordinate_env_vars)
     )
 
     await ops_test.model.wait_for_idle(apps=[DATABASE_APP_NAME], status="active", timeout=2000)
+    await ops_test.model.relate(f"{DATABASE_APP_NAME}:juju-info", f"{LS_CLIENT}:container")
     await ops_test.model.relate(
         f"{DATABASE_APP_NAME}:juju-info", f"{UBUNTU_PRO_APP_NAME}:juju-info"
     )
     await ops_test.model.wait_for_idle(
-        apps=[UBUNTU_PRO_APP_NAME, DATABASE_APP_NAME], status="active"
+        apps=[LS_CLIENT, UBUNTU_PRO_APP_NAME, DATABASE_APP_NAME], status="active"
     )
 
 
@@ -76,7 +77,7 @@ async def test_scale_up(ops_test: OpsTest, check_subordinate_env_vars):
     await scale_application(ops_test, DATABASE_APP_NAME, 4)
 
     await ops_test.model.wait_for_idle(
-        apps=[UBUNTU_PRO_APP_NAME, DATABASE_APP_NAME], status="active", timeout=1500
+        apps=[LS_CLIENT, UBUNTU_PRO_APP_NAME, DATABASE_APP_NAME], status="active", timeout=1500
     )
 
 
@@ -84,5 +85,5 @@ async def test_scale_down(ops_test: OpsTest, check_subordinate_env_vars):
     await scale_application(ops_test, DATABASE_APP_NAME, 3)
 
     await ops_test.model.wait_for_idle(
-        apps=[UBUNTU_PRO_APP_NAME, DATABASE_APP_NAME], status="active", timeout=1500
+        apps=[LS_CLIENT, UBUNTU_PRO_APP_NAME, DATABASE_APP_NAME], status="active", timeout=1500
     )


### PR DESCRIPTION
## Issue

The landscape-client subordinated tests have been disabled on PG14.

## Solution

They have been temporary disabled in
https://github.com/canonical/postgresql-operator/pull/831
due to the lack of subscriptions, which are available now.
Re-enabling.

