### PR TITLE
[test-only, draft] Pin 14 snap to Go-1.25.14 exporter revisions (423/424)

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -40,7 +40,7 @@ POSTGRESQL_SNAP_NAME = "charmed-postgresql"
 SNAP_PACKAGES = [
     (
         POSTGRESQL_SNAP_NAME,
-        {"revision": {"aarch64": "401", "x86_64": "402"}},
+        {"revision": {"aarch64": "424", "x86_64": "423"}},
     )
 ]
 


### PR DESCRIPTION
> **Draft — TEST ONLY.** Not for merge; exists to validate the SSDLC flow against a 14-track Charmed PostgreSQL snap whose Go exporters are built with go1.25.14.

## Change

`src/constants.py` `SNAP_PACKAGES` revision pin:

- amd64: revision **423** (was 402)
- arm64: revision **424** (was 401)

Those store revisions (`14/edge/pg-exporters-go125` channel of `neppel/pg-exporters-go125`'s snap) carry rebuilt exporters with **golang-1.25.14**: `prometheus-postgres-exporter 0.15.0-1ubuntu0.8ppa1`, `golang-github-prometheus-community-pgbouncer-exporter 0.7.0-1ubuntu0.24.04.6ppa1~22.04ppa3`, `golang-github-woblerr-pgbackrest-exporter 0.16.2+ds1-0ubuntu1.1ppa1~22.04ppa3` — `govulncheck` on all six binaries (16-track equivalents verified 0; 14-track binaries from the same toolchain).

Companion draft PRs: charmed-postgresql-snap (14/edge), charmed-postgresql-rock (14-22.04), postgresql-k8s-operator (main, test rock image).