### PR TITLE
[DPE-10364] fix(terraform): widen juju provider constraint to ~> 1.0

### DIFF
--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 1.0.0"
+      version = "~> 1.0"
     }
   }
 }


### PR DESCRIPTION
## Issue

The `juju/juju` Terraform provider is pinned with `~> 1.0.0`, a patch-only constraint (`>= 1.0.0, < 1.1.0`). Since `1.0.0` is the only stable `1.0.x` release, this effectively locks the provider to exactly `1.0.0`.

Terraform intersects a provider's version constraints across every module in a configuration, so this prevents Charmed PostgreSQL from being deployed alongside modules that require a newer 1.x provider — e.g. COS and Landscape use `~> 1.4`. The intersection with `1.0.0` is empty and `terraform init` fails with `no available releases match the given constraints ~> 1.0.0, ~> 1.4`.

## Solution

Relax the constraint to `~> 1.0` (`>= 1.0.0, < 2.0.0`). This keeps the same `1.0.0` floor but admits the entire 1.x range (currently up to `1.5.4`), while still excluding a potentially breaking `2.x` major (`2.0.x` already exists). It also aligns with the `~> 1.0` convention used by the other Canonical modules.

Validation:
- `terraform init` resolves `~> 1.0` → juju `1.5.4` (vs `~> 1.0.0` → `1.0.0`).
- Reproduced the cross-module failure with a `~> 1.4` consumer and confirmed `~> 1.0` resolves the intersection to `1.5.4`.
- `terraform apply` of the module deployed PostgreSQL to `active/idle` on LXD using provider `1.5.4` (no regression).

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.

Closes #1759.