### PR TITLE
[DPE-10012] Bump PostgreSQL to 16.14 with new timescaledb-tsl

### DIFF
--- a/refresh_versions.toml
+++ b/refresh_versions.toml
@@ -1,11 +1,11 @@
 charm_major = 1
-workload = "16.13"
+workload = "16.14"
 
 [snap]
 name = "charmed-postgresql"
 
 [snap.revisions]
 # amd64
-x86_64 = "332"
+x86_64 = "350"
 # arm64
-aarch64 = "331"
+aarch64 = "349"

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -140,7 +140,7 @@ def test_get_patroni_health(peers_ips, patroni):
 
 
 def test_get_postgresql_version(peers_ips, patroni):
-    assert patroni.get_postgresql_version() == "16.13"
+    assert patroni.get_postgresql_version() == "16.14"
 
 
 def test_dict_to_hba_string(harness, patroni):


### PR DESCRIPTION
## Issue

PostgreSQL released a new version 16.14 we should use in charm.

## Solution

The new snap ships:
* PostgreSQL 16.14
* TimescaleDB rebuilt for PostgreSQL 16.14: 
> postgresql-16-timescaledb-tsl=2.18.2-0ubuntu0.24.04.5~ppa1
* the new snap also ships the CVE fix for libssh2-1t64: https://ubuntu.com/security/notices/USN-8309-1/
> libssh2-1t64=1.11.0-4.1ubuntu0.24.04.1