### PR TITLE
[DPE-9737] fix(storage): chown versioned data parent so patronictl reinit can rebuild a replica

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -698,7 +698,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         return "stopped" in self.unit_peer_data
 
     def _ensure_storage_layout(self) -> None:
-        """Ensure the temp tablespace directory exists.
+        """Ensure the temp tablespace dir exists and versioned parents are _daemon_-owned.
 
         Data migration between storage roots and versioned 16/main
         subdirectories is handled by the snap hooks (pre-refresh for
@@ -707,16 +707,23 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         unconditionally.  CREATE TABLESPACE requires the directory to
         be writable by the PostgreSQL _daemon_ user, so we chown it.
 
-        The 16/ parent dir must also be _daemon_-owned: the snap daemon
-        runs as _daemon_ and needs write permission to clean up the
-        versioned subdirectory and run DROP/CREATE TABLESPACE during
-        rollback (handled by the snap's pre-refresh hook).
+        The 16/ parent dirs must also be _daemon_-owned: the snap daemon
+        runs as _daemon_ and needs write permission on the parent to
+        remove/rename the versioned subdirectory.  Without this, the temp
+        parent breaks DROP/CREATE TABLESPACE during rollback, and the data
+        parent breaks ``patronictl reinit`` (Patroni can only empty 16/main,
+        not remove it, logging permission errors).  The snap's
+        migrate-data.sh creates these parents as root, so we fix them here.
         """
         temp_dir = Path(TEMP_DATA_DIR)
         temp_dir.mkdir(parents=True, exist_ok=True)
         shutil.chown(temp_dir, user=SNAP_DAEMON_USER, group=SNAP_DAEMON_USER)
         if temp_dir.parent.exists():
             shutil.chown(temp_dir.parent, user=SNAP_DAEMON_USER, group=SNAP_DAEMON_USER)
+
+        data_parent = Path(POSTGRESQL_DATA_DIR).parent
+        if data_parent.exists():
+            shutil.chown(data_parent, user=SNAP_DAEMON_USER, group=SNAP_DAEMON_USER)
 
     def _resolve_primary_host(self) -> str | None:
         """Wait for Patroni to settle and return the primary host.

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -229,6 +229,8 @@ class Patroni:
     def configure_patroni_on_unit(self):
         """Configure Patroni (configuration files and service) on the unit."""
         os.makedirs(POSTGRESQL_DATA_DIR, exist_ok=True)
+        # Parent must be _daemon_-owned so Patroni can rename/remove the data dir on reinit.
+        _change_owner(Substrates.VM, os.path.dirname(POSTGRESQL_DATA_DIR))
         _change_owner(Substrates.VM, POSTGRESQL_DATA_DIR)
 
         # Create empty base config

--- a/tests/integration/high_availability/high_availability_helpers_new.py
+++ b/tests/integration/high_availability/high_availability_helpers_new.py
@@ -188,6 +188,13 @@ def get_db_standby_leader_unit(juju: Juju, app_name: str) -> str:
     raise Exception("No standby primary node found")
 
 
+def get_member_state(juju: Juju, app_name: str, member_name: str) -> str | None:
+    """Return a cluster member's reported state from the leader's /cluster endpoint."""
+    unit_address = get_unit_ip(juju, app_name, get_app_leader(juju, app_name))
+    members = requests.get(f"https://{unit_address}:8008/cluster", verify=False).json()["members"]
+    return next((member["state"] for member in members if member["name"] == member_name), None)
+
+
 def get_db_max_written_value(
     juju: Juju, app_name: str, unit_name: str, db_name: str = "postgresql_test_app_database"
 ) -> int:

--- a/tests/integration/high_availability/test_patroni_reinit.py
+++ b/tests/integration/high_availability/test_patroni_reinit.py
@@ -5,7 +5,6 @@
 import logging
 
 import jubilant
-import requests
 from jubilant import Juju
 from tenacity import Retrying, retry_if_exception, stop_after_delay, wait_fixed
 
@@ -16,7 +15,6 @@ from .high_availability_helpers_new import (
     get_app_units,
     get_db_primary_unit,
     get_member_state,
-    get_unit_ip,
     wait_for_apps_status,
 )
 
@@ -95,10 +93,7 @@ def test_patroni_reinit_after_pg_control_deletion(juju: Juju, continuous_writes)
 
     logger.info("Primary: %s | Replica under test: %s", primary_unit, replica_unit)
 
-    replica_ip = get_unit_ip(juju, DB_APP_NAME, replica_unit)
-
     replica_member_name = replica_unit.replace("/", "-")
-    cluster_name = DB_APP_NAME
 
     logger.info("Verifying continuous writes are flowing")
     check_db_units_writes_increment(juju, DB_APP_NAME)
@@ -125,6 +120,10 @@ def test_patroni_reinit_after_pg_control_deletion(juju: Juju, continuous_writes)
     juju.ssh(replica_unit, "sudo systemctl start snap.charmed-postgresql.patroni")
 
     logger.info("Confirming pg_control deletion broke replica %s (not streaming)", replica_unit)
+    pg_control_failure_grep = (
+        "sudo grep -iEh 'error when calling pg_controldata|system ID is invalid' "
+        f"{PATRONI_LOGS_PATH}/patroni.log* 2>/dev/null || true"
+    )
     broken_state: str | None = None
     for attempt in Retrying(
         stop=stop_after_delay(3 * MINUTE_SECS), wait=wait_fixed(5), reraise=True
@@ -138,23 +137,16 @@ def test_patroni_reinit_after_pg_control_deletion(juju: Juju, continuous_writes)
                 f"Replica {replica_unit} not yet present-and-broken ({broken_state!r}); expected it "
                 "registered but not running/streaming before reinit"
             )
+            assert juju.ssh(replica_unit, pg_control_failure_grep).strip(), (
+                f"Patroni on {replica_unit} has not logged a pg_control startup failure; the "
+                "pg_control deletion may not have broken PostgreSQL startup"
+            )
     logger.info("Replica %s broken (state=%r) before reinit", replica_unit, broken_state)
-
-    logger.info(
-        "Waiting for %s Patroni REST API to accept connections before reinit", replica_unit
-    )
-    for attempt in Retrying(
-        stop=stop_after_delay(2 * MINUTE_SECS), wait=wait_fixed(5), reraise=True
-    ):
-        with attempt:
-            # Any HTTP response means the API is listening; we only need it reachable so
-            # patronictl's POST /reinitialize is not connection-refused.
-            requests.get(f"https://{replica_ip}:8008/patroni", verify=False)
 
     logger.info("Running patronictl reinit on %s", replica_unit)
     patronictl_cmd = (
         f"sudo charmed-postgresql.patronictl -c {PATRONI_CONF_PATH}/patroni.yaml "
-        f"reinit {cluster_name} {replica_member_name} --force"
+        f"reinit {DB_APP_NAME} {replica_member_name} --force"
     )
     # Retry transient reinit failures (member not yet re-registered, or its REST API not yet
     # listening after the restart) until Patroni accepts the request.

--- a/tests/integration/high_availability/test_patroni_reinit.py
+++ b/tests/integration/high_availability/test_patroni_reinit.py
@@ -3,14 +3,13 @@
 """Integration test: replica reinit after pg_control corruption via patronictl reinit."""
 
 import logging
-import time
 
 import jubilant
 import requests
 from jubilant import Juju
 from tenacity import Retrying, stop_after_delay, wait_fixed
 
-from constants import PATRONI_CONF_PATH, POSTGRESQL_DATA_DIR
+from constants import PATRONI_CONF_PATH, PATRONI_LOGS_PATH, POSTGRESQL_DATA_DIR
 
 from .high_availability_helpers_new import (
     MINUTE_SECS,
@@ -68,12 +67,14 @@ def test_patroni_reinit_after_pg_control_deletion(juju: Juju, continuous_writes)
 
     Steps:
     1. Confirm the cluster is healthy and continuous writes are flowing.
-    2. Stop Patroni on a replica, delete pg_control, then restart Patroni so that
-       PostgreSQL fails to start due to the missing control file.
-    3. Verify Patroni logs record a pg_control startup failure.
+    2. Stop Patroni on a replica (waiting until it is fully stopped), delete pg_control,
+       then restart Patroni so that PostgreSQL fails to start due to the missing control file.
+    3. Verify Patroni logs record a pg_control startup failure and that the replica is no
+       longer streaming, so the test cannot falsely pass on a still-healthy replica.
     4. Run ``patronictl reinit`` to restore the replica from the primary.
-    5. Confirm the replica recovers, that pg_control is present in the data directory,
-       and that data integrity is maintained across all units.
+    5. Confirm the replica returns to the streaming state, that reinit did not log
+       data-directory permission errors, that pg_control is present, and that data
+       integrity is maintained across all units.
     """
     logger.info("Identifying primary and replica units")
     primary_unit = get_db_primary_unit(juju, DB_APP_NAME)
@@ -87,6 +88,12 @@ def test_patroni_reinit_after_pg_control_deletion(juju: Juju, continuous_writes)
 
     replica_member_name = replica_unit.replace("/", "-")
     cluster_name = DB_APP_NAME
+
+    def get_member_state() -> str | None:
+        """Return the replica's reported state from the primary's /cluster endpoint."""
+        cluster_resp = requests.get(f"https://{primary_ip}:8008/cluster", verify=False)
+        members = cluster_resp.json()["members"]
+        return next((m["state"] for m in members if m["name"] == replica_member_name), None)
 
     logger.info("Verifying initial health of replica %s", replica_unit)
     for attempt in Retrying(stop=stop_after_delay(60), wait=wait_fixed(5), reraise=True):
@@ -102,31 +109,36 @@ def test_patroni_reinit_after_pg_control_deletion(juju: Juju, continuous_writes)
     logger.info("Stopping Patroni on %s", replica_unit)
     juju.ssh(replica_unit, "sudo systemctl stop snap.charmed-postgresql.patroni")
 
+    logger.info("Waiting for Patroni to stop on %s before deleting pg_control", replica_unit)
+    for attempt in Retrying(stop=stop_after_delay(MINUTE_SECS), wait=wait_fixed(3), reraise=True):
+        with attempt:
+            active_state = juju.ssh(
+                replica_unit,
+                "systemctl is-active snap.charmed-postgresql.patroni || true",
+            ).strip()
+            assert active_state != "active", (
+                f"Patroni still active on {replica_unit} ({active_state!r}); refusing to delete "
+                "pg_control while PostgreSQL may still be running"
+            )
+
     logger.info("Deleting pg_control at %s on %s", PG_CONTROL_PATH, replica_unit)
     juju.ssh(replica_unit, f"sudo rm {PG_CONTROL_PATH}")
 
     logger.info("Starting Patroni on %s (pg_control is now missing)", replica_unit)
     juju.ssh(replica_unit, "sudo systemctl start snap.charmed-postgresql.patroni")
 
-    time.sleep(10)
-
-    logger.info("Verifying Patroni logs show a pg_control startup failure on %s", replica_unit)
+    logger.info("Confirming pg_control deletion broke replica %s (not streaming)", replica_unit)
+    broken_state: str | None = None
     for attempt in Retrying(
         stop=stop_after_delay(2 * MINUTE_SECS), wait=wait_fixed(5), reraise=True
     ):
         with attempt:
-            logs = juju.ssh(
-                replica_unit,
-                "sudo journalctl -u snap.charmed-postgresql.patroni --no-pager -n 200 2>&1",
+            broken_state = get_member_state()
+            assert broken_state not in ("running", "streaming"), (
+                f"Replica {replica_unit} unexpectedly healthy ({broken_state!r}) before reinit; "
+                "pg_control deletion did not break it, so the test would falsely pass"
             )
-            assert "pg_control" in logs.lower(), (
-                f"Expected Patroni logs on {replica_unit} to contain a pg_control error; "
-                f"last 1000 chars of logs: {logs[-1000:]!r}"
-            )
-
-    logger.info(
-        "Confirmed pg_control startup failure recorded in Patroni logs on %s", replica_unit
-    )
+    logger.info("Replica %s broken (state=%r) before reinit", replica_unit, broken_state)
 
     logger.info("Running patronictl reinit on %s", replica_unit)
     patronictl_cmd = (
@@ -135,28 +147,30 @@ def test_patroni_reinit_after_pg_control_deletion(juju: Juju, continuous_writes)
     )
     juju.ssh(replica_unit, patronictl_cmd)
 
-    logger.info("Waiting for %s to recover after patronictl reinit", replica_unit)
+    logger.info("Waiting for %s to reach the streaming state after reinit", replica_unit)
     for attempt in Retrying(
         stop=stop_after_delay(5 * MINUTE_SECS), wait=wait_fixed(10), reraise=True
     ):
         with attempt:
-            resp = requests.get(f"https://{replica_ip}:8008/health", verify=False)
-            assert resp.status_code == 200, (
-                f"Replica {replica_unit} still unhealthy after reinit: HTTP {resp.status_code}"
-            )
-
-    for attempt in Retrying(stop=stop_after_delay(60), wait=wait_fixed(5), reraise=True):
-        with attempt:
-            cluster_resp = requests.get(f"https://{primary_ip}:8008/cluster", verify=False)
-            members = cluster_resp.json()["members"]
-            replica_state = next(
-                (m["state"] for m in members if m["name"] == replica_member_name), None
-            )
-            assert replica_state in ("running", "streaming"), (
+            replica_state = get_member_state()
+            assert replica_state == "streaming", (
                 f"Replica {replica_unit} not streaming after reinit: {replica_state!r}"
             )
+    logger.info("Replica %s is streaming after reinit", replica_unit)
 
-    logger.info("Replica %s is healthy and streaming after reinit", replica_unit)
+    logger.info("Checking reinit logged no data-directory permission errors on %s", replica_unit)
+    permission_error_grep = (
+        "sudo grep -iEh "
+        "'could not remove data directory|could not rename data directory|permissionerror' "
+        f"{PATRONI_LOGS_PATH}/patroni.log* 2>/dev/null || true"
+    )
+    permission_errors = juju.ssh(replica_unit, permission_error_grep).strip()
+    assert not permission_errors, (
+        f"patronictl reinit on {replica_unit} logged data-directory permission failures; the "
+        "versioned-storage parent directory is not writable by the PostgreSQL user. "
+        f"Matching Patroni log lines:\n{permission_errors}"
+    )
+    logger.info("No data-directory permission errors logged during reinit on %s", replica_unit)
 
     logger.info("Verifying pg_control exists in data directory of %s after reinit", replica_unit)
     result = juju.ssh(

--- a/tests/integration/high_availability/test_patroni_reinit.py
+++ b/tests/integration/high_availability/test_patroni_reinit.py
@@ -1,0 +1,175 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""Integration test: replica reinit after pg_control corruption via patronictl reinit."""
+
+import logging
+import time
+
+import jubilant
+import requests
+from jubilant import Juju
+from tenacity import Retrying, stop_after_delay, wait_fixed
+
+from constants import PATRONI_CONF_PATH, POSTGRESQL_DATA_DIR
+
+from .high_availability_helpers_new import (
+    MINUTE_SECS,
+    check_db_units_writes_increment,
+    get_app_units,
+    get_db_primary_unit,
+    get_unit_ip,
+    wait_for_apps_status,
+)
+
+logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
+logger = logging.getLogger(__name__)
+
+DB_APP_NAME = "postgresql"
+DB_TEST_APP_NAME = "postgresql-test-app"
+
+PG_CONTROL_PATH = f"{POSTGRESQL_DATA_DIR}/global/pg_control"
+
+
+def test_deploy(juju: Juju, charm: str) -> None:
+    """Deploy a 3-unit PostgreSQL cluster and the continuous-writes test application."""
+    logger.info("Deploying PostgreSQL cluster (%s, 3 units)", DB_APP_NAME)
+    juju.deploy(
+        charm=charm,
+        app=DB_APP_NAME,
+        base="ubuntu@24.04",
+        config={"profile": "testing"},
+        num_units=3,
+    )
+
+    logger.info("Deploying test application (%s)", DB_TEST_APP_NAME)
+    juju.deploy(
+        charm=DB_TEST_APP_NAME,
+        app=DB_TEST_APP_NAME,
+        base="ubuntu@24.04",
+        channel="latest/edge",
+        num_units=1,
+    )
+
+    juju.integrate(f"{DB_APP_NAME}:database", f"{DB_TEST_APP_NAME}:database")
+
+    logger.info("Waiting for all applications to become active")
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active, DB_APP_NAME, DB_TEST_APP_NAME),
+        timeout=20 * MINUTE_SECS,
+    )
+
+
+def test_patroni_reinit_after_pg_control_deletion(juju: Juju, continuous_writes) -> None:
+    """Verify a replica reinitialises correctly after pg_control deletion and patronictl reinit.
+
+    This validates that the versioned storage layout (data under 16/main subdirectories)
+    works correctly with Patroni's reinit operation, which was previously broken when
+    data lived at the mount point roots.
+
+    Steps:
+    1. Confirm the cluster is healthy and continuous writes are flowing.
+    2. Stop Patroni on a replica, delete pg_control, then restart Patroni so that
+       PostgreSQL fails to start due to the missing control file.
+    3. Verify Patroni logs record a pg_control startup failure.
+    4. Run ``patronictl reinit`` to restore the replica from the primary.
+    5. Confirm the replica recovers, that pg_control is present in the data directory,
+       and that data integrity is maintained across all units.
+    """
+    logger.info("Identifying primary and replica units")
+    primary_unit = get_db_primary_unit(juju, DB_APP_NAME)
+    all_units = get_app_units(juju, DB_APP_NAME)
+    replica_unit = next(unit for unit in all_units if unit != primary_unit)
+
+    logger.info("Primary: %s | Replica under test: %s", primary_unit, replica_unit)
+
+    primary_ip = get_unit_ip(juju, DB_APP_NAME, primary_unit)
+    replica_ip = get_unit_ip(juju, DB_APP_NAME, replica_unit)
+
+    replica_member_name = replica_unit.replace("/", "-")
+    cluster_name = DB_APP_NAME
+
+    logger.info("Verifying initial health of replica %s", replica_unit)
+    for attempt in Retrying(stop=stop_after_delay(60), wait=wait_fixed(5), reraise=True):
+        with attempt:
+            resp = requests.get(f"https://{replica_ip}:8008/health", verify=False)
+            assert resp.status_code == 200, (
+                f"Replica {replica_unit} unhealthy before test: HTTP {resp.status_code}"
+            )
+
+    logger.info("Verifying continuous writes are flowing")
+    check_db_units_writes_increment(juju, DB_APP_NAME)
+
+    logger.info("Stopping Patroni on %s", replica_unit)
+    juju.ssh(replica_unit, "sudo systemctl stop snap.charmed-postgresql.patroni")
+
+    logger.info("Deleting pg_control at %s on %s", PG_CONTROL_PATH, replica_unit)
+    juju.ssh(replica_unit, f"sudo rm {PG_CONTROL_PATH}")
+
+    logger.info("Starting Patroni on %s (pg_control is now missing)", replica_unit)
+    juju.ssh(replica_unit, "sudo systemctl start snap.charmed-postgresql.patroni")
+
+    time.sleep(10)
+
+    logger.info("Verifying Patroni logs show a pg_control startup failure on %s", replica_unit)
+    for attempt in Retrying(
+        stop=stop_after_delay(2 * MINUTE_SECS), wait=wait_fixed(5), reraise=True
+    ):
+        with attempt:
+            logs = juju.ssh(
+                replica_unit,
+                "sudo journalctl -u snap.charmed-postgresql.patroni --no-pager -n 200 2>&1",
+            )
+            assert "pg_control" in logs.lower(), (
+                f"Expected Patroni logs on {replica_unit} to contain a pg_control error; "
+                f"last 1000 chars of logs: {logs[-1000:]!r}"
+            )
+
+    logger.info(
+        "Confirmed pg_control startup failure recorded in Patroni logs on %s", replica_unit
+    )
+
+    logger.info("Running patronictl reinit on %s", replica_unit)
+    patronictl_cmd = (
+        f"sudo charmed-postgresql.patronictl -c {PATRONI_CONF_PATH}/patroni.yaml "
+        f"reinit {cluster_name} {replica_member_name} --force"
+    )
+    juju.ssh(replica_unit, patronictl_cmd)
+
+    logger.info("Waiting for %s to recover after patronictl reinit", replica_unit)
+    for attempt in Retrying(
+        stop=stop_after_delay(5 * MINUTE_SECS), wait=wait_fixed(10), reraise=True
+    ):
+        with attempt:
+            resp = requests.get(f"https://{replica_ip}:8008/health", verify=False)
+            assert resp.status_code == 200, (
+                f"Replica {replica_unit} still unhealthy after reinit: HTTP {resp.status_code}"
+            )
+
+    for attempt in Retrying(stop=stop_after_delay(60), wait=wait_fixed(5), reraise=True):
+        with attempt:
+            cluster_resp = requests.get(f"https://{primary_ip}:8008/cluster", verify=False)
+            members = cluster_resp.json()["members"]
+            replica_state = next(
+                (m["state"] for m in members if m["name"] == replica_member_name), None
+            )
+            assert replica_state in ("running", "streaming"), (
+                f"Replica {replica_unit} not streaming after reinit: {replica_state!r}"
+            )
+
+    logger.info("Replica %s is healthy and streaming after reinit", replica_unit)
+
+    logger.info("Verifying pg_control exists in data directory of %s after reinit", replica_unit)
+    result = juju.ssh(
+        replica_unit,
+        f"sudo test -f {PG_CONTROL_PATH} && echo exists || echo missing",
+    )
+    assert "exists" in result, (
+        f"pg_control is missing from {replica_unit} after reinit (expected at {PG_CONTROL_PATH})"
+    )
+    logger.info("pg_control is present at %s on %s", PG_CONTROL_PATH, replica_unit)
+
+    logger.info("Verifying data integrity on all units after reinit")
+    check_db_units_writes_increment(juju, DB_APP_NAME)
+    logger.info(
+        "Data integrity verified: all units (including %s) have consistent data", replica_unit
+    )

--- a/tests/integration/high_availability/test_patroni_reinit.py
+++ b/tests/integration/high_availability/test_patroni_reinit.py
@@ -31,7 +31,7 @@ PG_CONTROL_PATH = f"{POSTGRESQL_DATA_DIR}/global/pg_control"
 
 def _reinit_transiently_failed(exc: BaseException) -> bool:
     """Return True for transient reinit failures that clear once Patroni settles."""
-    text = f"{exc} {getattr(exc, 'stderr', '') or ''} {getattr(exc, 'stdout', '') or ''}"
+    text = str(exc)  # jubilant's CLIError.__str__ already includes stdout and stderr
     # Member not yet re-registered in the cluster after the restart.
     if "No replica among provided members" in text:
         return True

--- a/tests/integration/high_availability/test_patroni_reinit.py
+++ b/tests/integration/high_availability/test_patroni_reinit.py
@@ -12,10 +12,10 @@ from tenacity import Retrying, retry_if_exception, stop_after_delay, wait_fixed
 from constants import PATRONI_CONF_PATH, PATRONI_LOGS_PATH, POSTGRESQL_DATA_DIR
 
 from .high_availability_helpers_new import (
-    MINUTE_SECS,
     check_db_units_writes_increment,
     get_app_units,
     get_db_primary_unit,
+    get_member_state,
     get_unit_ip,
     wait_for_apps_status,
 )
@@ -25,6 +25,8 @@ logger = logging.getLogger(__name__)
 
 DB_APP_NAME = "postgresql"
 DB_TEST_APP_NAME = "postgresql-test-app"
+
+MINUTE_SECS = 60
 
 PG_CONTROL_PATH = f"{POSTGRESQL_DATA_DIR}/global/pg_control"
 
@@ -93,25 +95,10 @@ def test_patroni_reinit_after_pg_control_deletion(juju: Juju, continuous_writes)
 
     logger.info("Primary: %s | Replica under test: %s", primary_unit, replica_unit)
 
-    primary_ip = get_unit_ip(juju, DB_APP_NAME, primary_unit)
     replica_ip = get_unit_ip(juju, DB_APP_NAME, replica_unit)
 
     replica_member_name = replica_unit.replace("/", "-")
     cluster_name = DB_APP_NAME
-
-    def get_member_state() -> str | None:
-        """Return the replica's reported state from the primary's /cluster endpoint."""
-        cluster_resp = requests.get(f"https://{primary_ip}:8008/cluster", verify=False)
-        members = cluster_resp.json()["members"]
-        return next((m["state"] for m in members if m["name"] == replica_member_name), None)
-
-    logger.info("Verifying initial health of replica %s", replica_unit)
-    for attempt in Retrying(stop=stop_after_delay(60), wait=wait_fixed(5), reraise=True):
-        with attempt:
-            resp = requests.get(f"https://{replica_ip}:8008/health", verify=False)
-            assert resp.status_code == 200, (
-                f"Replica {replica_unit} unhealthy before test: HTTP {resp.status_code}"
-            )
 
     logger.info("Verifying continuous writes are flowing")
     check_db_units_writes_increment(juju, DB_APP_NAME)
@@ -143,7 +130,7 @@ def test_patroni_reinit_after_pg_control_deletion(juju: Juju, continuous_writes)
         stop=stop_after_delay(3 * MINUTE_SECS), wait=wait_fixed(5), reraise=True
     ):
         with attempt:
