### PR TITLE
[DPE-10781] Bump PostgreSQL to 16.15

### DIFF
--- a/refresh_versions.toml
+++ b/refresh_versions.toml
@@ -1,11 +1,11 @@
 charm_major = 1
-workload = "16.14"
+workload = "16.15"
 
 [snap]
 name = "charmed-postgresql"
 
 [snap.revisions]
 # amd64
-x86_64 = "394"
+x86_64 = "406"
 # arm64
-aarch64 = "395"
+aarch64 = "407"


### PR DESCRIPTION
## Issue

We are shipping outraged PostgreSQL 16.14

## Solution

Bump to Charmed PostgreSQL 16.15