### PR TITLE
[DPE-10366] Bump pySyncObj from 0.3.12 to 0.3.15 for PG16

### DIFF
--- a/refresh_versions.toml
+++ b/refresh_versions.toml
@@ -6,6 +6,6 @@ name = "charmed-postgresql"
 
 [snap.revisions]
 # amd64
-x86_64 = "366"
+x86_64 = "371"
 # arm64
-aarch64 = "365"
+aarch64 = "372"


### PR DESCRIPTION
## Issue

There are stability issue with Raft 0.3.12 implementation. 

## Solution

The latest version is 0.3.15, start using it before bug reporting our issues upstream.

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