-            broken_state = get_member_state()
+            broken_state = get_member_state(juju, DB_APP_NAME, replica_member_name)
             # Reject None: right after restart the member is briefly absent from the cluster
             # (its DCS key TTL-expires while PostgreSQL fails to start), and reinit cannot
             # target an absent member ("No replica among provided members").
@@ -185,7 +172,7 @@ def test_patroni_reinit_after_pg_control_deletion(juju: Juju, continuous_writes)
         stop=stop_after_delay(5 * MINUTE_SECS), wait=wait_fixed(10), reraise=True
     ):
         with attempt:
-            replica_state = get_member_state()
+            replica_state = get_member_state(juju, DB_APP_NAME, replica_member_name)
             assert replica_state == "streaming", (
                 f"Replica {replica_unit} not streaming after reinit: {replica_state!r}"
             )

--- a/tests/integration/high_availability/test_patroni_reinit.py
+++ b/tests/integration/high_availability/test_patroni_reinit.py
@@ -7,7 +7,7 @@ import logging
 import jubilant
 import requests
 from jubilant import Juju
-from tenacity import Retrying, stop_after_delay, wait_fixed
+from tenacity import Retrying, retry_if_exception, stop_after_delay, wait_fixed
 
 from constants import PATRONI_CONF_PATH, PATRONI_LOGS_PATH, POSTGRESQL_DATA_DIR
 
