### PR TITLE
fix(backups): pass both stdout and stderr to _extract_error_message in _list_timelines

### DIFF
--- a/src/backups.py
+++ b/src/backups.py
@@ -567,7 +567,7 @@ class PostgreSQLBackups(Object):
             "--output=json",
         ])
         if return_code != 0:
-            extracted_error = self._extract_error_message(stderr)
+            extracted_error = self._extract_error_message(output, stderr)
             raise ListBackupsError(f"Failed to list repository with error: {extracted_error}")
 
         repository = json.loads(output).items()


### PR DESCRIPTION
## Summary

Closes #1482.

`_extract_error_message` is declared with two positional arguments (`stdout`, `stderr`):

```python
@staticmethod
def _extract_error_message(stdout: str, stderr: str) -> str:
```

Every other call site in `src/backups.py` (L214, L457, L531, L747, L811, L1028, L1195) supplies both arguments. The `_list_timelines` call at L570 was the lone exception:

```python
extracted_error = self._extract_error_message(stderr)
```

so whenever `pgbackrest repo-ls` returned a non-zero exit code, the error path raised

```
TypeError: _extract_error_message() missing 1 required positional argument: 'stderr'
```

instead of the intended `ListBackupsError`, masking the underlying backup failure.

## Fix

Pass the local `output` variable (the stdout captured from `_execute_command`) as the first argument, matching the surrounding convention. One-line change.

## Test plan

- [x] `python -c 'import ast; ast.parse(open("src/backups.py").read())'`, syntax OK
- [x] `grep _extract_error_message src/backups.py`, all 8 call sites now pass two arguments
- [ ] CI: integration tests that hit a failing `pgbackrest repo-ls` (e.g. revoked credentials) should now surface the real error inside `ListBackupsError` instead of the `TypeError`