### PR TITLE
[DPE-10017] Leader switchover update and faster topology cycle

### DIFF
--- a/refresh_versions.toml
+++ b/refresh_versions.toml
@@ -6,6 +6,6 @@ name = "charmed-postgresql"
 
 [snap.revisions]
 # amd64
-x86_64 = "289"
+x86_64 = "332"
 # arm64
-aarch64 = "288"
+aarch64 = "331"

--- a/scripts/cluster_topology_observer.py
+++ b/scripts/cluster_topology_observer.py
@@ -170,7 +170,7 @@ async def main():
             )
 
         # Wait some time before checking again for a cluster topology change.
-        sleep(30)
+        sleep(10)
 
 
 if __name__ == "__main__":

--- a/src/charm.py
+++ b/src/charm.py
@@ -436,6 +436,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         self._setup_exporter()
         self.backup.start_stop_pgbackrest_service()
         self._setup_pgbackrest_exporter()
+        self.watcher_offer.update_unit_address()
 
         # Wait until the database initialise.
         self.set_unit_status(WaitingStatus("waiting for database initialisation"), refresh=refresh)

--- a/src/charm.py
+++ b/src/charm.py
@@ -1996,6 +1996,9 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             try:
                 self._patroni.switchover(self._member_name)
                 self.unit_peer_data.update({"timestamp": str(datetime.now())})
+                if self.unit.is_leader():
+                    self.postgresql_client_relation.update_endpoints()
+                    self.async_replication.update_async_replication_data()
             except SwitchoverNotSyncError:
                 event.fail("Unit is not sync standby")
             except SwitchoverFailedError:

--- a/src/relations/watcher.py
+++ b/src/relations/watcher.py
@@ -414,7 +414,6 @@ class PostgreSQLWatcherRelation(Object):
         relation.data[self.charm.app].update({
             "cluster-name": self.charm.cluster_name,
             "raft-secret-id": secret_id,
-            "version": self.charm._patroni.get_postgresql_version(),
             "raft-partner-addrs": json.dumps(pg_endpoints),
             "raft-port": str(RAFT_PORT),
             "patroni-cas": self.charm.tls.get_peer_ca_bundle(),
@@ -439,27 +438,23 @@ class PostgreSQLWatcherRelation(Object):
         if not relation:
             return
 
-        unit_ip = self.charm._unit_ip
-        if unit_ip is None:
+        if not (unit_ip := self.charm._unit_ip):
             return
 
-        changed = False
+        relation.data[self.charm.unit]["version"] = self.charm._patroni.get_postgresql_version()
+        if self.charm.refresh:
+            relation.data[self.charm.unit]["snap"] = self.charm.refresh.pinned_snap_revision
         current_address = relation.data[self.charm.unit].get("unit-address")
         if current_address != unit_ip:
             logger.info(
                 f"Updating unit-address in watcher relation from {current_address} to {unit_ip}"
             )
             relation.data[self.charm.unit]["unit-address"] = unit_ip
-            changed = True
 
         unit_az = os.environ.get("JUJU_AVAILABILITY_ZONE")
         current_az = relation.data[self.charm.unit].get("unit-az")
         if unit_az and current_az != unit_az:
             relation.data[self.charm.unit]["unit-az"] = unit_az
-            changed = True
-
-        if changed:
-            logger.debug("Updated watcher relation unit data")
 
     def update_endpoints(self) -> None:
         """Update the watcher with current cluster endpoints.


### PR DESCRIPTION
* Update endpoints when switching over to the Juju leader
* Make the topology observer run every 10s
* Set snap and Postgresql version in the per unit data for the observer relation