### PR TITLE
[DPE-10366] Bump pySyncObj from 0.3.12 to 0.3.15 for PG14 (TESTING ONLY)

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -40,7 +40,7 @@ POSTGRESQL_SNAP_NAME = "charmed-postgresql"
 SNAP_PACKAGES = [
     (
         POSTGRESQL_SNAP_NAME,
-        {"revision": {"aarch64": "333", "x86_64": "334"}},
+        {"revision": {"aarch64": "333", "x86_64": "368"}},
     )
 ]
 


### PR DESCRIPTION
## Issue

We are using pySyncObj from 0.3.12 which has list of troubles to bugreport upstream.

## Solution

Validate all our tests using the latest 0.3.15 before contacting upstream.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
