### PR TITLE
fix(backups): pass both stdout and stderr to _extract_error_message in _list_timelines

### DIFF
--- a/src/backups.py
+++ b/src/backups.py
@@ -567,7 +567,7 @@ class PostgreSQLBackups(Object):
             "--output=json",
         ])
         if return_code != 0:
-            extracted_error = self._extract_error_message(stderr)
+            extracted_error = self._extract_error_message(output, stderr)
             raise ListBackupsError(f"Failed to list repository with error: {extracted_error}")
 
         repository = json.loads(output).items()


### PR DESCRIPTION
`_extract_error_message` is declared as

    @staticmethod
    def _extract_error_message(stdout: str, stderr: str) -> str:

Every other call site in src/backups.py (lines 214, 457, 531, 747, 811, 1028, 1195) supplies both arguments. The `_list_timelines` call at line 570 was the lone exception:

    extracted_error = self._extract_error_message(stderr)

so whenever `pgbackrest repo-ls` returned a non-zero exit code, the error path raised

    TypeError: _extract_error_message() missing 1 required positional
    argument: 'stderr'

instead of the intended ListBackupsError, masking the underlying backup failure.

Pass the local `output` (stdout) variable as the first argument to match the surrounding convention.

Closes #1482.

Author: Sai Asish Y in https://github.com/canonical/postgresql-operator/pull/1666
Signed-off-by: SAY-5 in https://github.com/canonical/postgresql-operator/pull/1666
Signed-off-by: Sai Asish Y in https://github.com/canonical/postgresql-operator/pull/1666