### PR TITLE
[DPE-9705] Add Patroni max_timelines_history=50

### DIFF
--- a/src/cluster.py
+++ b/src/cluster.py
@@ -594,6 +594,16 @@ class Patroni:
                 if self.get_primary() is None:
                     raise ClusterNotPromotedError("cluster not promoted")
 
+    def set_max_timelines_history(self) -> None:
+        """Patch the DCS with max_timelines_history limit."""
+        requests.patch(
+            f"{self._patroni_url}/config",
+            verify=self.verify,
+            json={"max_timelines_history": 50},
+            auth=self._patroni_auth,
+            timeout=PATRONI_TIMEOUT,
+        )
+
     def render_file(self, path: str, content: str, mode: int, change_owner: bool = True) -> None:
         """Write a content rendered from a template to a file.
 

--- a/src/upgrade.py
+++ b/src/upgrade.py
@@ -199,6 +199,7 @@ class PostgreSQLUpgrade(DataUpgrade):
                     self.charm.update_config()
 
                     self._set_up_new_access_roles_for_legacy()
+                    self._patch_max_timelines_history()
 
                     self.set_unit_completed()
 
@@ -275,6 +276,12 @@ class PostgreSQLUpgrade(DataUpgrade):
         self.charm.postgresql.grant_internal_access_group_memberships()
         self.charm.postgresql.grant_relation_access_group_memberships()
         logger.debug("Access roles created")
+
+    def _patch_max_timelines_history(self):
+        try:
+            self.charm._patroni.set_max_timelines_history()
+        except Exception:
+            logger.warning("Unable to patch in max_timelines_history")
 
     @property
     def unit_upgrade_data(self) -> RelationDataContent:

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -60,6 +60,7 @@ bootstrap:
     maximum_lag_on_failover: {{ maximum_lag_on_failover }}
     synchronous_mode: true
     synchronous_mode_strict: false
+    max_timelines_history: 50
     synchronous_node_count: {{ synchronous_node_count }}
     postgresql:
       use_pg_rewind: true

--- a/tests/integration/ha_tests/test_upgrade_from_stable.py
+++ b/tests/integration/ha_tests/test_upgrade_from_stable.py
@@ -17,6 +17,7 @@ from ..helpers import (
 from .helpers import (
     are_writes_increasing,
     check_writes,
+    get_patroni_setting,
     start_continuous_writes,
 )
 
@@ -142,3 +143,4 @@ async def test_upgrade_from_stable(ops_test: OpsTest, charm):
         assert (final_number_of_switchovers - initial_number_of_switchovers) <= 2, (
             "Number of switchovers is greater than 2"
         )
+        assert await get_patroni_setting(ops_test, "max_timelines_history") == 50

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -484,6 +484,21 @@ def test_update_synchronous_node_count(peers_ips, patroni):
             assert False
 
 
+def test_set_max_timelines_history(peers_ips, patroni):
+    with (
+        patch("requests.patch") as _patch,
+    ):
+        patroni.set_max_timelines_history()
+
+        _patch.assert_called_once_with(
+            f"{patroni._patroni_url}/config",
+            json={"max_timelines_history": 50},
+            verify=True,
+            auth=patroni._patroni_auth,
+            timeout=PATRONI_TIMEOUT,
+        )
+
+
 def test_configure_patroni_on_unit(peers_ips, patroni):
     with (
         patch("os.chmod") as _chmod,


### PR DESCRIPTION
## Issue

The 'history' part of Patroni config stored in DCS grows without limits.

## Solution

Backport from postgresql-k8s-operator commit 2ed8373.
Adds max_timelines_history=50 to Patroni DCS config to
prevent unbounded timeline history growth after repeated failovers.

Includes bootstrap template, runtime PATCH method,
upgrade-time patching for existing deployments, and unit/integration tests.

Assisted-by: Claude:claude-4.6-opus

Fixes https://github.com/canonical/postgresql-operator/issues/1628
