### PR TITLE
[DPE-7374] feat(terraform): add endpoint_bindings variable

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -43,6 +43,13 @@ terraform apply -var='juju_model_name=welcome' -auto-approve \
   -var='constraints=arch=amd64 cores=4 mem=4096M virt-type=virtual-machine'
 ```
 
+The juju endpoint bindings example (binds application endpoints to network spaces):
+```
+terraform apply -var='juju_model=<model uuid>' -auto-approve \
+  -var='endpoint_bindings=[{space="db-space"},{endpoint="cos-agent",space="oam-space"}]'
+```
+A binding without an `endpoint` sets the default space for the application.
+
 Example of deploying to the specific Juju machine:
 ```
 juju add-machine
@@ -65,6 +72,7 @@ Check [Charmed PostgreSQL Deployment How-to](https://charmhub.io/postgresql/docs
 | revision | Revision number to deploy charm | `number` | n/a | no |
 | base | Application base | `string` | `ubuntu@24.04` | no |
 | machine | Target Juju machine to deploy on | `string` | n/a | no |
+| endpoint_bindings | Bindings of the application endpoints to network spaces; a binding without an `endpoint` sets the default space | `set(object({endpoint = optional(string), space = string}))` | n/a | no |
 | units | Number of units to deploy | `number` | `1` | no |
 | constraints | Juju constraints to apply for this application | `string` | `arch=amd64` | no |
 | storage | Storage directive | `map(string)` | `{}` | no |

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -13,6 +13,7 @@ resource "juju_application" "machine_postgresql" {
   config             = var.config
   constraints        = var.constraints
   storage_directives = var.storage
+  endpoint_bindings  = var.endpoint_bindings
   model_uuid         = var.juju_model
 
   dynamic "expose" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -70,3 +70,12 @@ variable "machine" {
   type        = string
   default     = null
 }
+
+variable "endpoint_bindings" {
+  description = "Bindings of the application endpoints to network spaces. A binding without an endpoint sets the default space for the application"
+  type = set(object({
+    endpoint = optional(string)
+    space    = string
+  }))
+  default = null
+}


### PR DESCRIPTION
Fixes #911

Adds an `endpoint_bindings` variable to the Terraform module so deployments can bind the application's endpoints to network spaces.

## Changes

- `terraform/variables.tf`: new optional `endpoint_bindings` variable — a set of objects with a required `space` and an optional `endpoint`; a binding without an `endpoint` sets the default space for the application.
- `terraform/main.tf`: forwards the variable to `juju_application.endpoint_bindings` (provider attribute introduced in v0.19.0, guaranteed by the `~> 1.0` pin in `versions.tf`).
- `terraform/README.md`: usage example and Inputs row.

## Issue parts

1. `endpoint_bindings` variable — this PR.
2. Single-VM placement — already available via the `machine` variable (validated live: `machine="0"` places exactly one unit on machine 0); a set-of-machines variant is proposed in #1945 / PR #1956.
3. Integration documentation between modules — the README documents each variable with examples; full cross-module patterns live in the [deployment docs](https://charmhub.io/postgresql/docs/h-deploy-terraform), which use the [`terraform-modules`](https://github.com/canonical/terraform-modules) examples.

## Validation

- `terraform fmt -check -recursive` and `terraform validate` (provider juju v1.5.7) pass.
- Live on a test box (juju 3.6.28, LXD controller, single space `alpha`):
  - deployed with `endpoint_bindings=[{space="alpha"},{endpoint="cos-agent",space="alpha"}]` — apply succeeds and `juju show-application` records `"": "alpha"` and `"cos-agent": "alpha"` on the deployed application;
  - a binding referencing an unknown space is rejected by the Juju API ("unknown space"), confirming the attribute is forwarded end-to-end;
  - deployments without the variable are unaffected (default path, exercised by the existing examples).
- Differentiated multi-space bindings need a spaces-capable cloud with ≥ 2 spaces (LXD container models cannot host additional spaces); the exercised code path is identical.
