### PR TITLE
[DPE-11134] fix(async-replication): sync system-user password rotations to the standby cluster

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -2330,6 +2330,11 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             self.set_unit_status(BlockedStatus("Password update for system users failed."))
             return
 
+        # Refresh the shared async-replication secret content. The standby cluster only
+        # learns about password rotations when the primary cluster updates that secret,
+        # otherwise its own Juju app secret keeps the old password (DPE-11134).
+        self.async_replication.update_async_replication_data()
+
         # Update and reload Patroni configuration in this unit to use the new password.
         # Other units Patroni configuration will be reloaded in the peer relation changed event.
         self.update_config()

--- a/src/relations/async_replication.py
+++ b/src/relations/async_replication.py
@@ -828,6 +828,14 @@ class PostgreSQLAsyncReplication(Object):
 
     def _on_secret_changed(self, event: SecretChangedEvent) -> None:
         """Update the internal secret when the relation secret changes."""
+        if not self.charm.unit.is_leader():
+            # Both branches update application-scope data (the shared secret content on
+            # the offer side, the internal app secret on the consumer side), which only
+            # the leader can write. Every unit receives the same secret-changed event;
+            # the leader reconciles for the whole cluster.
+            logger.debug("Early exit on_secret_changed: Unit is not the leader.")
+            return
+
         relation = self._relation
         if relation is None:
             logger.debug("Early exit on_secret_changed: No relation found.")
@@ -1003,8 +1011,15 @@ class PostgreSQLAsyncReplication(Object):
         if relation is None:
             return
         relation.data[self.charm.unit].update({"unit-address": self._unit_ip})
-        if self.is_primary_cluster() and self.charm.unit.is_leader():
+        if self.charm.unit.is_leader() and self.is_primary_cluster():
             self._update_primary_cluster_data()
+        elif self.charm.unit.is_leader() and relation.name == REPLICATION_CONSUMER_RELATION:
+            # Juju does not deliver secret-changed events to the charm units when
+            # the primary cluster adds a revision to the shared secret across the
+            # cross-model relation, so the standby cluster must pull the shared
+            # secret content on its own reconciliations instead (DPE-11134).
+            # A missing shared secret is retried on the next reconciliation.
+            self._update_internal_secret()
 
     def _remote_secret_id(self) -> str | None:
         """Return the shared secret id published by the primary cluster, or None."""
@@ -1029,6 +1044,10 @@ class PostgreSQLAsyncReplication(Object):
         credentials = secret.peek_content()
         for key, password in credentials.items():
             user = key.split("-password")[0]
+            if password == self.charm.get_secret(APP_SCOPE, key):
+                # Already synced: every rewrite is a new Juju secret revision, so skip
+                # unchanged passwords instead of churning revisions on each hook.
+                continue
             self.charm.set_secret(APP_SCOPE, key, password)
             logger.debug("Synced %s password", user)
         return True

