### PR TITLE
[DPE-10283] test: remove redundant arch constraint from test_deploy_stable

### DIFF
--- a/tests/integration/high_availability/test_upgrade_skip_pre_upgrade_check.py
+++ b/tests/integration/high_availability/test_upgrade_skip_pre_upgrade_check.py
@@ -2,7 +2,6 @@
 # See LICENSE file for licensing details.
 
 import logging
-import platform
 
 import jubilant
 from jubilant import Juju
@@ -31,7 +30,6 @@ def test_deploy_stable(juju: Juju) -> None:
         base="ubuntu@24.04",
         channel="16/stable",
         config={"profile": "testing"},
-        constraints={"arch": "arm64"} if platform.machine() == "aarch64" else None,
         num_units=3,
     )
     juju.deploy(
@@ -39,7 +37,6 @@ def test_deploy_stable(juju: Juju) -> None:
         app=DB_TEST_APP_NAME,
         base="ubuntu@24.04",
         channel="latest/edge",
-        constraints={"arch": "arm64"} if platform.machine() == "aarch64" else None,
         num_units=1,
     )
 


### PR DESCRIPTION
## Issue

`test_deploy_stable` (in `tests/integration/high_availability/test_upgrade_skip_pre_upgrade_check.py`) pinned the deploy architecture conditionally on both of its deploys:

```python
constraints={"arch": "arm64"} if platform.machine() == "aarch64" else None,
```

This was a leftover from local testing on Apple Silicon (`aarch64`) and is redundant. Juju already infers the machine architecture from the test runner, and the sibling channel deploys in `test_upgrade.py` and `test_upgrade_from_stable.py` deploy the same charms with no arch constraint and pass on both architectures. Flagged in review of #1649.

## Solution

Remove the conditional `constraints=...` from both deploys in `test_deploy_stable`, along with the now-unused `import platform`.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
