### PR TITLE
[DPE-10284] fix(charm): skip user/role setup on read-only standby cluster

### DIFF
--- a/src/backups.py
+++ b/src/backups.py
@@ -164,7 +164,7 @@ class PostgreSQLBackups(Object):
 
     def _can_unit_perform_backup(self) -> tuple[bool, str | None]:
         """Validates whether this unit can perform a backup."""
-        if self._is_standby_cluster():
+        if self.charm.is_standby_cluster:
             return False, STANDBY_CLUSTER_CREATE_BACKUP_ERROR_MESSAGE
 
         if self.charm.is_blocked:
@@ -188,16 +188,6 @@ class PostgreSQLBackups(Object):
             return False, "Stanza was not initialised"
 
         return self._are_backup_settings_ok()
-
-    def _is_standby_cluster(self) -> bool:
-        """Return whether this unit belongs to a standby cluster."""
-        if (
-            self.model.get_relation(REPLICATION_CONSUMER_RELATION) is None
-            and self.model.get_relation(REPLICATION_OFFER_RELATION) is None
-        ):
-            return False
-
-        return not self.charm.async_replication.is_primary_cluster()
 
     def can_use_s3_repository(self) -> tuple[bool, str]:
         """Returns whether the charm was configured to use another cluster repository."""
@@ -1096,7 +1086,7 @@ Stderr:
 
     def _on_list_backups_action(self, event) -> None:
         """List the previously created backups."""
-        if self._is_standby_cluster():
+        if self.charm.is_standby_cluster:
             logger.warning(STANDBY_CLUSTER_LIST_BACKUPS_ERROR_MESSAGE)
             event.fail(STANDBY_CLUSTER_LIST_BACKUPS_ERROR_MESSAGE)
             return