@@ -27,6 +27,16 @@ DB_APP_NAME = "postgresql"
 DB_TEST_APP_NAME = "postgresql-test-app"
 
 PG_CONTROL_PATH = f"{POSTGRESQL_DATA_DIR}/global/pg_control"
+
+
+def _reinit_transiently_failed(exc: BaseException) -> bool:
+    """Return True for transient reinit failures that clear once Patroni settles."""
+    text = f"{exc} {getattr(exc, 'stderr', '') or ''} {getattr(exc, 'stdout', '') or ''}"
+    # Member not yet re-registered in the cluster after the restart.
+    if "No replica among provided members" in text:
+        return True
+    # The target's REST API was briefly not listening right after the restart.
+    return "Connection refused" in text and "/reinitialize" in text
 
 
 def test_deploy(juju: Juju, charm: str) -> None:
@@ -130,22 +140,45 @@ def test_patroni_reinit_after_pg_control_deletion(juju: Juju, continuous_writes)
     logger.info("Confirming pg_control deletion broke replica %s (not streaming)", replica_unit)
     broken_state: str | None = None
     for attempt in Retrying(
-        stop=stop_after_delay(2 * MINUTE_SECS), wait=wait_fixed(5), reraise=True
+        stop=stop_after_delay(3 * MINUTE_SECS), wait=wait_fixed(5), reraise=True
     ):
         with attempt:
             broken_state = get_member_state()
