### PR TITLE
[DPE-10450] Fix crash restoring non-settable unit status in PG16

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -533,6 +533,17 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             return
         self.unit.status = status
 
+    def _restore_unit_status(self, status: ops.StatusBase) -> None:
+        """Restore a previously cached unit status.
+
+        The status getter can return statuses that the setter rejects (e.g. an
+        "error" status left over from a previously failed hook). Skip restoring
+        any status juju does not allow us to set, to avoid an InvalidStatusError
+        that would deadlock the unit.
+        """
+        if isinstance(status, ActiveStatus | BlockedStatus | MaintenanceStatus | WaitingStatus):
+            self.set_unit_status(status)
+
     def _reconcile_refresh_status(self, _=None):
         if self.unit.is_leader():
             self.async_replication.set_app_status()
@@ -1857,7 +1868,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         if original_status.message == EXTENSION_OBJECT_MESSAGE:
             self.set_unit_status(ActiveStatus())
             return
-        self.set_unit_status(original_status)
+        self._restore_unit_status(original_status)
 
     def _check_extension_dependencies(self, extension: str, enable: bool) -> bool:
         skip = False
@@ -2613,13 +2624,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
                     logger.error("Data directory not attached.")
                     self.unit.status = WaitingStatus("Data directory not attached")
                     raise StorageUnavailableError()
-        # The status getter can return statuses that the setter rejects (e.g. an
-        # "error" status left over from a previously failed hook). Only restore
-        # the cached status if it is one juju allows us to set back.
-        if isinstance(
-            cached_status, ActiveStatus | BlockedStatus | MaintenanceStatus | WaitingStatus
-        ):
-            self.unit.status = cached_status
+        self._restore_unit_status(cached_status)
 
     def _restart(self, event: RunWithLock) -> None:
         """Restart PostgreSQL."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -2613,7 +2613,13 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
                     logger.error("Data directory not attached.")
                     self.unit.status = WaitingStatus("Data directory not attached")
                     raise StorageUnavailableError()
-        self.unit.status = cached_status
+        # The status getter can return statuses that the setter rejects (e.g. an
+        # "error" status left over from a previously failed hook). Only restore
+        # the cached status if it is one juju allows us to set back.
+        if isinstance(
+            cached_status, ActiveStatus | BlockedStatus | MaintenanceStatus | WaitingStatus
+        ):
+            self.unit.status = cached_status
 
     def _restart(self, event: RunWithLock) -> None:
         """Restart PostgreSQL."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -27,6 +27,7 @@ from ops import (
     RelationDataTypeError,
     RelationEvent,
     Unit,
+    UnknownStatus,
     WaitingStatus,
 )
 from ops.framework import EventBase
@@ -378,6 +379,33 @@ def test_enable_disable_extensions(harness, caplog):
             # Should resolve afterwards
             harness.charm.enable_disable_extensions()
             assert isinstance(harness.charm.unit.status, ActiveStatus)
+
+
+@pytest.mark.parametrize("unsettable_status", [ErrorStatus(), UnknownStatus()])
+def test_enable_disable_extensions_does_not_restore_unsettable_status(harness, unsettable_status):
+    # enable_disable_extensions caches the current unit status and restores it
+    # afterwards. The getter can return statuses the backend rejects on set
+    # (e.g. "error" or "unknown") left over from a previously failed hook;
+    # restoring such a cached status must not be attempted, otherwise the backend
+    # raises InvalidStatusError/ModelError and deadlocks the unit.
+    with (
+        patch("charm.Patroni.get_primary") as _get_primary,
+        patch("charm.PostgresqlOperatorCharm._unit_ip"),
+        patch("charm.PostgresqlOperatorCharm._patroni"),
+        patch("subprocess.check_output", return_value=b"C"),
+        patch.object(PostgresqlOperatorCharm, "postgresql", Mock()) as postgresql_mock,
+    ):
+        _get_primary.return_value = harness.charm.unit
+        postgresql_mock.enable_disable_extensions.side_effect = None
+
+        # Cache an unsettable status that would otherwise be restored verbatim.
+        harness.charm.unit._status = unsettable_status
+
+        # Must not raise when the cached status is restored at the end.
+        harness.charm.enable_disable_extensions()
+
+        # The unsettable cached status was skipped, not restored.
+        assert not isinstance(harness.charm.unit.status, ErrorStatus | UnknownStatus)
 
 
 def test_on_start_no_password(harness):
@@ -1203,14 +1231,15 @@ def test_check_detached_storage(harness):
         assert isinstance(harness.charm.unit.status, WaitingStatus)
 
 
-def test_check_detached_storage_does_not_restore_unsettable_status(harness):
+@pytest.mark.parametrize("unsettable_status", [ErrorStatus(), UnknownStatus()])
+def test_check_detached_storage_does_not_restore_unsettable_status(harness, unsettable_status):
     # The unit.status getter can return statuses that the juju backend rejects
     # on set (e.g. "error" or "unknown"). Restoring such a cached status must not
     # be attempted, otherwise the backend raises InvalidStatusError/ModelError.
-    harness.charm.unit._status = ErrorStatus()
+    harness.charm.unit._status = unsettable_status
     with patch("charm.PostgresqlOperatorCharm._is_storage_attached", return_value=True):
-        # Storage is attached, so the cached "error" status would be restored
-        # verbatim; this must not raise.
+        # Storage is attached, so the cached status would be restored verbatim;
+        # this must not raise.
         harness.charm._check_detached_storage()
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -20,6 +20,7 @@ from charmlibs import snap
 from ops import (
     ActiveStatus,
     BlockedStatus,
+    ErrorStatus,
     JujuVersion,
     MaintenanceStatus,
     ModelError,
@@ -1200,6 +1201,17 @@ def test_check_detached_storage(harness):
         with pytest.raises(StorageUnavailableError):
             harness.charm._check_detached_storage()
         assert isinstance(harness.charm.unit.status, WaitingStatus)
+
+
+def test_check_detached_storage_does_not_restore_unsettable_status(harness):
+    # The unit.status getter can return statuses that the juju backend rejects
+    # on set (e.g. "error" or "unknown"). Restoring such a cached status must not
+    # be attempted, otherwise the backend raises InvalidStatusError/ModelError.
+    harness.charm.unit._status = ErrorStatus()
+    with patch("charm.PostgresqlOperatorCharm._is_storage_attached", return_value=True):
+        # Storage is attached, so the cached "error" status would be restored
+        # verbatim; this must not raise.
+        harness.charm._check_detached_storage()
 
 
 def test_restart(harness):


### PR DESCRIPTION
## Issue

The unit.status getter can return statuses the setter rejects (e.g. an "error" status left over from a previously failed hook). When storage is already attached, _check_detached_storage restored the cached status verbatim, raising InvalidStatusError ("status must be in active, blocked, maintenance, waiting, not 'error'") and deadlocking the unit in error.

## Solution

Only restore the cached status when it is a settable status type.
(cherry picked from commit 0aaa1e28e33909b6d24881b13f089a86ab6e7494)

Assisted-by: Claude:claude-4.8-opus

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
