### PR TITLE
[DPE-10450] Skip Patroni REST API call in member_inactive when snap is down

### DIFF
--- a/src/cluster.py
+++ b/src/cluster.py
@@ -545,6 +545,8 @@ class Patroni:
             True if services is not running, starting or restarting. Retries over a period of 60
             seconds times to allow server time to start up.
         """
+        if not self.is_patroni_running():
+            return True
         try:
             response = self.cached_patroni_health
         except RetryError:

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -580,6 +580,7 @@ def test_member_inactive_true(peers_ips, patroni):
         patch("cluster.requests.get") as _get,
         patch("cluster.stop_after_delay", return_value=stop_after_delay(0)),
         patch("cluster.wait_fixed", return_value=wait_fixed(0)),
+        patch("charm.Patroni.is_patroni_running", return_value=True),
     ):
         _get.return_value.json.return_value = {"state": "stopped"}
 
@@ -595,6 +596,7 @@ def test_member_inactive_false(peers_ips, patroni):
         patch("cluster.requests.get") as _get,
         patch("cluster.stop_after_delay", return_value=stop_after_delay(0)),
         patch("cluster.wait_fixed", return_value=wait_fixed(0)),
+        patch("charm.Patroni.is_patroni_running", return_value=True),
     ):
         _get.return_value.json.return_value = {"state": "starting"}
 
@@ -610,6 +612,7 @@ def test_member_inactive_error(peers_ips, patroni):
         patch("cluster.requests.get") as _get,
         patch("cluster.stop_after_delay", return_value=stop_after_delay(0)),
         patch("cluster.wait_fixed", return_value=wait_fixed(0)),
+        patch("charm.Patroni.is_patroni_running", return_value=True),
     ):
         _get.side_effect = Exception
 
@@ -618,6 +621,18 @@ def test_member_inactive_error(peers_ips, patroni):
         _get.assert_called_once_with(
             "http://1.1.1.1:8008/health", verify=True, timeout=5, auth=patroni._patroni_auth
         )
+
+
+def test_member_inactive_patroni_not_running(peers_ips, patroni):
+    with (
+        patch("cluster.requests.get") as _get,
+        patch("charm.Patroni.is_patroni_running", return_value=False),
+    ):
+        # When the Patroni snap service is not running, the member is inactive
+        # and we must not waste time querying the Patroni REST API.
+        assert patroni.member_inactive
+
+        _get.assert_not_called()
 
 
 def test_patroni_logs(patroni):


### PR DESCRIPTION
## Issue

On the server restart, charm is spending ~60 seconds to
wait for Patroni which we didn't start yet (it happens in
case of unlucky update-status event timing).

## Solution

Backport of the PG16 fix to PG14/main. Guard member_inactive with
is_patroni_running() (mirroring member_started) so that when the
Patroni snap service is not active we return True immediately instead of
spending ~60s retrying the Patroni REST API.

The companion PG16 fix (data dir guard in _handle_processes_failures) is not backported: that os.listdir(POSTGRESQL_DATA_DIR) logic does not exist on main (introduced only by the 16/edge storage migration, DPE-9049), so the FileNotFoundError it guards cannot occur here.

Assisted-by: Claude:claude-4.8-opus

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