-            assert broken_state not in ("running", "streaming"), (
-                f"Replica {replica_unit} unexpectedly healthy ({broken_state!r}) before reinit; "
-                "pg_control deletion did not break it, so the test would falsely pass"
+            # Reject None: right after restart the member is briefly absent from the cluster
+            # (its DCS key TTL-expires while PostgreSQL fails to start), and reinit cannot
+            # target an absent member ("No replica among provided members").
+            assert broken_state is not None and broken_state not in ("running", "streaming"), (
+                f"Replica {replica_unit} not yet present-and-broken ({broken_state!r}); expected it "
+                "registered but not running/streaming before reinit"
             )
     logger.info("Replica %s broken (state=%r) before reinit", replica_unit, broken_state)
+
+    logger.info(
+        "Waiting for %s Patroni REST API to accept connections before reinit", replica_unit
+    )
+    for attempt in Retrying(
+        stop=stop_after_delay(2 * MINUTE_SECS), wait=wait_fixed(5), reraise=True
+    ):
+        with attempt:
+            # Any HTTP response means the API is listening; we only need it reachable so
+            # patronictl's POST /reinitialize is not connection-refused.
+            requests.get(f"https://{replica_ip}:8008/patroni", verify=False)
 
     logger.info("Running patronictl reinit on %s", replica_unit)
     patronictl_cmd = (
         f"sudo charmed-postgresql.patronictl -c {PATRONI_CONF_PATH}/patroni.yaml "
         f"reinit {cluster_name} {replica_member_name} --force"
     )
-    juju.ssh(replica_unit, patronictl_cmd)
+    # Retry transient reinit failures (member not yet re-registered, or its REST API not yet
+    # listening after the restart) until Patroni accepts the request.
+    for attempt in Retrying(
+        stop=stop_after_delay(3 * MINUTE_SECS),
+        wait=wait_fixed(10),
+        retry=retry_if_exception(_reinit_transiently_failed),
+        reraise=True,
+    ):
+        with attempt:
+            juju.ssh(replica_unit, patronictl_cmd)
 
     logger.info("Waiting for %s to reach the streaming state after reinit", replica_unit)
     for attempt in Retrying(

--- a/tests/integration/high_availability/test_patroni_reinit.py
+++ b/tests/integration/high_availability/test_patroni_reinit.py
@@ -3,6 +3,7 @@
 """Integration test: replica reinit after pg_control corruption via patronictl reinit."""
 
 import logging
+import subprocess
 
 import jubilant
 from jubilant import Juju
@@ -37,6 +38,17 @@ def _reinit_transiently_failed(exc: BaseException) -> bool:
         return True
     # The target's REST API was briefly not listening right after the restart.
     return "Connection refused" in text and "/reinitialize" in text
+
+
+def _grep_patroni_logs(juju: Juju, unit: str, pattern: str) -> str:
+    """Return matching Patroni log lines on the unit, or "" when grep finds none (exit 1)."""
+    command = f"sudo grep -iEh '{pattern}' {PATRONI_LOGS_PATH}/patroni.log*"
+    try:
+        return juju.ssh(unit, command).strip()
+    except subprocess.CalledProcessError as exc:
+        if exc.returncode == 1:  # grep exit 1 means no lines matched
+            return ""
+        raise
 
 
 def test_deploy(juju: Juju, charm: str) -> None:
@@ -104,11 +116,15 @@ def test_patroni_reinit_after_pg_control_deletion(juju: Juju, continuous_writes)
     logger.info("Waiting for Patroni to stop on %s before deleting pg_control", replica_unit)
     for attempt in Retrying(stop=stop_after_delay(MINUTE_SECS), wait=wait_fixed(3), reraise=True):
         with attempt:
-            active_state = juju.ssh(
-                replica_unit,
-                "systemctl is-active snap.charmed-postgresql.patroni || true",
-            ).strip()
-            assert active_state != "active", (
+            # `systemctl is-active` prints the state on stdout and exits non-zero once the
+            # service is no longer active; read that state whatever the exit code.
+            try:
+                active_state = juju.ssh(
+                    replica_unit, "systemctl is-active snap.charmed-postgresql.patroni"
+                ).strip()
+            except subprocess.CalledProcessError as exc:
+                active_state = (exc.stdout or "").strip()
+            assert active_state and active_state != "active", (
                 f"Patroni still active on {replica_unit} ({active_state!r}); refusing to delete "
                 "pg_control while PostgreSQL may still be running"
             )
@@ -120,10 +136,6 @@ def test_patroni_reinit_after_pg_control_deletion(juju: Juju, continuous_writes)
     juju.ssh(replica_unit, "sudo systemctl start snap.charmed-postgresql.patroni")
 
     logger.info("Confirming pg_control deletion broke replica %s (not streaming)", replica_unit)
-    pg_control_failure_grep = (
-        "sudo grep -iEh 'error when calling pg_controldata|system ID is invalid' "
-        f"{PATRONI_LOGS_PATH}/patroni.log* 2>/dev/null || true"
-    )
     broken_state: str | None = None
     for attempt in Retrying(
         stop=stop_after_delay(3 * MINUTE_SECS), wait=wait_fixed(5), reraise=True
@@ -137,7 +149,9 @@ def test_patroni_reinit_after_pg_control_deletion(juju: Juju, continuous_writes)
                 f"Replica {replica_unit} not yet present-and-broken ({broken_state!r}); expected it "
                 "registered but not running/streaming before reinit"
             )
-            assert juju.ssh(replica_unit, pg_control_failure_grep).strip(), (
+            assert _grep_patroni_logs(
+                juju, replica_unit, "error when calling pg_controldata|system ID is invalid"
+            ), (
                 f"Patroni on {replica_unit} has not logged a pg_control startup failure; the "
                 "pg_control deletion may not have broken PostgreSQL startup"
             )
@@ -171,12 +185,11 @@ def test_patroni_reinit_after_pg_control_deletion(juju: Juju, continuous_writes)
     logger.info("Replica %s is streaming after reinit", replica_unit)
 
     logger.info("Checking reinit logged no data-directory permission errors on %s", replica_unit)
-    permission_error_grep = (
-        "sudo grep -iEh "
-        "'could not remove data directory|could not rename data directory|permissionerror' "
-        f"{PATRONI_LOGS_PATH}/patroni.log* 2>/dev/null || true"
+    permission_errors = _grep_patroni_logs(
+        juju,
+        replica_unit,
+        "could not remove data directory|could not rename data directory|permissionerror",
     )
-    permission_errors = juju.ssh(replica_unit, permission_error_grep).strip()
     assert not permission_errors, (
         f"patronictl reinit on {replica_unit} logged data-directory permission failures; the "
         "versioned-storage parent directory is not writable by the PostgreSQL user. "

--- a/tests/spread/test_patroni_reinit.py/task.yaml
+++ b/tests/spread/test_patroni_reinit.py/task.yaml
@@ -1,0 +1,7 @@
+summary: test_patroni_reinit.py
+environment:
+  TEST_MODULE: high_availability/test_patroni_reinit.py
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -650,21 +650,33 @@ def test_on_start_after_blocked_state(harness):
 
 
 def test_ensure_storage_layout(harness, tmp_path):
-    """_ensure_storage_layout creates TEMP_DATA_DIR only.
+    """_ensure_storage_layout creates TEMP_DATA_DIR and chowns the versioned parents.
 
     Data migration between storage roots and versioned paths is handled
-    by the snap hooks — the charm only ensures TEMP_DATA_DIR exists
-    (it may live on a tmpfs mount that is wiped on reboot).
+    by the snap hooks.  The charm ensures TEMP_DATA_DIR exists (it may live
+    on a tmpfs mount that is wiped on reboot) and makes the 16/ parent of
+    both the temp and the data dirs _daemon_-owned, so Patroni can remove
+    the versioned subdirectory (e.g. during patronictl reinit).
     """
     temp_root = tmp_path / "temp" / "16" / "main"
+    data_root = tmp_path / "data" / "16" / "main"
+    # The snap's migrate-data.sh creates the data parent (as root); the
+    # charm only fixes its ownership, it does not create the data dir.
+    data_root.parent.mkdir(parents=True)
     with (
         patch("charm.TEMP_DATA_DIR", str(temp_root)),
-        patch("charm.shutil"),
+        patch("charm.POSTGRESQL_DATA_DIR", str(data_root)),
+        patch("charm.shutil") as mock_shutil,
     ):
         harness.charm._ensure_storage_layout()
     assert temp_root.is_dir()
-    # No other dirs should be created by the charm.
-    assert not (tmp_path / "data").exists()
+    # The charm does not create the data dir leaf — only the snap does.
+    assert not data_root.exists()
+    # Both versioned 16/ parents (and the temp leaf) are chowned to _daemon_.
+    chowned = {call.args[0] for call in mock_shutil.chown.call_args_list}
+    assert temp_root in chowned
+    assert temp_root.parent in chowned
+    assert data_root.parent in chowned
     assert not (tmp_path / "archive").exists()
     assert not (tmp_path / "logs").exists()
 

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1,8 +1,9 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import os
 from pathlib import Path
-from unittest.mock import MagicMock, Mock, PropertyMock, mock_open, patch, sentinel
+from unittest.mock import MagicMock, Mock, PropertyMock, call, mock_open, patch, sentinel
 
 import pytest
 import requests
@@ -478,14 +479,21 @@ def test_configure_patroni_on_unit(peers_ips, patroni):
 
         patroni.configure_patroni_on_unit()
 
-        _getpwnam.assert_called_once_with("_daemon_")
+        assert _getpwnam.call_args_list == [call("_daemon_"), call("_daemon_")]
         _makedirs.assert_called_once_with(POSTGRESQL_DATA_DIR, exist_ok=True)
 
+        # Parent and data dir are both chowned (parent enables Patroni reinit rename/remove).
+        _chown.assert_any_call(
+            os.path.dirname(POSTGRESQL_DATA_DIR),
+            uid=sentinel.uid,
+            gid=sentinel.gid,
+        )
         _chown.assert_any_call(
             POSTGRESQL_DATA_DIR,
             uid=sentinel.uid,
             gid=sentinel.gid,
         )
+        assert _chown.call_count == 2
 
         _open.assert_called_once_with(CREATE_CLUSTER_CONF_PATH, "a")
         _chmod.assert_called_once_with(POSTGRESQL_DATA_DIR, 448)


### PR DESCRIPTION
## Issue

On the versioned-storage layout the data-dir parent (`.../postgresql/16`) can be owned by `root:root` while Patroni runs as the unprivileged `_daemon_` user. During `patronictl reinit`, Patroni can empty `16/main` (it owns the contents) but cannot remove or rename the directory itself, which needs write permission on the parent. Reinit still succeeds via basebackup, but logs "Could not remove/rename data directory" errors and `PermissionError` tracebacks, which CI flags.

The parent ends up root-owned on two paths:

- **Fresh deploy:** the charm creates it via `os.makedirs(POSTGRESQL_DATA_DIR)` in `configure_patroni_on_unit` (which runs as root); only the `16/main` leaf was chowned.
- **Upgrade/rollback:** the snap's `migrate-data.sh` creates the parent as root.

## Solution

- Chown the `16/` data parent to `_daemon_` in `configure_patroni_on_unit`, right after `os.makedirs`, so it is correctly owned on a fresh deploy.
- Also chown it (existence-guarded) in `_ensure_storage_layout`, covering the upgrade/rollback path where `migrate-data.sh` already created the parent, mirroring the temp-tablespace parent handling.
- Unit tests assert both the parent and leaf chowns in `configure_patroni_on_unit` and cover the `_ensure_storage_layout` data-parent chown.
- Add a reinit integration test that catches this: wait for Patroni to stop before deleting pg_control; confirm the replica is genuinely broken before reinit — re-registered in the cluster, not streaming, and Patroni has logged a pg_control startup failure (so it can't false-pass); require it to return to "streaming" via the Patroni REST API; and grep the `patroni.log*` files (not journalctl, which never receives these errors) for the data-directory permission-error signatures.

As a follow-up, the ownership migration could be moved to the snap's script.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
