### PR TITLE
[DPE-10285] fix: defer relation-broken when no primary is available

### DIFF
--- a/src/relations/postgresql_provider.py
+++ b/src/relations/postgresql_provider.py
@@ -345,9 +345,11 @@ class PostgreSQLProvider(Object):
             not self.charm._peers
             or not self.charm.is_cluster_initialised
             or not self.charm._patroni.member_started
+            or not self.charm.primary_endpoint
         ):
             logger.debug(
-                "Deferring on_relation_broken: Cluster must be initialized before user can be deleted"
+                "Deferring on_relation_broken: Cluster must be initialized and primary "
+                "available before user can be deleted"
             )
             event.defer()
             return

--- a/tests/unit/test_postgresql_provider.py
+++ b/tests/unit/test_postgresql_provider.py
@@ -236,6 +236,10 @@ def test_on_relation_broken(harness):
         patch(
             "charm.Patroni.member_started", new_callable=PropertyMock(return_value=True)
         ) as _member_started,
+        patch(
+            "charm.PostgresqlOperatorCharm.primary_endpoint",
+            new_callable=PropertyMock(return_value="1.1.1.1"),
+        ) as _primary_endpoint,
     ):
         rel_id = harness.model.get_relation(RELATION_NAME).id
         peer_rel_id = harness.model.get_relation(PEER).id
@@ -253,6 +257,30 @@ def test_on_relation_broken(harness):
                 peer_rel_id, harness.charm.unit.name, {"departing": "True"}
             )
         harness.charm.postgresql_client_relation._on_relation_broken(event)
+        postgresql_mock.delete_user.assert_not_called()
+
+
+def test_on_relation_broken_defers_without_primary(harness):
+    with harness.hooks_disabled():
+        harness.set_leader()
+    with (
+        patch("charm.PostgresqlOperatorCharm.update_config"),
+        patch.object(PostgresqlOperatorCharm, "postgresql", Mock()) as postgresql_mock,
+        patch(
+            "charm.Patroni.member_started", new_callable=PropertyMock(return_value=True)
+        ) as _member_started,
+        patch(
+            "charm.PostgresqlOperatorCharm.primary_endpoint",
+            new_callable=PropertyMock(return_value=None),
+        ) as _primary_endpoint,
+    ):
+        rel_id = harness.model.get_relation(RELATION_NAME).id
+        event = Mock()
+        event.relation.id = rel_id
+        # No primary available yet: the event must defer without touching PostgreSQL.
+        harness.charm.postgresql_client_relation._on_relation_broken(event)
+        event.defer.assert_called_once()
+        postgresql_mock.list_users.assert_not_called()
         postgresql_mock.delete_user.assert_not_called()
 
 


### PR DESCRIPTION
## Issue

Random failure on server start from cold&dark: PostgreSQLUndefinedHostError: Host not set

```
unit-db1-0: 22:27:44 DEBUG unit.db1/0.juju-log cluster:API cluster_status: [{'name': 'db1-0', 'role': 'replica', 'state': 'stopped', 'api_url': 'https://10.69.235.97:8008/patroni', 'host': '10.69.235.97', 'port': 5432, 'lag': 'unknown'}]
unit-db1-0: 22:27:44 WARNING unit.db1/0.juju-log __main__:Missing primary IP for None                                          
unit-db1-0: 22:27:44 ERROR unit.db1/0.juju-log root:Uncaught exception while in charm code:                                    
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-db1-0/charm/src/charm.py", line 3287, in <module>                                            
...
  File "/var/lib/juju/agents/unit-db1-0/charm/venv/lib/python3.12/site-packages/single_kernel_postgresql/compat/postgresql.py", line 178, in _connect_to_database
    raise PostgreSQLUndefinedHostError("Host not set")
single_kernel_postgresql.compat.postgresql.PostgreSQLUndefinedHostError: Host not set  
```

A deferred database_relation_broken event can replay during an early
hook (e.g. leader-settings-changed) before Patroni has elected a
primary - Patroni health returns 503 and get_primary() returns None,
so charm.primary_endpoint is None. _on_relation_broken then calls
postgresql.list_users()/delete_user(), which connect using
primary_endpoint as host and raise PostgreSQLUndefinedHostError:
"Host not set", crashing the hook into error state.

## Solution
  
The precondition guard checked member_started but not primary_endpoint,
unlike the sibling _on_database_requested handler. Add the
primary_endpoint check so the event defers cleanly and replays once a
primary is available.

Assisted-by: Claude:claude-4.8-opus

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
