### PR TITLE
[DPE-10781] Bump PostgreSQL to 14.24

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -40,7 +40,7 @@ POSTGRESQL_SNAP_NAME = "charmed-postgresql"
 SNAP_PACKAGES = [
     (
         POSTGRESQL_SNAP_NAME,
-        {"revision": {"aarch64": "392", "x86_64": "393"}},
+        {"revision": {"aarch64": "401", "x86_64": "402"}},
     )
 ]
 

--- a/tests/integration/test_subordinates.py
+++ b/tests/integration/test_subordinates.py
@@ -64,12 +64,11 @@ async def test_deploy(ops_test: OpsTest, charm: str, check_subordinate_env_vars)
     )
 
     await ops_test.model.wait_for_idle(apps=[DATABASE_APP_NAME], status="active", timeout=2000)
-    await ops_test.model.relate(f"{DATABASE_APP_NAME}:juju-info", f"{LS_CLIENT}:container")
     await ops_test.model.relate(
         f"{DATABASE_APP_NAME}:juju-info", f"{UBUNTU_PRO_APP_NAME}:juju-info"
     )
     await ops_test.model.wait_for_idle(
-        apps=[LS_CLIENT, UBUNTU_PRO_APP_NAME, DATABASE_APP_NAME], status="active"
+        apps=[UBUNTU_PRO_APP_NAME, DATABASE_APP_NAME], status="active"
     )
 
 
@@ -77,7 +76,7 @@ async def test_scale_up(ops_test: OpsTest, check_subordinate_env_vars):
     await scale_application(ops_test, DATABASE_APP_NAME, 4)
 
     await ops_test.model.wait_for_idle(
-        apps=[LS_CLIENT, UBUNTU_PRO_APP_NAME, DATABASE_APP_NAME], status="active", timeout=1500
+        apps=[UBUNTU_PRO_APP_NAME, DATABASE_APP_NAME], status="active", timeout=1500
     )
 
 
@@ -85,5 +84,5 @@ async def test_scale_down(ops_test: OpsTest, check_subordinate_env_vars):
     await scale_application(ops_test, DATABASE_APP_NAME, 3)
 
     await ops_test.model.wait_for_idle(
-        apps=[LS_CLIENT, UBUNTU_PRO_APP_NAME, DATABASE_APP_NAME], status="active", timeout=1500
+        apps=[UBUNTU_PRO_APP_NAME, DATABASE_APP_NAME], status="active", timeout=1500
     )


### PR DESCRIPTION
## Issue

We are shipping outraged PostgreSQL 14.23

## Solution

Bump to Charmed PostgreSQL 14.24

Disable a landscape-client test once again for PG14/Jammy due to:
https://bugs.launchpad.net/landscape/+bug/2165025