### PR TITLE
[DPE-10368] Bump replication lag defaults from 16kB to 100MB

### DIFF
--- a/src/cluster.py
+++ b/src/cluster.py
@@ -482,7 +482,7 @@ class Patroni:
                     members_ips = {self.unit_ip}
                     members_ips.update(self.peers_ips)
                     for members_ip in members_ips:
-                        endpoint = "leader" if members_ip == primary_ip else "replica?lag=16kB"
+                        endpoint = "leader" if members_ip == primary_ip else "replica?lag=100MB"
                         url = self._patroni_url.replace(self.unit_ip, members_ip)
                         member_status = requests.get(
                             f"{url}/{endpoint}",


### PR DESCRIPTION
## Issue

The new units have troubles to join the cluster if active writes performed to Primary.

## Solution

Bump replication lag defaults from 16kB to 100MB for replication health (to mimic PG16 behavior).

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