@@ -1282,7 +1272,7 @@ Stderr:
         Returns:
             a boolean indicating whether restore should be run.
         """
-        if self._is_standby_cluster():
+        if self.charm.is_standby_cluster:
             logger.error(f"Restore failed: {STANDBY_CLUSTER_RESTORE_ERROR_MESSAGE}")
             event.fail(STANDBY_CLUSTER_RESTORE_ERROR_MESSAGE)
             return False

--- a/src/charm.py
+++ b/src/charm.py
@@ -1473,6 +1473,16 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         return self.unit.name == self._patroni.get_standby_leader(unit_name_pattern=True)
 
     @property
+    def is_standby_cluster(self) -> bool:
+        """Return whether this unit belongs to a standby (read-only) cluster."""
+        if (
+            self.model.get_relation(REPLICATION_CONSUMER_RELATION) is None
+            and self.model.get_relation(REPLICATION_OFFER_RELATION) is None
+        ):
+            return False
+        return not self.async_replication.is_primary_cluster()
+
+    @property
     def is_tls_enabled(self) -> bool:
         """Return whether TLS is enabled."""
         return all(self.tls.get_client_tls_files())
@@ -2002,6 +2012,13 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         postgres_snap.restart(services=["ldap-sync"])
 
     def _setup_users(self) -> None:
+        # A standby cluster's PostgreSQL is a read-only hot standby; these objects are
+        # provisioned on the primary cluster and replicated here, so the write DDL below
+        # would fail with ReadOnlySqlTransaction. Skip it (DPE-10284).
+        if self.is_standby_cluster:
+            logger.debug("Early exit _setup_users: standby cluster is read-only")
+            return
+
         self.postgresql.create_predefined_instance_roles()
 
         # Create the default postgres database user that is needed for some

--- a/tests/integration/high_availability/test_async_replication_outage.py
+++ b/tests/integration/high_availability/test_async_replication_outage.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Regression test for DPE-10284.
+
+A standby (read-only) cluster whose units are all restarted (a full outage) must
+not crash the standby leader. The standby leader's re-emitted start hook used to
+run user/role setup (``CREATE EXTENSION ...``) against the read-only instance and
+fail with ``ReadOnlySqlTransaction``, leaving the unit stuck in error even though
+replication was healthy.
+"""
+
+import logging
+import subprocess
+from collections.abc import Generator
+
+import jubilant
+import pytest
+from jubilant import Juju
+
+from .. import architecture
+from .high_availability_helpers_new import (
+    get_app_leader,
+    get_db_standby_leader_unit,
+    wait_for_apps_status,
+)
+
+DB_APP_1 = "db1"
+DB_APP_2 = "db2"
+
+MINUTE_SECS = 60
+
+logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
+
+
+@pytest.fixture(scope="module")
+def first_model(juju: Juju) -> Generator:
+    """Return the first (primary cluster) model."""
+    yield juju.model
+
+
+@pytest.fixture(scope="module")
+def second_model(juju: Juju, request: pytest.FixtureRequest) -> Generator:
+    """Create and return the second (standby cluster) model."""
+    model_name = f"{juju.model}-other"
+
+    logging.info(f"Creating model: {model_name}")
+    juju.add_model(model_name)
+
+    yield model_name
+    if request.config.getoption("--keep-models"):
+        return
+
+    logging.info(f"Destroying model: {model_name}")
+    juju.destroy_model(model_name, destroy_storage=True, force=True)
+
+
+def test_deploy(first_model: str, second_model: str, charm: str) -> None:
+    """Deploy a PostgreSQL cluster in each model."""
+    configuration = {"profile": "testing"}
+    constraints = {"arch": architecture.architecture}
+
+    model_1 = Juju(model=first_model)
+    model_1.deploy(
+        charm=charm,
+        app=DB_APP_1,
+        base="ubuntu@24.04",
+        config=configuration,
+        constraints=constraints,
+        num_units=2,
+    )
+    model_2 = Juju(model=second_model)
+    model_2.deploy(
+        charm=charm,
+        app=DB_APP_2,
+        base="ubuntu@24.04",
+        config=configuration,
+        constraints=constraints,
+        num_units=2,
+    )
+
+    model_1.wait(
+        ready=wait_for_apps_status(jubilant.all_active, DB_APP_1), timeout=20 * MINUTE_SECS
+    )
+    model_2.wait(
+        ready=wait_for_apps_status(jubilant.all_active, DB_APP_2), timeout=20 * MINUTE_SECS
+    )
+
+
+def test_async_relate_and_replicate(first_model: str, second_model: str) -> None:
+    """Relate the two clusters and start replication, making db2 a standby cluster."""
+    model_1 = Juju(model=first_model)
+    model_2 = Juju(model=second_model)
+
+    model_1.offer(f"{first_model}.{DB_APP_1}", endpoint="replication-offer")
+    model_2.consume(f"{first_model}.{DB_APP_1}")
+    model_2.integrate(DB_APP_1, f"{DB_APP_2}:replication")
+
+    # Wait for the relation to settle before create-replication: the action fails unless
+    # every unit has published its address in the relation data.
+    model_1.wait(
+        ready=wait_for_apps_status(jubilant.any_active, DB_APP_1), timeout=10 * MINUTE_SECS
+    )
+    model_2.wait(
+        ready=wait_for_apps_status(jubilant.any_active, DB_APP_2), timeout=10 * MINUTE_SECS
+    )
+
+    model_1.run(
+        unit=get_app_leader(model_1, DB_APP_1), action="create-replication", wait=5 * MINUTE_SECS
+    ).raise_on_failure()
+
+    model_1.wait(
+        ready=wait_for_apps_status(jubilant.all_active, DB_APP_1), timeout=20 * MINUTE_SECS
+    )
+    model_2.wait(
+        ready=wait_for_apps_status(jubilant.all_active, DB_APP_2), timeout=20 * MINUTE_SECS
+    )
+
+    # db2 must now be the read-only standby cluster.
+    assert get_db_standby_leader_unit(model_2, DB_APP_2)
+
+
+def test_full_outage_recovery(first_model: str, second_model: str) -> None:
+    """Stop every unit on both clusters, start them again, and assert recovery.
+
+    Reproduces DPE-10284: before the fix, the standby leader's start hook failed
+    with ReadOnlySqlTransaction and the unit stayed in error forever.
+    """
+    model_1 = Juju(model=first_model)
+    model_2 = Juju(model=second_model)
+
+    # Resolve every unit's LXD machine (container) while the units are reachable.
+    machines = []
+    for model, app in ((model_1, DB_APP_1), (model_2, DB_APP_2)):
+        status = model.status()
+        machines.extend(
+            status.machines[unit.machine].instance_id for unit in status.get_units(app).values()
+        )
+
+    logging.info(f"Simulating a full outage by force-stopping all machines: {machines}")
+    for machine in machines:
+        subprocess.run(["lxc", "stop", "--force", machine], check=True)
+    for machine in machines:
+        subprocess.run(["lxc", "start", machine], check=True)
+
+    logging.info("Waiting for both clusters to recover")
+    model_1.wait(
+        ready=wait_for_apps_status(jubilant.all_active, DB_APP_1), timeout=20 * MINUTE_SECS
+    )
+    # If the standby leader crashes its start hook (DPE-10284), db2 never reaches
+    # all-active and this wait fails.
+    model_2.wait(
+        ready=wait_for_apps_status(jubilant.all_active, DB_APP_2), timeout=20 * MINUTE_SECS
+    )
+
+    # The standby cluster must still expose a standby leader after recovery.
+    assert get_db_standby_leader_unit(model_2, DB_APP_2)

