### PR TITLE
[DPE-11060] feat(terraform): support placement on a set of machines

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -11,7 +11,7 @@ and [deployment tutorial](https://charmhub.io/postgresql/docs/h-deploy-terraform
 | Name | Version |
 |------|---------|
 | terraform | >= 1.6.6 |
-| juju provider | >= 0.14.0 |
+| juju provider | ~> 1.0 |
 
 ## Usage
 
@@ -20,26 +20,31 @@ Users should ensure that Juju model has been created to deploy into:
 juju add-model welcome
 ```
 
+The module takes the model UUID rather than the model name. Export it once and reuse it in the examples below:
+```
+export JUJU_MODEL_UUID=$(juju show-model welcome --format json | jq -r '.welcome.model-uuid')
+```
+
 To deploy Charmed PostgreSQL into the model `welcome`, run:
 ```
-terraform apply -var='juju_model_name=welcome' -auto-approve
+terraform apply -var="juju_model=$JUJU_MODEL_UUID" -auto-approve
 ```
 
 By default, this Terraform module will deploy PostgreSQL with `1` unit only.
 To configure the module to deploy `3` units, run:
 ```
-terraform apply -var='juju_model_name=welcome' -var='units=3' -auto-approve
+terraform apply -var="juju_model=$JUJU_MODEL_UUID" -var='units=3' -auto-approve
 ```
 
 The juju storage directives config example:
 ```
-terraform apply -var='juju_model_name=welcome' -auto-approve \
+terraform apply -var="juju_model=$JUJU_MODEL_UUID" -auto-approve \
   -var='storage={data="10G", archive="2G,lxd", logs="3G", temp="tmpfs,2G"}'
 ```
 
 The juju constraints example:
 ```
-terraform apply -var='juju_model_name=welcome' -auto-approve \
+terraform apply -var="juju_model=$JUJU_MODEL_UUID" -auto-approve \
   -var='constraints=arch=amd64 cores=4 mem=4096M virt-type=virtual-machine'
 ```
 
@@ -48,7 +53,7 @@ Example of deploying to the specific Juju machine:
 juju add-machine
 > created machine 19
 
-terraform apply -var='juju_model_name=welcome' -var='machine=19'
+terraform apply -var="juju_model=$JUJU_MODEL_UUID" -var='machine=19'
 ```
 
 Example of deploying multiple units to specific Juju machines (e.g. for HA):
@@ -60,7 +65,7 @@ juju add-machine
 juju add-machine
 > created machine 21
 
-terraform apply -var='juju_model_name=welcome' -var='machines=["19","20","21"]' -auto-approve
+terraform apply -var="juju_model=$JUJU_MODEL_UUID" -var='machines=["19","20","21"]' -auto-approve
 ```
 The number of machines in the set determines the number of units deployed.
 
@@ -72,7 +77,7 @@ Check [Charmed PostgreSQL Deployment How-to](https://charmhub.io/postgresql/docs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| juju_model_name | Juju model name (to deployed into) | `string` | n/a | yes |
+| juju_model | Juju model UUID to deploy into | `string` | n/a | yes |
 | charm_name | Name of the charm on charmhub.io to deploy | `string` | `postgresql` | no |
 | app_name | Name of the deployed application in the Juju model | `string` | `postgresql` | no |
 | channel | Charm channel to use when deploying | `string` | `16/stable` | no |

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -50,7 +50,21 @@ juju add-machine
 
 terraform apply -var='juju_model_name=welcome' -var='machine=19'
 ```
-Note: the module variables `units` and `machine` are self-exclusive.
+
+Example of deploying multiple units to specific Juju machines (e.g. for HA):
+```
+juju add-machine
+> created machine 19
+juju add-machine
+> created machine 20
+juju add-machine
+> created machine 21
+
+terraform apply -var='juju_model_name=welcome' -var='machines=["19","20","21"]' -auto-approve
+```
+The number of machines in the set determines the number of units deployed.
+
+Note: the module variables `units`, `machine` and `machines` are self-exclusive: `machines` takes precedence over `machine`, and either overrides `units`.
 
 Check [Charmed PostgreSQL Deployment How-to](https://charmhub.io/postgresql/docs/h-deploy-terraform) for more examples.
 
@@ -65,6 +79,7 @@ Check [Charmed PostgreSQL Deployment How-to](https://charmhub.io/postgresql/docs
 | revision | Revision number to deploy charm | `number` | n/a | no |
 | base | Application base | `string` | `ubuntu@24.04` | no |
 | machine | Target Juju machine to deploy on | `string` | n/a | no |
+| machines | Target Juju machines to deploy on | `set(string)` | n/a | no |
 | units | Number of units to deploy | `number` | `1` | no |
 | constraints | Juju constraints to apply for this application | `string` | `arch=amd64` | no |
 | storage | Storage directive | `map(string)` | `{}` | no |

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -8,8 +8,8 @@ resource "juju_application" "machine_postgresql" {
     base     = var.base
   }
 
-  machines           = var.machine != null ? [var.machine] : null
-  units              = var.machine == null ? var.units : null
+  machines           = var.machines != null ? var.machines : (var.machine != null ? [var.machine] : null)
+  units              = (var.machines == null && var.machine == null) ? var.units : null
   config             = var.config
   constraints        = var.constraints
   storage_directives = var.storage

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,5 +1,5 @@
 variable "juju_model" {
-  description = "Juju model uuid"
+  description = "Juju model UUID to deploy into"
   type        = string
   default     = null
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -70,3 +70,14 @@ variable "machine" {
   type        = string
   default     = null
 }
+
+variable "machines" {
+  description = "Target Juju machines to deploy on"
+  type        = set(string)
+  default     = null
+
+  validation {
+    condition     = var.machines == null ? true : length(var.machines) > 0
+    error_message = "machines must contain at least one machine id, or be left unset."
+  }
+}


### PR DESCRIPTION
Fixes #1945

Adds a `machines` (set of string) variable alongside the existing `machine` variable so an HA (multi-unit) deployment can be placed on a fixed set of pre-created Juju machines, keeping the single-`machine` case from #911 working.

## Changes

- `terraform/variables.tf`: new optional `machines` variable (`set(string)`, default `null`), with a validation rejecting an empty set — an empty set would otherwise reach `juju_application` as `machines=[]` and bypass the provider's zero-unit guard.
- `terraform/main.tf`:
  ```hcl
  machines = var.machines != null ? var.machines : (var.machine != null ? [var.machine] : null)
  units    = (var.machines == null && var.machine == null) ? var.units : null
  ```
  Precedence: `machines` > `machine` > `units`; the unit count derives from the number of machines in the set.
- `terraform/README.md`: HA placement example, updated exclusivity note, Inputs row.
- `terraform/README.md` + `variables.tf` (docs corrections): the Requirements row now matches the `~> 1.0` provider pin (it claimed `>= 0.14.0`), and all examples/Inputs use `juju_model` — the module takes the model UUID (per the provider's `model_uuid` attribute) — with a `juju show-model`/`jq` helper exporting it once. The old references to an undeclared `juju_model_name` variable failed verbatim.

Existing inputs are unaffected: with `machines` unset, both expressions reduce to the previous ones.
