### PR TITLE
test(subordinates): bisect CI failure — ubuntu-advantage only

### DIFF
--- a/tests/integration/test_subordinates.py
+++ b/tests/integration/test_subordinates.py
@@ -15,7 +15,6 @@ from .helpers import (
 )
 
 DATABASE_APP_NAME = "pg"
-LS_CLIENT = "landscape-client"
 UBUNTU_PRO_APP_NAME = "ubuntu-advantage"
 
 logger = logging.getLogger(__name__)
@@ -23,11 +22,7 @@ logger = logging.getLogger(__name__)
 
 @pytest.fixture(scope="module")
 async def check_subordinate_env_vars(ops_test: OpsTest) -> None:
-    if (
-        not os.environ.get("UBUNTU_PRO_TOKEN", "").strip()
-        or not os.environ.get("LANDSCAPE_ACCOUNT_NAME", "").strip()
-        or not os.environ.get("LANDSCAPE_REGISTRATION_KEY", "").strip()
-    ):
+    if not os.environ.get("UBUNTU_PRO_TOKEN", "").strip():
         pytest.skip("Subordinate configs not set")
 
 
@@ -50,26 +45,14 @@ async def test_deploy(ops_test: OpsTest, charm: str, check_subordinate_env_vars)
             # https://github.com/juju/python-libjuju/issues/1240
             series="jammy",
         ),
-        ops_test.model.deploy(
-            LS_CLIENT,
-            config={
-                "account-name": os.environ["LANDSCAPE_ACCOUNT_NAME"],
-                "registration-key": os.environ["LANDSCAPE_REGISTRATION_KEY"],
-                "ppa": "ppa:landscape/self-hosted-beta",
-            },
-            channel="latest/edge",
-            num_units=0,
-            base=CHARM_BASE,
-        ),
     )
 
     await ops_test.model.wait_for_idle(apps=[DATABASE_APP_NAME], status="active", timeout=2000)
-    await ops_test.model.relate(f"{DATABASE_APP_NAME}:juju-info", f"{LS_CLIENT}:container")
     await ops_test.model.relate(
         f"{DATABASE_APP_NAME}:juju-info", f"{UBUNTU_PRO_APP_NAME}:juju-info"
     )
     await ops_test.model.wait_for_idle(
-        apps=[LS_CLIENT, UBUNTU_PRO_APP_NAME, DATABASE_APP_NAME], status="active"
+        apps=[UBUNTU_PRO_APP_NAME, DATABASE_APP_NAME], status="active"
     )
 
 
@@ -77,7 +60,7 @@ async def test_scale_up(ops_test: OpsTest, check_subordinate_env_vars):
     await scale_application(ops_test, DATABASE_APP_NAME, 4)
 
     await ops_test.model.wait_for_idle(
-        apps=[LS_CLIENT, UBUNTU_PRO_APP_NAME, DATABASE_APP_NAME], status="active", timeout=1500
+        apps=[UBUNTU_PRO_APP_NAME, DATABASE_APP_NAME], status="active", timeout=1500
     )
 
 
@@ -85,5 +68,5 @@ async def test_scale_down(ops_test: OpsTest, check_subordinate_env_vars):
     await scale_application(ops_test, DATABASE_APP_NAME, 3)
 
     await ops_test.model.wait_for_idle(
-        apps=[LS_CLIENT, UBUNTU_PRO_APP_NAME, DATABASE_APP_NAME], status="active", timeout=1500
+        apps=[UBUNTU_PRO_APP_NAME, DATABASE_APP_NAME], status="active", timeout=1500
     )


### PR DESCRIPTION
## Issue

#1904: the `test_subordinates.py` integration test fails on every CI leg of the PR (juju29/amd64, juju36/amd64, juju36/arm64 — e.g. run 32797737974). The failure needs isolating to one of the two subordinate charms the test deploys.

## Solution

Bisect branch off `renovate/main-lock-file-maintenance-python-dependencies` (the #1904 head): the subordinates test deploys `pg` with **only `ubuntu-advantage`** attached — the `landscape-client` deploy, relation, and env-var gate are removed. The sibling branch does the inverse (landscape-client only). Whichever of the two passes CI identifies the subordinate responsible for the failure.

Throwaway diagnostic branch — not for merging.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
