### PR TITLE
[DPE-10968] Bump pySyncObj from 0.3.15 to to 0.3.17 for PG14

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -40,7 +40,7 @@ POSTGRESQL_SNAP_NAME = "charmed-postgresql"
 SNAP_PACKAGES = [
     (
         POSTGRESQL_SNAP_NAME,
-        {"revision": {"aarch64": "401", "x86_64": "402"}},
+        {"revision": {"aarch64": "418", "x86_64": "417"}},
     )
 ]
 


### PR DESCRIPTION
## Issue

Raft library is randomly failing to start on the complete cluster reboot,
The issue has been traced and reported upstream in https://github.com/bakwc/PySyncObj/issues/201

## Solution

Upgrade pySyncObj from 0.3.15 to 0.3.17 to include library fixes merged in 0.3.16
https://github.com/bakwc/PySyncObj/releases/tag/v0.3.16 ,
particularly https://github.com/bakwc/PySyncObj/issues/202 .