### PR TITLE
[DPE-10368] Bump replication lag defaults from 16kB to 100MB

### DIFF
--- a/src/cluster.py
+++ b/src/cluster.py
@@ -456,7 +456,7 @@ class Patroni:
                     members_ips = {self.unit_ip}
                     members_ips.update(self.peers_ips)
                     for members_ip in members_ips:
-                        endpoint = "leader" if members_ip == primary_ip else "replica?lag=16kB"
+                        endpoint = "leader" if members_ip == primary_ip else "replica?lag=100MB"
                         url = self._patroni_url.replace(self.unit_ip, members_ip)
                         r = requests.get(
                             f"{url}/{endpoint}",


### PR DESCRIPTION
## Issue

The systems with heavy writes might never joining the cluster reporting back `awaiting for member to start`.

## Solution

As a quick win bump the too low values 16K to 100M (c) @7annaba3l 

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
