### PR TITLE
[DPE-10366] Bump pySyncObj from 0.3.12 to 0.3.15 for PG14

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -40,7 +40,7 @@ POSTGRESQL_SNAP_NAME = "charmed-postgresql"
 SNAP_PACKAGES = [
     (
         POSTGRESQL_SNAP_NAME,
-        {"revision": {"aarch64": "333", "x86_64": "334"}},
+        {"revision": {"aarch64": "369", "x86_64": "370"}},
     )
 ]
 


### PR DESCRIPTION
## Issue

There are stability issue with Raft 0.3.12 implementation. 

## Solution

The latest version is 0.3.15, start using it before bug reporting our issues upstream.

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
