### PR TITLE
test(subordinates): bisect CI failure — landscape-client only

### DIFF
--- a/tests/integration/test_subordinates.py
+++ b/tests/integration/test_subordinates.py
@@ -16,7 +16,6 @@ from .helpers import (
 
 DATABASE_APP_NAME = "pg"
 LS_CLIENT = "landscape-client"
-UBUNTU_PRO_APP_NAME = "ubuntu-advantage"
 
 logger = logging.getLogger(__name__)
 
@@ -24,8 +23,7 @@ logger = logging.getLogger(__name__)
 @pytest.fixture(scope="module")
 async def check_subordinate_env_vars(ops_test: OpsTest) -> None:
     if (
-        not os.environ.get("UBUNTU_PRO_TOKEN", "").strip()
-        or not os.environ.get("LANDSCAPE_ACCOUNT_NAME", "").strip()
+        not os.environ.get("LANDSCAPE_ACCOUNT_NAME", "").strip()
         or not os.environ.get("LANDSCAPE_REGISTRATION_KEY", "").strip()
     ):
         pytest.skip("Subordinate configs not set")
@@ -39,16 +37,6 @@ async def test_deploy(ops_test: OpsTest, charm: str, check_subordinate_env_vars)
             application_name=DATABASE_APP_NAME,
             num_units=3,
             base=CHARM_BASE,
-        ),
-        ops_test.model.deploy(
-            UBUNTU_PRO_APP_NAME,
-            config={"token": os.environ["UBUNTU_PRO_TOKEN"]},
-            channel="latest/edge",
-            num_units=0,
-            base=CHARM_BASE,
-            # TODO switch back to series when pylib juju can figure out the base:
-            # https://github.com/juju/python-libjuju/issues/1240
-            series="jammy",
         ),
         ops_test.model.deploy(
             LS_CLIENT,
@@ -65,11 +53,8 @@ async def test_deploy(ops_test: OpsTest, charm: str, check_subordinate_env_vars)
 
     await ops_test.model.wait_for_idle(apps=[DATABASE_APP_NAME], status="active", timeout=2000)
     await ops_test.model.relate(f"{DATABASE_APP_NAME}:juju-info", f"{LS_CLIENT}:container")
-    await ops_test.model.relate(
-        f"{DATABASE_APP_NAME}:juju-info", f"{UBUNTU_PRO_APP_NAME}:juju-info"
-    )
     await ops_test.model.wait_for_idle(
-        apps=[LS_CLIENT, UBUNTU_PRO_APP_NAME, DATABASE_APP_NAME], status="active"
+        apps=[LS_CLIENT, DATABASE_APP_NAME], status="active"
     )
 
 
@@ -77,7 +62,7 @@ async def test_scale_up(ops_test: OpsTest, check_subordinate_env_vars):
     await scale_application(ops_test, DATABASE_APP_NAME, 4)
 
     await ops_test.model.wait_for_idle(
-        apps=[LS_CLIENT, UBUNTU_PRO_APP_NAME, DATABASE_APP_NAME], status="active", timeout=1500
+        apps=[LS_CLIENT, DATABASE_APP_NAME], status="active", timeout=1500
     )
 
 
@@ -85,5 +70,5 @@ async def test_scale_down(ops_test: OpsTest, check_subordinate_env_vars):
     await scale_application(ops_test, DATABASE_APP_NAME, 3)
 
     await ops_test.model.wait_for_idle(
-        apps=[LS_CLIENT, UBUNTU_PRO_APP_NAME, DATABASE_APP_NAME], status="active", timeout=1500
+        apps=[LS_CLIENT, DATABASE_APP_NAME], status="active", timeout=1500
     )

--- a/tests/integration/test_subordinates.py
+++ b/tests/integration/test_subordinates.py
@@ -53,9 +53,7 @@ async def test_deploy(ops_test: OpsTest, charm: str, check_subordinate_env_vars)
 
     await ops_test.model.wait_for_idle(apps=[DATABASE_APP_NAME], status="active", timeout=2000)
     await ops_test.model.relate(f"{DATABASE_APP_NAME}:juju-info", f"{LS_CLIENT}:container")
-    await ops_test.model.wait_for_idle(
-        apps=[LS_CLIENT, DATABASE_APP_NAME], status="active"
-    )
+    await ops_test.model.wait_for_idle(apps=[LS_CLIENT, DATABASE_APP_NAME], status="active")
 
 
 async def test_scale_up(ops_test: OpsTest, check_subordinate_env_vars):


### PR DESCRIPTION
## Issue

#1904: the `test_subordinates.py` integration test fails on every CI leg of the PR (juju29/amd64, juju36/amd64, juju36/arm64 — e.g. run 32797737974). The failure needs isolating to one of the two subordinate charms the test deploys.

## Solution

Bisect branch off `renovate/main-lock-file-maintenance-python-dependencies` (the #1904 head): the subordinates test deploys `pg` with **only `landscape-client`** attached — the `ubuntu-advantage` deploy, relation, and env-var gate are removed. The sibling branch does the inverse (ubuntu-advantage only). Whichever of the two passes CI identifies the subordinate responsible for the failure.

Throwaway diagnostic branch — not for merging.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
