### PR TITLE
fix: make create-replication action fail cleanly without async-replication relation

### DIFF
--- a/src/relations/async_replication.py
+++ b/src/relations/async_replication.py
@@ -567,6 +567,13 @@ class PostgreSQLAsyncReplication(Object):
             event.fail("There is already a replication set up.")
             return
 
+        if self._relation is None:
+            event.fail(
+                "No async-replication relation has been established."
+                " Create the offer and relate the two clusters before running this action."
+            )
+            return
+
         if self._relation.name == REPLICATION_CONSUMER_RELATION:
             event.fail("This action must be run in the cluster where the offer was created.")
             return

--- a/tests/unit/test_async_replication.py
+++ b/tests/unit/test_async_replication.py
@@ -578,9 +578,11 @@ def test_on_create_replication():
     relation = PostgreSQLAsyncReplication(mock_charm)
 
     relation._get_primary_cluster = MagicMock(return_value=None)
-    type(relation)._relation = PropertyMock(return_value=None)
 
-    result = relation._on_create_replication(mock_event)
+    with patch.object(
+        PostgreSQLAsyncReplication, "_relation", new_callable=PropertyMock, return_value=None
+    ):
+        result = relation._on_create_replication(mock_event)
 
     assert result is None
     mock_event.fail.assert_called_once_with(

--- a/tests/unit/test_async_replication.py
+++ b/tests/unit/test_async_replication.py
@@ -571,6 +571,23 @@ def test_on_create_replication():
 
     assert result is None
 
+    # 5. No async-replication relation established (regression for #1675).
+    mock_charm = MagicMock()
+    mock_event = MagicMock()
+
+    relation = PostgreSQLAsyncReplication(mock_charm)
+
+    relation._get_primary_cluster = MagicMock(return_value=None)
+    type(relation)._relation = PropertyMock(return_value=None)
+
+    result = relation._on_create_replication(mock_event)
+
+    assert result is None
+    mock_event.fail.assert_called_once_with(
+        "No async-replication relation has been established."
+        " Create the offer and relate the two clusters before running this action."
+    )
+
 
 def test_promote_to_primary():
     # 1.


### PR DESCRIPTION
## Issue

Closes #1675. Running `juju run postgresql/<unit> create-replication name=default` on a unit with no `async-replication` relation crashed with `AttributeError: 'NoneType' object has no attribute 'name'` because `_on_create_replication` dereferenced `self._relation.name` before checking that the relation existed.

## Solution

Guard `self._relation` for `None` and call `event.fail` with a clear message instructing the operator to create the offer and relate the clusters first. Added a regression test exercising the missing-relation path.

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.