### PR TITLE
docs(restore): fix restore-to-time format hint to PSQL timestamp form

### DIFF
--- a/docs/how-to/back-up-and-restore/restore-a-backup.md
+++ b/docs/how-to/back-up-and-restore/restore-a-backup.md
@@ -68,9 +68,9 @@ When the user needs to restore a specific backup that was made, they can use the
 juju run postgresql/leader restore backup-id=YYYY-MM-DDTHH:MM:SSZ
 ```
 
-However, if the user needs to restore to a specific point in time between different backups (e.g. to restore only specific transactions made between those backups), they can use the `restore-to-time` parameter to pass a timestamp related to the moment they want to restore.
+However, if the user needs to restore to a specific point in time between different backups (e.g. to restore only specific transactions made between those backups), they can use the `restore-to-time` parameter to pass a timestamp related to the moment they want to restore. The format matches PostgreSQL's `SELECT current_timestamp` output (`YYYY-MM-DD HH:MM:SS` with a space separator, optional fractional seconds, and an optional `+HH` / `-HH:MM` timezone offset):
  ```text
-juju run postgresql/leader restore restore-to-time="YYYY-MM-DDTHH:MM:SSZ"
+juju run postgresql/leader restore restore-to-time="YYYY-MM-DD HH:MM:SS"
 ```
 
 Your restore will then be in progress.


### PR DESCRIPTION
## Summary

Closes #1625.

The PITR `restore-a-backup` how-to documented the `restore-to-time` value as `"YYYY-MM-DDTHH:MM:SSZ"`, but the charm validates that argument against the PostgreSQL `SELECT current_timestamp` shape — `_is_psql_timestamp` in `src/backups.py`:

```python
re.match(
    r"^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}(\\.\\d{1,6})?([-+](?:\\d{2}|\\d{4}|\\d{2}:\\d{2}))?$",
    timestamp,
)
```

The regex requires a **space** separator (not `T`) and rejects a trailing `Z`, so following the doc's format returns `Bad restore-to-time format` on every PITR attempt — exactly the reproducer in the issue. The format that actually works (`2026-04-14 09:40:20`) is the PostgreSQL form noted in the issue body.

## Change

Update the snippet in `docs/how-to/back-up-and-restore/restore-a-backup.md`:

```diff
-juju run postgresql/leader restore restore-to-time="YYYY-MM-DDTHH:MM:SSZ"
+juju run postgresql/leader restore restore-to-time="YYYY-MM-DD HH:MM:SS"
```

…and call out that the format matches `SELECT current_timestamp` with optional fractional seconds and an optional `+HH` / `-HH:MM` timezone offset, mirroring the regex.

The `backup-id` line above (line 68) is unchanged — `backup-id` uses a separate stored-label format, not a free-form timestamp.

## Test plan

- [x] Verified the regex rejects `2026-04-14T09:40:20Z` (matches the issue's failure) and accepts `2026-04-14 09:40:20`, `2026-04-14 09:40:20.001`, and `2026-04-14 09:40:20+00`.
- [ ] Maintainer review: confirm the same wording is appropriate for the other doc files that mention this format if any (none referenced `restore-to-time` after grep).