### PR TITLE
[DPE-9282] fix(terraform): bound juju provider to 1.x and use model_uuid

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,6 +1,6 @@
 resource "juju_application" "machine_postgresql" {
-  name  = var.app_name
-  model = var.juju_model_name
+  name       = var.app_name
+  model_uuid = var.juju_model
 
   charm {
     name     = "postgresql"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,6 +1,7 @@
-variable "juju_model_name" {
-  description = "Juju model name"
+variable "juju_model" {
+  description = "Juju model uuid"
   type        = string
+  default     = null
 }
 
 variable "app_name" {

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.14.0"
+      version = "~> 1.0"
     }
   }
 }


### PR DESCRIPTION
## Issue

The Terraform module sets no upper bound on the `juju/juju` provider (`>= 0.14.0`), so `terraform init` resolves the newest release available — currently the `2.x` major. That release replaced the `model` (name) attribute with the required `model_uuid`, but the module still passes `model = var.juju_model_name`. As a result `terraform plan`/`apply` fails for every consumer with `The argument "model_uuid" is required` and `An argument named "model" is not expected here`.

## Solution

Bound the provider to `~> 1.0` (`>= 1.0.0, < 2.0.0`) so deployments stay on the compatible 1.x line and a breaking major is never selected unattended, and adopt `model_uuid`, fed by the renamed `juju_model` (UUID) input. This aligns `main` with the migration already shipped on `16/edge`.

Validation:
- Pre-fix (`>= 0.14.0` + `model`): `terraform init` pulls juju `2.0.1`; `plan` fails with the `model_uuid` / `model` errors above (reproduces #1393).
- Fixed (`~> 1.0` + `model_uuid`): `terraform init` resolves juju `1.5.4`; `plan` + `apply` deploy PostgreSQL to `active/idle` on LXD.

Future work:
- Validate whether we intend to update this to v2 from the provider. I believe not, as this track is in maintenance mode.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.

Closes #1393.
