### PR TITLE
[DPE-10484] test: add integration test for wrong-architecture deployments

### DIFF
--- a/tests/integration/test_wrong_arch.py
+++ b/tests/integration/test_wrong_arch.py
@@ -17,6 +17,12 @@ def fetch_charm(charm_path: str | os.PathLike, architecture: str) -> pathlib.Pat
     return packed_charms[0].resolve(strict=True)
 
 
+def _unit_is_blocked(juju: JujuFixture) -> bool:
+    """Return True once the deployed unit reports a blocked workload status."""
+    units = juju.ext.model.applications[DATABASE_APP_NAME].units
+    return bool(units) and units[0].workload_status == "blocked"
+
+
 @markers.amd64_only
 def test_arm_charm_on_amd_host(juju: JujuFixture) -> None:
     """Try deploying an arm64 charm on an amd64 host."""
@@ -27,7 +33,10 @@ def test_arm_charm_on_amd_host(juju: JujuFixture) -> None:
         num_units=1,
         config={"profile": "testing"},
     )
-    juju.ext.model.wait_for_idle(apps=[DATABASE_APP_NAME], raise_on_error=False, status="blocked")
+    # The wrong-architecture charm sets BlockedStatus and exits on every hook, so
+    # it never converges to a fully idle state (less so under slow CI machine
+    # provisioning). Wait for the blocked status directly rather than for idle.
+    juju.ext.model.block_until(lambda: _unit_is_blocked(juju), timeout=20 * 60)
 
 
 @markers.arm64_only
@@ -40,4 +49,7 @@ def test_amd_charm_on_arm_host(juju: JujuFixture) -> None:
         num_units=1,
         config={"profile": "testing"},
     )
-    juju.ext.model.wait_for_idle(apps=[DATABASE_APP_NAME], raise_on_error=False, status="blocked")
+    # The wrong-architecture charm sets BlockedStatus and exits on every hook, so
+    # it never converges to a fully idle state (less so under slow CI machine
+    # provisioning). Wait for the blocked status directly rather than for idle.
+    juju.ext.model.block_until(lambda: _unit_is_blocked(juju), timeout=20 * 60)

--- a/tests/integration/test_wrong_arch.py
+++ b/tests/integration/test_wrong_arch.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import os
+import pathlib
+
+from . import markers
+from .adapters import JujuFixture
+from .jubilant_helpers import DATABASE_APP_NAME
+
+
+def fetch_charm(charm_path: str | os.PathLike, architecture: str) -> pathlib.Path:
+    """Fetch a packed charm for a specific architecture, ignoring the host architecture."""
+    charm_path = pathlib.Path(charm_path)
+    packed_charms = list(charm_path.glob(f"*-{architecture}.charm"))
+    return packed_charms[0].resolve(strict=True)
+
+
+@markers.amd64_only
+def test_arm_charm_on_amd_host(juju: JujuFixture) -> None:
+    """Try deploying an arm64 charm on an amd64 host."""
+    charm = fetch_charm(".", "arm64")
+    juju.ext.model.deploy(
+        str(charm),
+        application_name=DATABASE_APP_NAME,
+        num_units=1,
+        config={"profile": "testing"},
+    )
+    juju.ext.model.wait_for_idle(apps=[DATABASE_APP_NAME], raise_on_error=False, status="blocked")
+
+
+@markers.arm64_only
+def test_amd_charm_on_arm_host(juju: JujuFixture) -> None:
+    """Try deploying an amd64 charm on an arm64 host."""
+    charm = fetch_charm(".", "amd64")
+    juju.ext.model.deploy(
+        str(charm),
+        application_name=DATABASE_APP_NAME,
+        num_units=1,
+        config={"profile": "testing"},
+    )
+    juju.ext.model.wait_for_idle(apps=[DATABASE_APP_NAME], raise_on_error=False, status="blocked")

--- a/tests/spread/test_wrong_arch.py/task.yaml
+++ b/tests/spread/test_wrong_arch.py/task.yaml
@@ -1,0 +1,7 @@
+summary: test_wrong_arch.py
+environment:
+  TEST_MODULE: test_wrong_arch.py
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results


### PR DESCRIPTION
## Issue

The VM charm has no integration coverage for the architecture guard — i.e. deploying a charm built for the wrong CPU architecture. The K8s charm (`postgresql-k8s-operator`) ships `tests/integration/test_wrong_arch.py`, but the VM charm never had an equivalent, so a regression in the single-kernel arch guard (`single_kernel_postgresql.utils.arch`, wired in by the auxiliary-code migration, #1769) could ship unnoticed on the VM substrate.

## Solution

Port the wrong-architecture test from the K8s charm, adapted to the VM's Jubilant harness:

- `tests/integration/test_wrong_arch.py` — `test_arm_charm_on_amd_host` (`@amd64_only`) and `test_amd_charm_on_arm_host` (`@arm64_only`) deploy a charm built for the opposite architecture and assert the unit goes `blocked` (the `WrongArchitectureWarningCharm` guard self-blocks).
- `tests/spread/test_wrong_arch.py/task.yaml` — the matching spread task.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
