### PR TITLE
test(async-replication): allow more time for the upgrade actions

### DIFF
--- a/tests/integration/high_availability/test_async_replication_upgrade.py
+++ b/tests/integration/high_availability/test_async_replication_upgrade.py
@@ -252,13 +252,13 @@ def run_upgrade_from_edge(juju: Juju, app_name: str, charm: str) -> None:
                 unit=unit_names[-1],
                 action="force-refresh-start",
                 params={"check-compatibility": False},
-                wait=10 * MINUTE_SECS,
+                wait=20 * MINUTE_SECS,
             )
 
-        juju.wait(jubilant.all_agents_idle, timeout=10 * MINUTE_SECS)
+        juju.wait(jubilant.all_agents_idle, timeout=20 * MINUTE_SECS)
 
         logging.info("Run resume-refresh action")
-        juju.run(unit=unit_names[1], action="resume-refresh", wait=15 * MINUTE_SECS)
+        juju.run(unit=unit_names[1], action="resume-refresh", wait=20 * MINUTE_SECS)
     except TimeoutError:
         logging.info("Upgrade completed without snap refresh (charm.py upgrade only)")
         assert juju.status().apps[app_name].is_active


### PR DESCRIPTION
## Issue

The `test_async_replication_upgrade` integration test fails on slower arm64 runners with `TimeoutError: timed out waiting for action` around the `force-refresh-start` step: the action (charm revision bump plus PostgreSQL 16.14-to-16.15 snap refresh and rolling restart) does not complete within its 10-minute wait on those runners. The `TimeoutError` falls into the `except` branch, which asserts the app active while it is still mid-refresh, so the test fails on environment speed rather than charm behavior.

Example failures: https://github.com/canonical/postgresql-operator/actions/runs/33760285083/job/100667895846 (arm64) and https://github.com/canonical/postgresql-operator/actions/runs/33760285083/job/100667896351 (amd64, where the same tight waits stalled the follow-up data-replication assertions after units were still settling).

## Solution

Bump the `force-refresh-start` wait from 10 to 20 minutes, the `resume-refresh` wait from 15 to 20 minutes, and the intermediate `all_agents_idle` wait from 10 to 20 minutes, giving the rolling upgrade enough time to complete on slow runners before the assertions run.
