### PR TITLE
fix(backups): configure pgBackRest stderr logging

### DIFF
--- a/templates/pgbackrest.conf.j2
+++ b/templates/pgbackrest.conf.j2
@@ -2,6 +2,7 @@
 backup-standby=y
 compress-type=zst
 lock-path=/tmp
+log-level-stderr=warn
 log-path={{ log_path }}
 repo1-retention-full-type=time
 repo1-retention-full={{ retention_full }}

--- a/tests/unit/test_backups.py
+++ b/tests/unit/test_backups.py
@@ -1870,6 +1870,13 @@ def test_render_pgbackrest_conf_file(harness, tls_ca_chain_filename):
 
         # Check the template is opened read-only in the call to open.
         assert mock.call_args_list[0][0] == ("templates/pgbackrest.conf.j2",)
+        rendered_pgbackrest_conf = next(
+            call_args[0][1]
+            for call_args in _render_file.call_args_list
+            if call_args[0][0]
+            == "/var/snap/charmed-postgresql/current/etc/pgbackrest/pgbackrest.conf"
+        )
+        assert "log-level-stderr=warn" in rendered_pgbackrest_conf
 
         # Get the expected content from a file.
         with open("templates/pgbackrest.conf.j2") as file:


### PR DESCRIPTION
## Summary

Adds `log-level-stderr=warn` to the rendered pgBackRest global configuration so the stderr logging level is configured once for every pgBackRest invocation that uses `pgbackrest.conf`, as requested in #1353.

The existing `--log-level-console=debug` backup argument is left unchanged because it controls console output for the backup action and is distinct from the stderr logging level being moved into the config file.

## Verification

- `python3 -m compileall -q tests/unit/test_backups.py`
- `ruff check tests/unit/test_backups.py`
- `ruff format --check tests/unit/test_backups.py`
- `git diff --check`
- Jinja render smoke check confirmed `log-level-stderr=warn` appears in the rendered config

Could not run the focused pytest locally because this container lacks the project test environment: host pytest autoloads a missing `evalcraft` plugin, plugin-autoload-disabled pytest then lacks `botocore`, and `poetry`/`tox` are not installed here.

Closes #1353