--- a/tests/integration/high_availability/test_async_replication_password_rotation.py
+++ b/tests/integration/high_availability/test_async_replication_password_rotation.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""Test that system-user password rotations propagate to the standby cluster's Juju secrets.
+
+Covers DPE-11134: rotating the `operator` password on the primary cluster (Rome) through a
+Juju user secret must also update the standby cluster's (Lisbon) Juju app secret, since the
+app secret is the recovery credential for a lost datacenter.
+"""
+
+import json
+import logging
+from collections.abc import Generator
+
+import jubilant
+import pytest
+from jubilant import Juju
+from single_kernel_postgresql.config.literals import PEER_RELATION
+from tenacity import Retrying, stop_after_attempt, wait_fixed
+
+from .. import architecture
+from ..jubilant_helpers import db_connect, get_unit_address
+from .high_availability_helpers_new import (
+    get_app_leader,
+    get_db_primary_unit,
+    get_db_standby_leader_unit,
+    wait_for_apps_status,
+)
+
+DB_APP_1 = "db1"
+DB_APP_2 = "db2"
+MINUTE_SECS = 60
+OPERATOR_USER = "operator"
+
+# Juju app secret holding the system users' passwords, per cluster.
+APP_SECRET_LABEL_1 = f"{PEER_RELATION}.{DB_APP_1}.app"
+APP_SECRET_LABEL_2 = f"{PEER_RELATION}.{DB_APP_2}.app"
+
+
+SYSTEM_USERS_SECRET_NAME = "system-users-secret"
+OLD_PASSWORD = "dpe-11134-old-password"
+NEW_PASSWORD = "dpe-11134-new-password"
+
+
+@pytest.fixture(scope="module")
+def first_model(juju: Juju, request: pytest.FixtureRequest) -> Generator:
+    """Creates and return the first model."""
+    yield juju.model
+
+
+@pytest.fixture(scope="module")
+def second_model(juju: Juju, request: pytest.FixtureRequest) -> Generator:
+    """Creates and returns the second model."""
+    model_name = f"{juju.model}-other"
+
+    logging.info(f"Creating model: {model_name}")
+    juju.add_model(model_name)
+
+    yield model_name
+    if request.config.getoption("--keep-models"):
+        return
+
+    logging.info("Destroying model: {model_name}")
+    juju.destroy_model(model_name, destroy_storage=True, force=True)
+
+
+@pytest.fixture()
+def fast_forward_both(first_model: str, second_model: str) -> Generator:
+    """Speed up the update-status hook on both models."""
+    model_1 = Juju(model=first_model)
+    model_2 = Juju(model=second_model)
+    model_1.model_config({"update-status-hook-interval": "10s"})
+    model_2.model_config({"update-status-hook-interval": "10s"})
+    yield
+    model_1.model_config({"update-status-hook-interval": "5m"})
+    model_2.model_config({"update-status-hook-interval": "5m"})
+
+
+def test_deploy(first_model: str, second_model: str, charm: str) -> None:
+    """Deploy both PostgreSQL clusters."""
+    configuration = {"profile": "testing"}
+    constraints = {"arch": architecture.architecture}
+
+    logging.info("Deploying postgresql clusters")
+    model_1 = Juju(model=first_model)
+    model_2 = Juju(model=second_model)
+    model_1.deploy(
+        charm=charm,
+        app=DB_APP_1,
+        base="ubuntu@24.04",
+        config=configuration,
+        constraints=constraints,
+        num_units=3,
+    )
+    model_2.deploy(
+        charm=charm,
+        app=DB_APP_2,
+        base="ubuntu@24.04",
+        config=configuration,
+        constraints=constraints,
+        num_units=3,
+    )
+
+    logging.info("Waiting for the applications to settle")
+    model_1.wait(
+        ready=wait_for_apps_status(jubilant.all_active, DB_APP_1),
+        timeout=20 * MINUTE_SECS,
+    )
+    model_2.wait(
+        ready=wait_for_apps_status(jubilant.all_active, DB_APP_2),
+        timeout=20 * MINUTE_SECS,
+    )
+
+
+def test_async_relate(first_model: str, second_model: str) -> None:
+    """Relate the two PostgreSQL clusters."""
+    logging.info("Creating offers in first model")
+    model_1 = Juju(model=first_model)
+    model_1.offer(f"{first_model}.{DB_APP_1}", endpoint="replication-offer")
+
+    logging.info("Consuming offer in second model")
+    model_2 = Juju(model=second_model)
+    model_2.consume(f"{first_model}.{DB_APP_1}")
+
+    logging.info("Relating the two postgresql clusters")
+    model_2.integrate(f"{DB_APP_1}", f"{DB_APP_2}:replication")
+
+    logging.info("Waiting for the applications to settle")
+    model_1.wait(
+        ready=wait_for_apps_status(jubilant.all_active, DB_APP_1),
+        timeout=10 * MINUTE_SECS,
+    )
+    model_2.wait(
+        ready=wait_for_apps_status(jubilant.all_active, DB_APP_2),
+        timeout=10 * MINUTE_SECS,
+    )
+
+
+def test_create_replication(first_model: str, second_model: str) -> None:
+    """Run the create-replication action and wait for the applications to settle."""
+    model_1 = Juju(model=first_model)
+    model_2 = Juju(model=second_model)
+
+    logging.info("Running create replication action")
+    model_1.run(
+        unit=get_app_leader(model_1, DB_APP_1), action="create-replication", wait=5 * MINUTE_SECS
+    ).raise_on_failure()
+
+    logging.info("Waiting for the applications to settle")
+    model_1.wait(
+        ready=wait_for_apps_status(jubilant.all_active, DB_APP_1),
+        timeout=20 * MINUTE_SECS,
+    )
+    model_2.wait(
+        ready=wait_for_apps_status(jubilant.all_active, DB_APP_2),
+        timeout=20 * MINUTE_SECS,
+    )
+
+
+def test_configure_system_users_secret(first_model: str, second_model: str) -> None:
+    """Configure a Juju user secret holding the operator password in the primary cluster."""
+    model_1 = Juju(model=first_model)
+    model_2 = Juju(model=second_model)
+    secret_id = model_1.cli(
+        "add-secret", SYSTEM_USERS_SECRET_NAME, f"{OPERATOR_USER}={OLD_PASSWORD}"
+    ).strip()
+    model_1.cli("grant-secret", SYSTEM_USERS_SECRET_NAME, DB_APP_1)
+    model_1.config(DB_APP_1, {"system-users": secret_id})
+
+    logging.info("Waiting for the secret to be processed by the primary cluster")
+    model_1.wait(
+        ready=wait_for_apps_status(jubilant.all_agents_idle, DB_APP_1),
+        timeout=10 * MINUTE_SECS,
+    )
+
+    # The primary cluster must now store the configured password in its app secret.
+    app_secret = get_app_secret_content(model_1, APP_SECRET_LABEL_1)
+    assert app_secret.get(f"{OPERATOR_USER}-password") == OLD_PASSWORD, (
+        f"Primary cluster app secret was not updated with the configured password: {app_secret}"
+    )
+
+    # The configured password must be usable on both clusters (the standby cluster
+    # receives it through data replication).
+    assert_credentials_accepted(model_1, DB_APP_1, OLD_PASSWORD)
+    assert_credentials_accepted(model_2, DB_APP_2, OLD_PASSWORD)
+
+
+def test_rotate_system_users_secret(
+    first_model: str, second_model: str, fast_forward_both: None
+) -> None:
+    """Rotate the system users secret and check both clusters converge to the new password."""
+    model_1 = Juju(model=first_model)
+    model_2 = Juju(model=second_model)
+
+    # Wait for both clusters to settle before rotating.
+    model_1.wait(ready=wait_for_apps_status(jubilant.all_agents_idle, DB_APP_1), timeout=600)
+    model_2.wait(ready=wait_for_apps_status(jubilant.all_agents_idle, DB_APP_2), timeout=600)
+
+    logging.info("Rotating the operator password through the user secret")
+    model_1.cli("update-secret", SYSTEM_USERS_SECRET_NAME, f"{OPERATOR_USER}={NEW_PASSWORD}")
+
+    # Give both clusters time to process the rotation (secret-changed hooks and
+    # cross-cluster secret synchronisation).
+    model_1.wait(
+        ready=wait_for_apps_status(jubilant.all_active, DB_APP_1),
+        timeout=10 * MINUTE_SECS,
+    )
+    model_2.wait(
+        ready=wait_for_apps_status(jubilant.all_active, DB_APP_2),
+        timeout=10 * MINUTE_SECS,
+    )
+
+    # The new password must be accepted by both clusters.
+    assert_credentials_accepted(model_1, DB_APP_1, NEW_PASSWORD)
+    assert_credentials_accepted(model_2, DB_APP_2, NEW_PASSWORD)
+
+    # The password rotation must be reflected in the Juju app secrets of both clusters.
+    # https://warthogs.atlassian.net/browse/DPE-11134
+    app_secret_1 = get_app_secret_content(model_1, APP_SECRET_LABEL_1)
+    app_secret_2 = get_app_secret_content(model_2, APP_SECRET_LABEL_2)
+    assert app_secret_1.get("operator-password") == NEW_PASSWORD, (
+        f"Primary cluster app secret holds the wrong password: {app_secret_1}"
+    )
+    assert app_secret_2.get("operator-password") == NEW_PASSWORD, (
+        f"Standby cluster app secret holds the wrong password: {app_secret_2}"
+    )
+
+
+def assert_credentials_accepted(model: Juju, app: str, password: str) -> None:
+    """Assert that the operator user can connect to the database with the given password."""
+    for attempt in Retrying(stop=stop_after_attempt(10), wait=wait_fixed(3), reraise=True):
+        with attempt:
+            if app == DB_APP_1:
+                unit = get_db_primary_unit(model, app)
+            else:
+                unit = get_db_standby_leader_unit(model, app)
+            address = get_unit_address(model, unit)
+            with db_connect(address, password) as connection:
+                cursor = connection.cursor()
+                cursor.execute("SELECT 1")
+                assert cursor.fetchone() == (1,)
+                cursor.close()
+
+
+def get_app_secret_content(model: Juju, label: str) -> dict[str, str]:
+    """Return the content of the Juju secret with the given label in the given model."""
+    for secret_uri in list_secret_ids(model):
+        output = model.cli("show-secret", "--reveal", "--format", "json", secret_uri)
+        secret_data = json.loads(output)
+        if secret_data[secret_uri].get("label") == label:
+            return secret_data[secret_uri]["content"]["Data"]
+    raise AssertionError(f"Secret with label {label} not found in model {model.model}")
+
+
+def list_secret_ids(model: Juju) -> list[str]:
+    """List the Juju secret ids in the given model."""
+    return [line.split()[0] for line in model.cli("list-secrets").splitlines()[1:] if line]

--- a/tests/spread/test_async_replication_password_rotation.py/task.yaml
+++ b/tests/spread/test_async_replication_password_rotation.py/task.yaml
@@ -1,0 +1,7 @@
+summary: test_async_replication_password_rotation.py
+environment:
+  TEST_MODULE: high_availability/test_async_replication_password_rotation.py
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/tests/unit/test_async_replication.py
+++ b/tests/unit/test_async_replication.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, PropertyMock, patch
 import pytest
 from ops import Application, ModelError
 from single_kernel_postgresql.config.literals import (
+    APP_SCOPE,
     REPLICATION_CONSUMER_RELATION,
     REPLICATION_OFFER_RELATION,
 )
@@ -1133,3 +1134,149 @@ def test_remote_unit_addresses_skips_unreadable_dead_peer_units():
         PostgreSQLAsyncReplication, "model", new_callable=PropertyMock, return_value=mock_model
     ):
         assert relation._remote_unit_addresses() == ["10.0.0.1"]
+
+
+def test_on_secret_changed_early_exits_for_non_leader():
+    # Every unit of the cluster receives secret-changed events for the shared secrets,
+    # but both handler branches write application-scope data (offer: the shared secret
+    # content; consumer: the internal app secret), which only the leader can write.
+    # Non-leader units must exit early instead of crashing the hook (DPE-11134).
+    mock_charm = MagicMock()
+    mock_charm.unit.is_leader.return_value = False
+    relation = PostgreSQLAsyncReplication(mock_charm)
+
+    offer_event = MagicMock()
+    offer_event.secret.label = f"database-peers.{mock_charm.model.app.name}.app"
+    consumer_event = MagicMock()
+    consumer_event.secret.id = "secret://uuid/abc123"
+
+    with (
+        patch.object(
+            PostgreSQLAsyncReplication,
+            "_relation",
+            new_callable=PropertyMock,
+            return_value=_consumer_relation("secret://uuid/abc123"),
+        ),
+        patch.object(PostgreSQLAsyncReplication, "_get_secret") as mock_get_secret,
+        patch.object(
+            PostgreSQLAsyncReplication, "_update_internal_secret", return_value=True
+        ) as mock_update_internal,
+    ):
+        relation._on_secret_changed(offer_event)
+        relation._on_secret_changed(consumer_event)
+
+    mock_get_secret.assert_not_called()
+    mock_update_internal.assert_not_called()
+    offer_event.defer.assert_not_called()
+    consumer_event.defer.assert_not_called()
+
+
+def test_on_secret_changed_still_processes_for_leader():
+    # The leader guard must not break the existing leader-side behaviour.
+    mock_charm = MagicMock()
+    mock_charm.unit.is_leader.return_value = True
+    relation = PostgreSQLAsyncReplication(mock_charm)
+
+    consumer_event = MagicMock()
+    consumer_event.secret.id = "secret://uuid/abc123"
+
+    with (
+        patch.object(
+            PostgreSQLAsyncReplication,
+            "_relation",
+            new_callable=PropertyMock,
+            return_value=_consumer_relation("secret:abc123"),
+        ),
+        patch.object(
+            PostgreSQLAsyncReplication, "_update_internal_secret", return_value=True
+        ) as mock_update_internal,
+    ):
+        relation._on_secret_changed(consumer_event)
+
+    mock_update_internal.assert_called_once()
+
+
+def test_update_async_replication_data_pulls_shared_secret_on_standby():
+    # Juju does not notify the consumer side when the primary cluster rotates the
+    # shared secret across the cross-model relation, so the standby leader must pull
+    # the shared secret content on every reconciliation (DPE-11134).
+    mock_charm = MagicMock()
+    relation = PostgreSQLAsyncReplication(mock_charm)
+
+    standby_relation = MagicMock()
+    standby_relation.name = REPLICATION_CONSUMER_RELATION
+
+    with (
+        patch.object(
+            PostgreSQLAsyncReplication,
+            "_relation",
+            new_callable=PropertyMock,
+            return_value=standby_relation,
+        ),
+        patch.object(
+            PostgreSQLAsyncReplication,
+            "_get_primary_cluster",
+            return_value=MagicMock(),
+        ),
+        patch.object(
+            PostgreSQLAsyncReplication, "_update_internal_secret", return_value=True
+        ) as mock_update_internal,
+    ):
+        relation.update_async_replication_data()
+
+    mock_update_internal.assert_called_once()
+
+
+def test_update_async_replication_data_pushes_on_primary():
+    # The primary cluster keeps pushing its own secret content to the shared secret.
+    mock_charm = MagicMock()
+    relation = PostgreSQLAsyncReplication(mock_charm)
+
+    offer_relation = MagicMock()
+    offer_relation.name = REPLICATION_OFFER_RELATION
+
+    with (
+        patch.object(
+            PostgreSQLAsyncReplication,
+            "_relation",
+            new_callable=PropertyMock,
+            return_value=offer_relation,
+        ),
+        patch.object(
+            PostgreSQLAsyncReplication,
+            "_get_primary_cluster",
+            return_value=mock_charm.app,
+        ),
+        patch.object(PostgreSQLAsyncReplication, "_update_primary_cluster_data") as mock_push,
+        patch.object(
+            PostgreSQLAsyncReplication, "_update_internal_secret", return_value=True
+        ) as mock_update_internal,
+    ):
+        relation.update_async_replication_data()
+
+    mock_push.assert_called_once()
+    mock_update_internal.assert_not_called()
+
+
+def test_update_internal_secret_skips_unchanged_passwords():
+    # Every rewrite of the app secret creates a new Juju revision; passwords that
+    # already match the shared secret must not be rewritten.
+    mock_charm = MagicMock()
+    relation = PostgreSQLAsyncReplication(mock_charm)
+
+    secret = MagicMock()
+    secret.peek_content.return_value = {
+        "operator-password": "changed-password",
+        "replication-password": "unchanged-password",
+    }
+    mock_charm.model.get_secret.return_value = secret
+    mock_charm.get_secret.return_value = "unchanged-password"
+
+    with patch.object(
+        PostgreSQLAsyncReplication, "_remote_secret_id", return_value="secret://uuid/abc123"
+    ):
+        assert relation._update_internal_secret() is True
+
+    mock_charm.set_secret.assert_called_once_with(
+        APP_SCOPE, "operator-password", "changed-password"
+    )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -38,7 +38,11 @@ from single_kernel_postgresql.config.exceptions import (
     SwitchoverFailedError,
     SwitchoverNotSyncError,
 )
-from single_kernel_postgresql.config.literals import PEER_RELATION, SECRET_INTERNAL_LABEL
+from single_kernel_postgresql.config.literals import (
+    APP_SCOPE,
+    PEER_RELATION,
+    SECRET_INTERNAL_LABEL,
+)
 from single_kernel_postgresql.utils.postgresql import (
     PostgreSQLCreateUserError,
     PostgreSQLEnableDisableExtensionError,
@@ -2966,3 +2970,66 @@ def test_planned_units_survives_goal_state_failure(harness):
         side_effect=ModelError('ERROR saas application "db1" not found'),
     ):
         assert charm._planned_units == len(charm._hosts)
+
+
+def test_on_secret_changed_refreshes_async_replication_data(harness):
+    """Rotating system-user passwords must refresh the shared async-replication secret.
+
+    Regression for DPE-11134: the standby cluster only learns about password rotations
+    when the primary cluster updates the shared secret content; without the refresh the
+    standby's own Juju app secret keeps the old password.
+    """
+    harness.update_config({"system-users": "secret:fake-user-secret-id"})
+    with harness.hooks_disabled():
+        harness.set_leader()
+
+    with (
+        patch.object(harness.charm, "_on_peer_relation_changed"),
+        patch("charm.PatroniManager.are_all_members_ready", return_value=True),
+        patch.object(harness.charm, "postgresql") as postgresql_mock,
+        patch.object(
+            harness.charm, "get_secret_from_id", return_value={"operator": "new-password"}
+        ),
+        patch.object(
+            harness.charm,
+            "get_secret",
+            side_effect=lambda scope, key: "old-password" if key == "operator-password" else None,
+        ),
+        patch.object(harness.charm, "set_secret") as set_secret_mock,
+        patch("charm.PostgresqlOperatorCharm.update_config"),
+        patch.object(
+            harness.charm.async_replication, "update_async_replication_data"
+        ) as update_async_data_mock,
+    ):
+        harness.charm.on.secret_changed.emit("secret:fake-user-secret-id", None)
+
+    postgresql_mock.update_user_password.assert_called_once_with(
+        "operator", "new-password", database_host=None
+    )
+    set_secret_mock.assert_called_once_with(APP_SCOPE, "operator-password", "new-password")
+    update_async_data_mock.assert_called_once()
+
+
+def test_update_admin_password_refreshes_async_replication_data(harness):
+    """Password rotation driven by config-changed must also refresh the shared secret.
+
+    On config-changed the async-replication data is refreshed BEFORE the password
+    rotation happens, so `_update_admin_password` itself must trigger the refresh
+    afterwards (DPE-11134).
+    """
+    with (
+        patch("charm.PatroniManager.are_all_members_ready", return_value=True),
+        patch.object(harness.charm, "postgresql"),
+        patch.object(
+            harness.charm, "get_secret_from_id", return_value={"operator": "new-password"}
+        ),
+        patch.object(harness.charm, "get_secret", return_value="old-password"),
+        patch.object(harness.charm, "set_secret"),
+        patch("charm.PostgresqlOperatorCharm.update_config"),
+        patch.object(
+            harness.charm.async_replication, "update_async_replication_data"
+        ) as update_async_data_mock,
+    ):
+        harness.charm._update_admin_password("secret:fake-user-secret-id")
+
+    update_async_data_mock.assert_called_once()


### PR DESCRIPTION
## Issue

DPE-11134: rotating a system-user password (e.g. `operator`) through a Juju user secret on the primary cluster of a cluster<>cluster (async replication) deployment updated the database on both sides, the primary cluster's Juju app secret and the shared async-replication secret, but never the standby cluster's own Juju app secret.

Two defects, both confirmed on a real two-model deployment (juju 3.6.28, LXD):

1. The standby cluster only pulled the shared secret during initial setup and on `secret_changed`. Juju does not deliver `secret-changed` events to the consumer units when the owner adds a revision across the cross-model relation (observed: owner revision 2 added at 17:50:04; zero `secret-changed` hooks on any consumer unit in the following ~90 minutes while the same units received one at consumption time). The standby's app secret therefore kept the pre-setup password indefinitely — the recovery credential silently went stale.
2. Every unit receives `secret_changed` for the shared secrets, but both branches of `PostgreSQLAsyncReplication._on_secret_changed` write application-scope data, which only the leader can write: the replicas crashed the hook in a loop (`hook failed: "secret-changed"`, `RelationDataAccessError` on `app_peer_data.update` inside `_get_secret`).

The config-changed rotation path additionally pushed the (pre-rotation) secret content to the shared secret before `_update_admin_password` ran, so that entry point never propagated either.

## Solution

- `_update_admin_password` now refreshes the async-replication data right after rotating, so the primary cluster pushes the new passwords into the shared secret in the same event (covers both the `secret_changed` and config-changed paths).
- `update_async_replication_data` now pulls the shared secret content into the standby cluster's app secret on every reconciliation of the consumer side — self-healing, not dependent on cross-model secret notifications.
- `_update_internal_secret` skips unchanged passwords: every rewrite is a new Juju secret revision, so unchanged values must not churn revisions.
- `_on_secret_changed` now exits early for non-leader units (leader-only app data writes).

Stacked on #1914 (base is its head branch).

## Verification

- TDD: event-driven unit test failed pre-fix on the missing refresh (`update_async_replication_data` never called), green after; 6 new unit tests total. Full unit suite: 217 passed. `tox run -e lint` passes.
- Integration (two-model cluster<>cluster on LXD, matching the ticket STR):
  - Pre-fix: after `juju update-secret`, the primary's app secret and the shared secret held the new password while the standby's app secret kept the original password, and both databases accepted the new password (replication) — the reported divergence.
  - Post-fix (charm refreshed on both apps): fresh rotation converged both clusters' app secrets within a minute with no hook errors on any unit, and the same at the default 5-minute update-status interval (no fast-forward), with both databases accepting the rotated password.
- New regression test module `test_async_replication_password_rotation.py` (+ spread task) mirrors the STR for CI: deploy both clusters, relate, create-replication, configure the user secret, rotate it, and assert both clusters' app secrets and database access converge.

## Checklist

- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.