### PR TITLE
[DPE-9705] Add Patroni max_timelines_history=50

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -450,6 +450,10 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
                 "Did not allow next unit to refresh: member not ready or not joined the cluster yet"
             )
         else:
+            try:
+                self._patroni.set_max_timelines_history()
+            except Exception:
+                logger.warning("Unable to patch in max_timelines_history")
             refresh.next_unit_allowed_to_refresh = True
 
     def set_unit_status(

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -610,6 +610,16 @@ class Patroni:
                 if self.get_primary() is None:
                     raise ClusterNotPromotedError("cluster not promoted")
 
+    def set_max_timelines_history(self) -> None:
+        """Patch the DCS with max_timelines_history limit."""
+        requests.patch(
+            f"{self._patroni_url}/config",
+            verify=self.verify,
+            json={"max_timelines_history": 50},
+            auth=self._patroni_auth,
+            timeout=PATRONI_TIMEOUT,
+        )
+
     def render_patroni_yml_file(
         self,
         connectivity: bool = False,

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -54,6 +54,7 @@ bootstrap:
     maximum_lag_on_failover: {{ maximum_lag_on_failover }}
     synchronous_mode: true
     synchronous_mode_strict: false
+    max_timelines_history: 50
     synchronous_node_count: {{ synchronous_node_count }}
     postgresql:
       use_pg_rewind: true

--- a/tests/integration/high_availability/test_upgrade_from_stable.py
+++ b/tests/integration/high_availability/test_upgrade_from_stable.py
@@ -4,6 +4,7 @@
 import logging
 
 import jubilant
+import requests
 from jubilant import Juju
 
 from .high_availability_helpers_new import (
@@ -11,6 +12,7 @@ from .high_availability_helpers_new import (
     count_switchovers,
     get_app_leader,
     get_app_units,
+    get_unit_ip,
     wait_for_apps_status,
 )
 
@@ -111,3 +113,8 @@ def test_upgrade_from_stable(juju: Juju, charm: str, continuous_writes) -> None:
     assert (final_number_of_switchovers - initial_number_of_switchovers) <= 2, (
         "Number of switchovers is greater than 2"
     )
+
+    leader = get_app_leader(juju, DB_APP_NAME)
+    leader_ip = get_unit_ip(juju, DB_APP_NAME, leader)
+    config = requests.get(f"https://{leader_ip}:8008/config", verify=False).json()
+    assert config.get("max_timelines_history") == 50

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -446,6 +446,21 @@ def test_update_synchronous_node_count(peers_ips, patroni):
             assert False
 
 
+def test_set_max_timelines_history(peers_ips, patroni):
+    with (
+        patch("requests.patch") as _patch,
+    ):
+        patroni.set_max_timelines_history()
+
+        _patch.assert_called_once_with(
+            f"{patroni._patroni_url}/config",
+            json={"max_timelines_history": 50},
+            verify=patroni.verify,
+            auth=patroni._patroni_auth,
+            timeout=PATRONI_TIMEOUT,
+        )
+
+
 def test_configure_patroni_on_unit(peers_ips, patroni):
     with (
         patch("os.chmod") as _chmod,


### PR DESCRIPTION
## Issue

The 'history' part of Patroni config stored in DCS grows without limits.

## Solution

Backport from postgresql-k8s-operator commit 2ed8373.
Adds max_timelines_history=50 to Patroni DCS config to prevent
unbounded timeline history growth after repeated failovers.

Includes bootstrap template, runtime PATCH method, refresh-time
patching for existing deployments, and unit/integration tests.

Assisted-by: Claude:claude-4.6-opus

Fixes: https://github.com/canonical/postgresql-operator/issues/1628