### PR TITLE
[DPE-10366] Bump pySyncObj from 0.3.12 to 0.3.15 (TESTING)

### DIFF
--- a/refresh_versions.toml
+++ b/refresh_versions.toml
@@ -6,6 +6,6 @@ name = "charmed-postgresql"
 
 [snap.revisions]
 # amd64
-x86_64 = "366"
+x86_64 = "367" # pySyncObj 0.3.15
 # arm64
-aarch64 = "365"
+aarch64 = "365" # pySyncObj 0.3.12


### PR DESCRIPTION
## Issue

We are using pySyncObj from 0.3.12 which has list of troubles to bugreport upstream.

## Solution

Validate all our tests using the latest 0.3.15 before contacting upstream.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
