### PR TITLE
[DPE-10450] Skip Patroni REST API call in member_inactive when snap is down

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -2429,6 +2429,14 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         # Restart the PostgreSQL process if it was frozen (in that case, the Patroni
         # process is running by the PostgreSQL process not).
         if self._unit_ip in self.members_ips and self._patroni.member_inactive:
+            if not os.path.exists(POSTGRESQL_DATA_DIR):
+                # The data directory is created during bootstrap. If it does not exist yet,
+                # the member has not been initialised (e.g. update-status firing before the
+                # start event completes), so there is no frozen process to recover.
+                logger.debug(
+                    "Early exit handle_processes_failures: data directory does not exist yet"
+                )
+                return False
             data_directory_contents = os.listdir(POSTGRESQL_DATA_DIR)
             if len(data_directory_contents) == 1 and data_directory_contents[0] == "pg_wal":
                 os.rename(

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -511,6 +511,8 @@ class Patroni:
             True if services is not running, starting or restarting. Retries over a period of 60
             seconds times to allow server time to start up.
         """
+        if not self.is_patroni_running():
+            return True
         try:
             response = self.cached_patroni_health
         except RetryError:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -3411,6 +3411,7 @@ def test_handle_processes_failures(harness):
             "charm.Patroni.restart_patroni",
         ) as _restart_patroni,
         patch("charm.os.listdir", return_value=["other_dirs", "pg_wal"]) as _listdir,
+        patch("charm.os.path.exists", return_value=True) as _exists,
         patch("charm.os.rename") as _rename,
         patch("charm.datetime") as _datetime,
     ):
@@ -3449,6 +3450,15 @@ def test_handle_processes_failures(harness):
         _restart_patroni.assert_called_once_with()
         assert not _rename.called
         _restart_patroni.reset_mock()
+
+        # Does nothing if the data directory does not exist yet (member not bootstrapped)
+        _listdir.reset_mock()
+        _exists.return_value = False
+        assert not harness.charm._handle_processes_failures()
+        assert not _restart_patroni.called
+        assert not _rename.called
+        assert not _listdir.called
+        _exists.return_value = True
 
 
 def test_on_databases_change(harness):

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -562,6 +562,7 @@ def test_member_inactive_true(peers_ips, patroni):
         patch("cluster.requests.get") as _get,
         patch("cluster.stop_after_delay", return_value=stop_after_delay(0)),
         patch("cluster.wait_fixed", return_value=wait_fixed(0)),
+        patch("charm.Patroni.is_patroni_running", return_value=True),
     ):
         _get.return_value.json.return_value = {"state": "stopped"}
 
@@ -580,6 +581,7 @@ def test_member_inactive_false(peers_ips, patroni):
         patch("cluster.requests.get") as _get,
         patch("cluster.stop_after_delay", return_value=stop_after_delay(0)),
         patch("cluster.wait_fixed", return_value=wait_fixed(0)),
+        patch("charm.Patroni.is_patroni_running", return_value=True),
     ):
         _get.return_value.json.return_value = {"state": "starting"}
 
@@ -598,6 +600,7 @@ def test_member_inactive_error(peers_ips, patroni):
         patch("cluster.requests.get") as _get,
         patch("cluster.stop_after_delay", return_value=stop_after_delay(0)),
         patch("cluster.wait_fixed", return_value=wait_fixed(0)),
+        patch("charm.Patroni.is_patroni_running", return_value=True),
     ):
         _get.side_effect = Exception
 
@@ -609,6 +612,18 @@ def test_member_inactive_error(peers_ips, patroni):
             timeout=5,
             auth=patroni._patroni_auth,
         )
+
+
+def test_member_inactive_patroni_not_running(peers_ips, patroni):
+    with (
+        patch("cluster.requests.get") as _get,
+        patch("charm.Patroni.is_patroni_running", return_value=False),
+    ):
+        # When the Patroni snap service is not running, the member is inactive
+        # and we must not waste time querying the Patroni REST API.
+        assert patroni.member_inactive
+
+        _get.assert_not_called()
 
 
 def test_patroni_logs(patroni):


### PR DESCRIPTION
## Issue

The update-status cost 1 extra minute (for nothing) on the server restart IF `update-status` comes before `start`.
See https://github.com/juju/juju/issues/22688
It also affects all cluster recovery cases when update-status is unpredictable/random but real event.

Example:
```
unit-postgresql-0: 23:20:47 DEBUG unit.postgresql/0.juju-log root:Emitting Juju event update_status.
unit-postgresql-0: 23:20:47 DEBUG unit.postgresql/0.juju-log root:Starting root trace with id='356b6169143c7f5e150efdd273a59559'.
unit-postgresql-0: 23:20:47 DEBUG unit.postgresql/0.juju-log urllib3.connectionpool:Starting new HTTPS connection (1): 10.69.235.205:8008
unit-postgresql-0: 23:20:54 DEBUG unit.postgresql/0.juju-log urllib3.connectionpool:Starting new HTTPS connection (1): 10.69.235.205:8008
unit-postgresql-0: 23:21:01 DEBUG unit.postgresql/0.juju-log urllib3.connectionpool:Starting new HTTPS connection (1): 10.69.235.205:8008
unit-postgresql-0: 23:21:08 DEBUG unit.postgresql/0.juju-log urllib3.connectionpool:Starting new HTTPS connection (1): 10.69.235.205:8008
unit-postgresql-0: 23:21:15 DEBUG unit.postgresql/0.juju-log urllib3.connectionpool:Starting new HTTPS connection (1): 10.69.235.205:8008
unit-postgresql-0: 23:21:22 DEBUG unit.postgresql/0.juju-log urllib3.connectionpool:Starting new HTTPS connection (1): 10.69.235.205:8008
unit-postgresql-0: 23:21:29 DEBUG unit.postgresql/0.juju-log urllib3.connectionpool:Starting new HTTPS connection (1): 10.69.235.205:8008
unit-postgresql-0: 23:21:36 DEBUG unit.postgresql/0.juju-log urllib3.connectionpool:Starting new HTTPS connection (1): 10.69.235.205:8008
unit-postgresql-0: 23:21:43 DEBUG unit.postgresql/0.juju-log urllib3.connectionpool:Starting new HTTPS connection (1): 10.69.235.205:8008
unit-postgresql-0: 23:21:50 DEBUG unit.postgresql/0.juju-log urllib3.connectionpool:Starting new HTTPS connection (1): 10.69.235.205:8008
unit-postgresql-0: 23:21:50 INFO unit.postgresql/0.juju-log __main__:restarted PostgreSQL because it was not running
unit-postgresql-0: 23:21:50 DEBUG unit.postgresql/0.juju-log cluster:Restarting Patroni...
unit-postgresql-0: 23:21:51 INFO juju.worker.uniter.operation ran "update-status" hook (via hook dispatching script: dispatch)
unit-postgresql-0: 23:21:51 INFO juju.worker.uniter reboot detected; triggering implicit start hook to notify charm
unit-postgresql-0: 23:21:51 DEBUG unit.postgresql/0.juju-log ops 3.7.1 up and running.
```

## Solution

Guard member_inactive with is_patroni_running() (mirroring member_started) so that when the Patroni snap service is not active we return True immediately instead of spending ~60s retrying the Patroni REST API.

Assisted-by: Claude:claude-4.8-opus

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
