### PR TITLE
[DPE-10012] Bump PostgreSQL to 14.23

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -40,7 +40,7 @@ POSTGRESQL_SNAP_NAME = "charmed-postgresql"
 SNAP_PACKAGES = [
     (
         POSTGRESQL_SNAP_NAME,
-        {"revision": {"aarch64": "280", "x86_64": "281"}},
+        {"revision": {"aarch64": "333", "x86_64": "334"}},
     )
 ]
 

--- a/src/dependency.json
+++ b/src/dependency.json
@@ -9,6 +9,6 @@
     "dependencies": {},
     "name": "charmed-postgresql",
     "upgrade_supported": "^14",
-    "version": "14.22"
+    "version": "14.23"
   }
 }


### PR DESCRIPTION
## Issue

New PostgreSQL 14.23 has been released with list of CVE fixes.

## Solution

Update PostgreSQL.