### PR TITLE
fix(backups): move pgBackRest log-level-stderr to its config file

### DIFF
--- a/src/backups.py
+++ b/src/backups.py
@@ -216,7 +216,6 @@ class PostgreSQLBackups(Object):
                 [
                     PGBACKREST_EXECUTABLE,
                     PGBACKREST_CONFIGURATION_FILE,
-                    PGBACKREST_LOG_LEVEL_STDERR,
                     "info",
                     "--output=json",
                 ],
@@ -469,7 +468,6 @@ class PostgreSQLBackups(Object):
         return_code, output, stderr = self._execute_command([
             PGBACKREST_EXECUTABLE,
             PGBACKREST_CONFIGURATION_FILE,
-            PGBACKREST_LOG_LEVEL_STDERR,
             "info",
             "--output=json",
         ])
@@ -542,7 +540,6 @@ class PostgreSQLBackups(Object):
         return_code, output, stderr = self._execute_command([
             PGBACKREST_EXECUTABLE,
             PGBACKREST_CONFIGURATION_FILE,
-            PGBACKREST_LOG_LEVEL_STDERR,
             "info",
             "--output=json",
         ])
@@ -578,7 +575,6 @@ class PostgreSQLBackups(Object):
         return_code, output, stderr = self._execute_command([
             PGBACKREST_EXECUTABLE,
             PGBACKREST_CONFIGURATION_FILE,
-            PGBACKREST_LOG_LEVEL_STDERR,
             "repo-ls",
             "archive",
             "--recurse",
@@ -698,7 +694,6 @@ class PostgreSQLBackups(Object):
                     return_code, _, stderr = self._execute_command([
                         PGBACKREST_EXECUTABLE,
                         PGBACKREST_CONFIGURATION_FILE,
-                        PGBACKREST_LOG_LEVEL_STDERR,
                         f"--stanza={self.stanza_name}",
                         "stanza-create",
                     ])
@@ -757,7 +752,6 @@ class PostgreSQLBackups(Object):
                     return_code, _, stderr = self._execute_command([
                         PGBACKREST_EXECUTABLE,
                         PGBACKREST_CONFIGURATION_FILE,
-                        PGBACKREST_LOG_LEVEL_STDERR,
                         f"--stanza={self.stanza_name}",
                         "check",
                     ])
@@ -1022,7 +1016,6 @@ Juju Version: {self.charm.model.juju_version!s}
         command = [
             PGBACKREST_EXECUTABLE,
             PGBACKREST_CONFIGURATION_FILE,
-            PGBACKREST_LOG_LEVEL_STDERR,
             f"--stanza={self.stanza_name}",
             "--log-level-console=debug",
             f"--type={BACKUP_TYPE_OVERRIDES[backup_type]}",

--- a/templates/pgbackrest.conf.j2
+++ b/templates/pgbackrest.conf.j2
@@ -2,6 +2,7 @@
 backup-standby=y
 compress-type=zst
 lock-path=/tmp
+log-level-stderr=warn
 log-path={{ log_path }}
 repo1-retention-full-type=time
 repo1-retention-full={{ retention_full }}

--- a/tests/unit/test_backups.py
+++ b/tests/unit/test_backups.py
@@ -771,7 +771,6 @@ def test_initialise_stanza(harness):
         stanza_creation_command = [
             "charmed-postgresql.pgbackrest",
             "--config=/var/snap/charmed-postgresql/current/etc/pgbackrest/pgbackrest.conf",
-            "--log-level-stderr=warn",
             f"--stanza={harness.charm.backup.stanza_name}",
             "stanza-create",
         ]
@@ -1894,6 +1893,11 @@ def test_render_pgbackrest_conf_file(harness, tls_ca_chain_filename):
         if tls_ca_chain_filename != "":
             calls.insert(0, call(Substrates.VM, tls_ca_chain_filename, "fake-tls-ca-chain", 0o644))
         _render_file.assert_has_calls(calls)
+
+        # pgBackRest's own stderr log level should come from the config file, not a
+        # per-command CLI flag, so it's applied consistently to every invocation that
+        # loads this config.
+        assert "log-level-stderr=warn" in expected_content
 
 
 def test_restart_database(harness):


### PR DESCRIPTION
Fixes #1767

`--log-level-stderr=warn` was passed as a CLI flag on almost every
pgBackRest invocation individually. Set it once in `pgbackrest.conf.j2`
instead, so it applies consistently to any command that loads this
config, without repeating it at every call site.

`_is_primary_pgbackrest_service_running`'s `server-ping` health check
doesn't pass `--config`, so it never reads `pgbackrest.conf` — it keeps
the explicit `--log-level-stderr=warn` flag so its logging behavior
isn't silently dropped.

Mirrors the equivalent change already open on `main`/14-edge
(#1750, for #1353, discussion_r2622432819) — this ports it to `16/edge`,
which hadn't picked it up yet.

## Test plan
- [x] `tox run -e unit` — 222 passed, 0 failed (full suite, not just the
      touched tests).
- [x] `tox run -e lint` (`poetry check --lock`, `codespell`, `ruff
      check`, `ruff format --check`) — clean on the changed files.
- [x] `poetry run ty check` — all checks passed.