--- a/tests/spread/test_async_replication_outage.py/task.yaml
+++ b/tests/spread/test_async_replication_outage.py/task.yaml
@@ -1,0 +1,7 @@
+summary: test_async_replication_outage.py
+environment:
+  TEST_MODULE: high_availability/test_async_replication_outage.py
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/tests/unit/test_backups.py
+++ b/tests/unit/test_backups.py
@@ -164,7 +164,9 @@ def test_can_initialise_stanza(harness):
 def test_can_unit_perform_backup(harness):
     with (
         patch("charm.PostgreSQLBackups._are_backup_settings_ok") as _are_backup_settings_ok,
-        patch("charm.PostgreSQLBackups._is_standby_cluster") as _is_standby_cluster,
+        patch(
+            "charm.PostgresqlOperatorCharm.is_standby_cluster", new_callable=PropertyMock
+        ) as _is_standby_cluster,
         patch("charm.Patroni.member_started", new_callable=PropertyMock) as _member_started,
         patch("ops.model.Application.planned_units") as _planned_units,
         patch(
@@ -232,33 +234,6 @@ def test_can_unit_perform_backup(harness):
         # Test when everything is ok to run a backup.
         _are_backup_settings_ok.return_value = (True, None)
         assert harness.charm.backup._can_unit_perform_backup() == (True, None)
-
-
-def test_is_standby_cluster(harness):
-    with (
-        patch.object(harness.charm.backup.model, "get_relation") as _get_relation,
-        patch.object(harness.charm.async_replication, "is_primary_cluster") as _is_primary_cluster,
-    ):
-        # Test when async replication relation is not present.
-        _get_relation.side_effect = [None, None]
-        assert not harness.charm.backup._is_standby_cluster()
-        _is_primary_cluster.assert_not_called()
-
-        # Test when relation is present and this is the primary cluster.
-        _get_relation.reset_mock()
-        _is_primary_cluster.reset_mock()
-        _get_relation.side_effect = [object()]
-        _is_primary_cluster.return_value = True
-        assert not harness.charm.backup._is_standby_cluster()
-        _is_primary_cluster.assert_called_once()
-
-        # Test when relation is present and this is the standby cluster.
-        _get_relation.reset_mock()
-        _is_primary_cluster.reset_mock()
-        _get_relation.side_effect = [object()]
-        _is_primary_cluster.return_value = False
-        assert harness.charm.backup._is_standby_cluster()
-        _is_primary_cluster.assert_called_once()
 
 
 def test_can_use_s3_repository(harness):
@@ -1410,7 +1385,9 @@ def test_on_list_backups_action(harness):
         patch(
             "charm.PostgreSQLBackups._generate_backup_list_output"
         ) as _generate_backup_list_output,
-        patch("charm.PostgreSQLBackups._is_standby_cluster") as _is_standby_cluster,
+        patch(
+            "charm.PostgresqlOperatorCharm.is_standby_cluster", new_callable=PropertyMock
+        ) as _is_standby_cluster,
         patch("charm.PostgreSQLBackups._are_backup_settings_ok") as _are_backup_settings_ok,
     ):
         # Test when unit belongs to a standby cluster.
@@ -1750,7 +1727,9 @@ def test_on_restore_action(harness):
 def test_pre_restore_checks(harness):
     with (
         patch("ops.model.Application.planned_units") as _planned_units,
-        patch("charm.PostgreSQLBackups._is_standby_cluster") as _is_standby_cluster,
+        patch(
+            "charm.PostgresqlOperatorCharm.is_standby_cluster", new_callable=PropertyMock
+        ) as _is_standby_cluster,
         patch("charm.PostgreSQLBackups._are_backup_settings_ok") as _are_backup_settings_ok,
     ):
         # Test when unit belongs to a standby cluster.

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -528,6 +528,73 @@ def test_on_start_success(harness):
         _restart_services_after_reboot.assert_called_once()
 
 
+def test_setup_users_skips_writes_on_standby_cluster(harness):
+    """A standby cluster is read-only, so _setup_users must not issue write DDL (DPE-10284)."""
+    with (
+        patch(
+            "charm.PostgresqlOperatorCharm.is_standby_cluster",
+            new_callable=PropertyMock,
+            return_value=True,
+        ),
+        patch("charm.PostgreSQLProvider.oversee_users") as _oversee_users,
+        patch("charm.PostgresqlOperatorCharm.postgresql") as _postgresql,
+    ):
+        # Even though this would raise on a read-only standby, the guard must
+        # short-circuit before create_predefined_instance_roles is ever called.
+        _postgresql.create_predefined_instance_roles.side_effect = (
+            psycopg2.errors.ReadOnlySqlTransaction
+        )
+
+        harness.charm._setup_users()
+
+        _postgresql.create_predefined_instance_roles.assert_not_called()
+        _postgresql.create_user.assert_not_called()
+        _postgresql.set_up_database.assert_not_called()
+        _oversee_users.assert_not_called()
+
+
+def test_setup_users_runs_on_primary_cluster(harness):
+    """On a primary cluster _setup_users provisions the predefined roles and users."""
+    with (
+        patch(
+            "charm.PostgresqlOperatorCharm.is_standby_cluster",
+            new_callable=PropertyMock,
+            return_value=False,
+        ),
+        patch("charm.PostgreSQLProvider.oversee_users") as _oversee_users,
+        patch("charm.PostgresqlOperatorCharm.get_secret"),
+        patch("charm.PostgresqlOperatorCharm.postgresql") as _postgresql,
+    ):
+        _postgresql.list_users.return_value = []
+        _postgresql.list_access_groups.return_value = set()
+
+        harness.charm._setup_users()
+
+        _postgresql.create_predefined_instance_roles.assert_called_once()
+        assert _postgresql.create_user.call_count == 2  # backup user + monitoring user
+        _oversee_users.assert_called_once()
+
+
+def test_is_standby_cluster(harness):
+    """is_standby_cluster is relation-based and independent of the Patroni API."""
+    with (
+        patch("charm.PostgreSQLAsyncReplication.is_primary_cluster") as _is_primary_cluster,
+        patch.object(harness.charm.model, "get_relation") as _get_relation,
+    ):
+        # No replication relation at all -> not a standby cluster.
+        _get_relation.return_value = None
+        assert harness.charm.is_standby_cluster is False
+
+        # Replication relation present, and this app is the primary cluster.
+        _get_relation.return_value = Mock()
+        _is_primary_cluster.return_value = True
+        assert harness.charm.is_standby_cluster is False
+
+        # Replication relation present, and this app is NOT the primary cluster -> standby.
+        _is_primary_cluster.return_value = False
+        assert harness.charm.is_standby_cluster is True
+
+
 def test_on_start_replica(harness):
     with (
         patch("charm.snap.SnapCache") as _snap_cache,


### PR DESCRIPTION
## Issue
On a cluster<>cluster async-replication deployment, after a full outage (all units on both clusters stopped, then restarted), the standby cluster's leader gets stuck in error. Its re-emitted `start` hook runs user/role setup (`CREATE EXTENSION ...`) against the read-only standby and fails with `psycopg2.errors.ReadOnlySqlTransaction: cannot execute CREATE EXTENSION in a read-only transaction`.

## Solution
- Add `is_standby_cluster` (relation-based, independent of the Patroni API) and skip `_setup_users` on a standby cluster — those roles/users/extensions are created on the primary and arrive via replication, so the write DDL must not run on the read-only standby.
- Refactor `backups._is_standby_cluster` to delegate to the new charm property.
- Add unit tests and an integration test (`test_async_replication_outage.py`) that does a full outage + restart and asserts the standby leader recovers (validated on a live LXD deployment, before/after).

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.