### PR TITLE
[DPE-10275] fix(tests): correct the location of the Harness cleanup

### DIFF
--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -175,12 +175,12 @@ def test_get_extensions(harness):
         default: false
         type: boolean"""
     harness = Harness(PostgresqlOperatorCharm, config=config)
-    harness.cleanup()
     harness.begin()
     assert harness.charm.legacy_db_relation._get_extensions(relation) == (
         [extensions[1], extensions[2]],
         {extensions[2]},
     )
+    harness.cleanup()
 
 
 def test_set_up_relation(harness):


### PR DESCRIPTION
## Issue

`test_get_extensions` called `cleanup()` on the Harness before using it, so `begin()` and the assertion ran against an already-cleaned harness. This only worked because of a Harness bug that leaves a dangling sqlite3 reference; the fix for that bug (canonical/operator#2507) makes `cleanup()` tear down properly and breaks the test.

## Solution

Call `cleanup()` once the harness is finished with instead.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.

Port of https://github.com/canonical/postgresql-k8s-operator/pull/1551.
