### PR TITLE
[DPE-10968] Bump pySyncObj from 0.3.15 to 0.3.17 for PG16

### DIFF
--- a/refresh_versions.toml
+++ b/refresh_versions.toml
@@ -6,6 +6,6 @@ name = "charmed-postgresql"
 
 [snap.revisions]
 # amd64
-x86_64 = "406"
+x86_64 = "416"
 # arm64
-aarch64 = "407"
+aarch64 = "415"


### PR DESCRIPTION
## Issue

Raft library is randomly failing to start on the complete cluster reboot,
The issue has been traced and reported upstream in https://github.com/bakwc/PySyncObj/issues/201

## Solution

Upgrade pySyncObj from 0.3.15 to 0.3.17 to include library fixes merged in 0.3.16
https://github.com/bakwc/PySyncObj/releases/tag/v0.3.16 ,
particularly https://github.com/bakwc/PySyncObj/issues/202 .