### PR TITLE
[test-only, draft] Pin snap to Go-1.25.14 exporter revisions (421/422)

### DIFF
--- a/refresh_versions.toml
+++ b/refresh_versions.toml
@@ -6,6 +6,6 @@ name = "charmed-postgresql"
 
 [snap.revisions]
 # amd64
-x86_64 = "406"
+x86_64 = "421"
 # arm64
-aarch64 = "407"
+aarch64 = "422"


### PR DESCRIPTION
> **Draft — TEST ONLY.** Not for merge; exists to validate the SSDLC flow against a Charmed PostgreSQL snap whose Go exporters are built with go1.25.14.

## Change

`refresh_versions.toml` `[snap.revisions]` now pins the store revisions carrying the go1.25.14 exporter rebuilds, published to the branch channel `16/edge/pg-exporters-go125` of `neppel/pg-exporters-go125`:

- amd64: revision **421** (was 406)
- arm64: revision **422** (was 407)

`charm_refresh` installs the snap by revision, so the deployed workload picks up `prometheus-postgres-exporter 0.15.0-1ubuntu0.7ppa1`, `golang-github-prometheus-community-pgbouncer-exporter 0.7.0-1ubuntu0.24.04.6ppa1` and `prometheus-pgbackrest-exporter 0.17.0+ds1-0ubuntu0.24.04.4ppa1` — `govulncheck` on all six binaries: **0 vulnerabilities**.

Companion draft PRs: canonical/charmed-postgresql-rock (rock packing the same snap channel) and canonical/postgresql-k8s-operator (OCI resource pointing at the test rock).

> **CI result:** lint/unit/build ✓ both arches; ~90 integration jobs ran — **83 passed** including all core scenarios (test_charm, test_async_replication, backups, TLS, password rotation) with revisions 421/422. The 7 failures (self_healing_3, async_replication_upgrade, stereo_mode, async_replication_backups_ceph, backups_pitr_aws) are juju-controller networking flakes (`no route to host` to the controller API), unrelated to the snap revision change.